### PR TITLE
fix(mistral): Allow `stream` kwarg.

### DIFF
--- a/src/any_llm/providers/mistral/mistral.py
+++ b/src/any_llm/providers/mistral/mistral.py
@@ -14,7 +14,6 @@ from any_llm.provider import Provider
 from any_llm.providers.helpers import create_completion_from_response
 from openai._streaming import Stream
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
-from any_llm.exceptions import UnsupportedParameterError
 
 
 class MistralProvider(Provider):
@@ -45,8 +44,7 @@ class MistralProvider(Provider):
 
     def verify_kwargs(self, kwargs: dict[str, Any]) -> None:
         """Verify the kwargs for the Mistral provider."""
-        if kwargs.get("stream", False) is True:
-            raise UnsupportedParameterError("stream", self.PROVIDER_NAME)
+        pass
 
     def _make_api_call(
         self,


### PR DESCRIPTION
`verify_kwargs` was unnecessarily raising an exception.

- main

<img width="889" height="57" alt="image" src="https://github.com/user-attachments/assets/7a560430-e99e-4fff-b317-72d66207f78c" />

- This PR

<img width="900" height="38" alt="image" src="https://github.com/user-attachments/assets/25df30a0-b998-486d-909d-1583a16be83d" />

