### PR TITLE
tests(xai): Use `grok-3-mini-latest` instead of `grok-3-latest`.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def provider_model_map() -> dict[ProviderName, str]:
         ProviderName.MOONSHOT: "moonshot-v1-8k",
         ProviderName.SAMBANOVA: "Meta-Llama-3.1-8B-Instruct",
         ProviderName.TOGETHER: "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
-        ProviderName.XAI: "grok-3-latest",
+        ProviderName.XAI: "grok-3-mini-latest",
         ProviderName.INCEPTION: "inception-3-70b-instruct",
         ProviderName.NEBIUS: "meta-llama/Meta-Llama-3.1-8B-Instruct",
         ProviderName.OLLAMA: "llama3.2:1b",


### PR DESCRIPTION
It's about 10x cheaper and works the same for our testing purposes:

https://docs.x.ai/docs/models#model-pricing