### PR TITLE
feat: attach reasoning to OpenAI ChatCompletion 

### DIFF
--- a/src/any_llm/providers/helpers.py
+++ b/src/any_llm/providers/helpers.py
@@ -18,13 +18,17 @@ def create_openai_tool_call(tool_call_id: str, name: str, arguments: str) -> Cha
 
 
 def create_openai_message(
-    role: str, content: Optional[str] = None, tool_calls: Optional[list[ChatCompletionMessageToolCall]] = None
+    role: str,
+    content: Optional[str] = None,
+    tool_calls: Optional[list[ChatCompletionMessageToolCall]] = None,
+    reasoning: Optional[str] = None,
 ) -> ChatCompletionMessage:
     """Create a standardized OpenAI message object."""
     return ChatCompletionMessage(
         role=role,  # type: ignore[arg-type]
         content=content,
         tool_calls=tool_calls,
+        reasoning=reasoning,  # type: ignore[call-arg]
     )
 
 
@@ -111,6 +115,7 @@ def create_choice_from_message_data(
         role=message_data.get("role", "assistant"),
         content=message_data.get("content"),
         tool_calls=tool_calls,
+        reasoning=message_data.get("reasoning"),
     )
 
     return Choice(

--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -68,7 +68,11 @@ def _create_openai_chunk_from_ollama_chunk(ollama_chunk: OllamaChatResponse) -> 
     if message_role:
         role = cast(Literal["developer", "system", "user", "assistant", "tool"], message_role)
 
-    delta = ChoiceDelta(content=content, role=role, thinking=thinking)
+    delta = (
+        ChoiceDelta(content=content, role=role, thinking=thinking)  # type: ignore[call-arg]
+        if thinking
+        else ChoiceDelta(content=content, role=role)
+    )
 
     tool_calls = message.tool_calls
     if tool_calls:

--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -61,13 +61,14 @@ def _create_openai_chunk_from_ollama_chunk(ollama_chunk: OllamaChatResponse) -> 
         created = int(datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp())
 
     content = message.content
+    thinking = message.thinking
 
     role = None
     message_role = message.role
     if message_role:
         role = cast(Literal["developer", "system", "user", "assistant", "tool"], message_role)
 
-    delta = ChoiceDelta(content=content, role=role)
+    delta = ChoiceDelta(content=content, role=role, thinking=thinking)
 
     tool_calls = message.tool_calls
     if tool_calls:

--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -61,7 +61,7 @@ def _create_openai_chunk_from_ollama_chunk(ollama_chunk: OllamaChatResponse) -> 
         created = int(datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp())
 
     content = message.content
-    thinking = message.thinking
+    reasoning = message.thinking
 
     role = None
     message_role = message.role
@@ -69,8 +69,8 @@ def _create_openai_chunk_from_ollama_chunk(ollama_chunk: OllamaChatResponse) -> 
         role = cast(Literal["developer", "system", "user", "assistant", "tool"], message_role)
 
     delta = (
-        ChoiceDelta(content=content, role=role, thinking=thinking)  # type: ignore[call-arg]
-        if thinking
+        ChoiceDelta(content=content, role=role, reasoning=reasoning)  # type: ignore[call-arg]
+        if reasoning
         else ChoiceDelta(content=content, role=role)
     )
 
@@ -180,6 +180,7 @@ def _create_response_dict_from_ollama_response(
                 "message": {
                     "role": response_message.role,
                     "content": response_message.content,
+                    "reasoning": response_message.thinking,
                     "tool_calls": tool_calls,
                 },
                 "finish_reason": "tool_calls",
@@ -192,6 +193,7 @@ def _create_response_dict_from_ollama_response(
                 "message": {
                     "role": response_message.role,
                     "content": response_message.content,
+                    "reasoning": response_message.thinking,
                     "tool_calls": None,
                 },
                 "finish_reason": response.done_reason,


### PR DESCRIPTION
Relates to https://github.com/BerriAI/litellm/issues/11680 and https://github.com/mozilla-ai/any-llm/issues/26:

OpenAI ChatCompletion base type doesn't have a 'reasoning' key, which means accepting that as the standard for LLM output requires us to hack around passing a reasoning key.

For the time being, we can attach a `reasoning` attribute to the Completion object (and delta for streaming), but it ejects us from type checking and isn't ideal in the long term. I think we need to figure out a reliable way to support providing reasoning info. 

Maybe it means support for the `responses` API format, or maybe it means extending the OpenAI completion into our own type. Not sure. 