### PR TITLE
fix(anthropic): Drop duplicated `stream` + `response_format` check.

### DIFF
--- a/src/any_llm/providers/anthropic/anthropic.py
+++ b/src/any_llm/providers/anthropic/anthropic.py
@@ -78,8 +78,6 @@ class AnthropicProvider(Provider):
         kwargs = _convert_kwargs(kwargs)
 
         if "response_format" in kwargs:
-            if kwargs.get("stream", False):
-                raise UnsupportedParameterError("response_format with streaming", self.PROVIDER_NAME)
             instructor_client = instructor.from_anthropic(client)
 
             response_format = kwargs.pop("response_format")


### PR DESCRIPTION
Check is already happening inside `verify_kwargs`.