### PR TITLE
chore: clean up naming

### DIFF
--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -148,8 +148,11 @@ class Provider(ABC):
         }
 
     @abstractmethod
-    def _make_api_call(
-        self, model: str, messages: list[dict[str, Any]], **kwargs: Any
+    def completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """This method is designed to make the API call to the provider.
 
@@ -163,14 +166,6 @@ class Provider(ABC):
         """
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
-
-    def completion(
-        self,
-        model: str,
-        messages: list[dict[str, Any]],
-        **kwargs: Any,
-    ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
-        return self._make_api_call(model, messages, **kwargs)
 
     async def acompletion(
         self,

--- a/src/any_llm/providers/anthropic/anthropic.py
+++ b/src/any_llm/providers/anthropic/anthropic.py
@@ -62,7 +62,7 @@ class AnthropicProvider(Provider):
             for event in anthropic_stream:
                 yield _create_openai_chunk_from_anthropic_chunk(event)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/aws/aws.py
+++ b/src/any_llm/providers/aws/aws.py
@@ -52,7 +52,7 @@ class AwsProvider(Provider):
         if credentials is None and bedrock_api_key is None:
             raise MissingApiKeyError(provider_name=self.PROVIDER_NAME, env_var_name=self.ENV_API_KEY_NAME)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -84,7 +84,7 @@ class AzureProvider(Provider):
         for chunk in azure_stream:
             yield _create_openai_chunk_from_azure_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/cerebras/cerebras.py
+++ b/src/any_llm/providers/cerebras/cerebras.py
@@ -61,7 +61,7 @@ class CerebrasProvider(Provider):
                 msg = f"Unsupported chunk type: {type(chunk)}"
                 raise ValueError(msg)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -50,7 +50,7 @@ class CohereProvider(Provider):
         for chunk in cohere_stream:
             yield _create_openai_chunk_from_cohere_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -16,7 +16,7 @@ class DeepseekProvider(BaseOpenAIProvider):
 
     SUPPORTS_EMBEDDING = False  # DeepSeek doesn't host an embedding model
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],
@@ -29,4 +29,4 @@ class DeepseekProvider(BaseOpenAIProvider):
                 kwargs["response_format"] = {"type": "json_object"}
                 messages = modified_messages
 
-        return super()._make_api_call(model, messages, **kwargs)
+        return super().completion(model, messages, **kwargs)

--- a/src/any_llm/providers/fireworks/fireworks.py
+++ b/src/any_llm/providers/fireworks/fireworks.py
@@ -40,7 +40,7 @@ class FireworksProvider(Provider):
         for chunk in response_generator:
             yield _create_openai_chunk_from_fireworks_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/google/google.py
+++ b/src/any_llm/providers/google/google.py
@@ -82,7 +82,7 @@ class GoogleProvider(Provider):
 
         return _create_openai_embedding_response_from_google(model, result)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -59,7 +59,7 @@ class GroqProvider(Provider):
         for chunk in stream:
             yield _create_openai_chunk_from_groq_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -51,7 +51,7 @@ class HuggingfaceProvider(Provider):
         for chunk in response:
             yield _create_openai_chunk_from_huggingface_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/mistral/mistral.py
+++ b/src/any_llm/providers/mistral/mistral.py
@@ -50,7 +50,7 @@ class MistralProvider(Provider):
 
             yield _create_openai_chunk_from_mistral_chunk(event)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -72,7 +72,7 @@ class OllamaProvider(Provider):
         for chunk in response:
             yield _create_openai_chunk_from_ollama_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -107,7 +107,7 @@ class BaseOpenAIProvider(Provider, ABC):
 
         return (_convert_chunk(chunk) for chunk in response)
 
-    def _make_api_call(
+    def completion(
         self, model: str, messages: list[dict[str, Any]], **kwargs: Any
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """Make the API call to OpenAI-compatible service."""

--- a/src/any_llm/providers/together/together.py
+++ b/src/any_llm/providers/together/together.py
@@ -52,7 +52,7 @@ class TogetherProvider(Provider):
         for chunk in response:
             yield _create_openai_chunk_from_together_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/src/any_llm/providers/watsonx/watsonx.py
+++ b/src/any_llm/providers/watsonx/watsonx.py
@@ -47,7 +47,7 @@ class WatsonxProvider(Provider):
         for chunk in response_stream:
             yield _convert_streaming_chunk(chunk)
 
-    def _make_api_call(
+    def completion(
         self,
         model: str,
         messages: list[dict[str, Any]],

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -27,7 +27,7 @@ def test_anthropic_client_created_with_api_key_and_api_base() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
-        provider._make_api_call("model-id", [{"role": "user", "content": "Hello"}])
+        provider.completion("model-id", [{"role": "user", "content": "Hello"}])
 
         mock_anthropic.assert_called_once_with(api_key=api_key, base_url=custom_endpoint)
 
@@ -38,13 +38,13 @@ def test_anthropic_client_created_without_api_base() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call("model-id", [{"role": "user", "content": "Hello"}])
+        provider.completion("model-id", [{"role": "user", "content": "Hello"}])
 
         mock_anthropic.assert_called_once_with(api_key=api_key, base_url=None)
 
 
-def test_make_api_call_with_system_message() -> None:
-    """Test that _make_api_call correctly processes a system message."""
+def testcompletion_with_system_message() -> None:
+    """Test that completion correctly processes a system message."""
     api_key = "test-api-key"
     model = "model-id"
     messages = [
@@ -54,7 +54,7 @@ def test_make_api_call_with_system_message() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages)
+        provider.completion(model, messages)
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,
@@ -64,8 +64,8 @@ def test_make_api_call_with_system_message() -> None:
         )
 
 
-def test_make_api_call_with_multiple_system_messages() -> None:
-    """Test that _make_api_call concatenates multiple system messages."""
+def testcompletion_with_multiple_system_messages() -> None:
+    """Test that completion concatenates multiple system messages."""
     api_key = "test-api-key"
     model = "model-id"
     messages = [
@@ -76,7 +76,7 @@ def test_make_api_call_with_multiple_system_messages() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages)
+        provider.completion(model, messages)
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,
@@ -86,8 +86,8 @@ def test_make_api_call_with_multiple_system_messages() -> None:
         )
 
 
-def test_make_api_call_with_kwargs() -> None:
-    """Test that _make_api_call passes kwargs to the Anthropic client."""
+def testcompletion_with_kwargs() -> None:
+    """Test that completion passes kwargs to the Anthropic client."""
     api_key = "test-api-key"
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
@@ -95,7 +95,7 @@ def test_make_api_call_with_kwargs() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages, **kwargs)
+        provider.completion(model, messages, **kwargs)
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,
@@ -104,8 +104,8 @@ def test_make_api_call_with_kwargs() -> None:
         )
 
 
-def test_make_api_call_with_tool_choice_required() -> None:
-    """Test that _make_api_call correctly processes tool_choice='required'."""
+def testcompletion_with_tool_choice_required() -> None:
+    """Test that completion correctly processes tool_choice='required'."""
     api_key = "test-api-key"
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
@@ -113,7 +113,7 @@ def test_make_api_call_with_tool_choice_required() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages, **kwargs)
+        provider.completion(model, messages, **kwargs)
 
         expected_kwargs = {"tool_choice": {"type": "any", "disable_parallel_tool_use": False}}
 
@@ -126,8 +126,8 @@ def test_make_api_call_with_tool_choice_required() -> None:
 
 
 @pytest.mark.parametrize("parallel_tool_calls", [True, False])
-def test_make_api_call_with_tool_choice_and_parallel_tool_calls(parallel_tool_calls: bool) -> None:
-    """Test that _make_api_call correctly processes tool_choice and parallel_tool_calls."""
+def testcompletion_with_tool_choice_and_parallel_tool_calls(parallel_tool_calls: bool) -> None:
+    """Test that completion correctly processes tool_choice and parallel_tool_calls."""
     api_key = "test-api-key"
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
@@ -135,7 +135,7 @@ def test_make_api_call_with_tool_choice_and_parallel_tool_calls(parallel_tool_ca
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages, **kwargs)
+        provider.completion(model, messages, **kwargs)
 
         expected_kwargs = {"tool_choice": {"type": "auto", "disable_parallel_tool_use": not parallel_tool_calls}}
 

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -30,7 +30,7 @@ def test_boto3_client_created_with_api_base() -> None:
 
     with mock_aws_provider(region) as mock_boto3_client:
         provider = AwsProvider(ApiConfig(api_base=custom_endpoint, api_key="test_key"))
-        provider._make_api_call("model-id", [{"role": "user", "content": "Hello"}])
+        provider.completion("model-id", [{"role": "user", "content": "Hello"}])
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=custom_endpoint, region_name=region)
 
@@ -41,7 +41,7 @@ def test_boto3_client_created_without_api_base() -> None:
 
     with mock_aws_provider(region) as mock_boto3_client:
         provider = AwsProvider(ApiConfig(api_key="test_key"))
-        provider._make_api_call("model-id", [{"role": "user", "content": "Hello"}])
+        provider.completion("model-id", [{"role": "user", "content": "Hello"}])
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None, region_name=region)
 

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -45,7 +45,7 @@ def test_azure_with_api_key_and_api_base() -> None:
     messages = [{"role": "user", "content": "Hello"}]
     with mock_azure_provider() as (mock_client, mock_convert_response, mock_chat_client):
         provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
-        provider._make_api_call("model-id", messages)
+        provider.completion("model-id", messages)
 
         # Verify ChatCompletionsClient was created with correct parameters
         mock_chat_client.assert_called_once()
@@ -69,7 +69,7 @@ def test_azure_with_tools() -> None:
     tool_choice = "auto"
     with mock_azure_provider() as (mock_client, mock_convert_response, mock_chat_client):
         provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
-        provider._make_api_call("model-id", messages, tools=tools, tool_choice=tool_choice)
+        provider.completion("model-id", messages, tools=tools, tool_choice=tool_choice)
 
         # Verify the complete method was called with correct parameters including tools
         mock_client.complete.assert_called_once_with(
@@ -99,7 +99,7 @@ def test_azure_streaming() -> None:
         mock_openai_chunk2 = MagicMock()
         mock_stream_completion.return_value = [mock_openai_chunk1, mock_openai_chunk2]
 
-        result = provider._make_api_call("model-id", messages, stream=True)
+        result = provider.completion("model-id", messages, stream=True)
 
         # Verify _stream_completion was called
         assert mock_stream_completion.call_count == 1

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -17,7 +17,7 @@ def test_response_format_raises_for_non_streaming() -> None:
     provider = _mk_provider()
 
     with pytest.raises(UnsupportedParameterError):
-        provider._make_api_call(
+        provider.completion(
             model="model-id",
             messages=[{"role": "user", "content": "Hello"}],
             response_format={"type": "json_object"},
@@ -28,7 +28,7 @@ def test_stream_and_response_format_combination_raises() -> None:
     provider = _mk_provider()
 
     with pytest.raises(UnsupportedParameterError):
-        provider._make_api_call(
+        provider.completion(
             model="model-id",
             messages=[{"role": "user", "content": "Hello"}],
             stream=True,
@@ -40,7 +40,7 @@ def test_parallel_tool_calls_raises() -> None:
     provider = _mk_provider()
 
     with pytest.raises(UnsupportedParameterError):
-        provider._make_api_call(
+        provider.completion(
             model="model-id",
             messages=[{"role": "user", "content": "Hello"}],
             parallel_tool_calls=False,

--- a/tests/unit/providers/test_google_provider.py
+++ b/tests/unit/providers/test_google_provider.py
@@ -40,8 +40,8 @@ def mock_google_provider():  # type: ignore[no-untyped-def]
         ("required", "ANY"),
     ],
 )
-def test_make_api_call_with_tool_choice_auto(tool_choice: str, expected_mode: str) -> None:
-    """Test that _make_api_call correctly processes tool_choice='auto'."""
+def testcompletion_with_tool_choice_auto(tool_choice: str, expected_mode: str) -> None:
+    """Test that completion correctly processes tool_choice='auto'."""
     api_key = "test-api-key"
     model = "gemini-pro"
     messages = [{"role": "user", "content": "Hello"}]
@@ -49,7 +49,7 @@ def test_make_api_call_with_tool_choice_auto(tool_choice: str, expected_mode: st
 
     with mock_google_provider() as mock_genai:
         provider = GoogleProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages, **kwargs)
+        provider.completion(model, messages, **kwargs)
 
         _, call_kwargs = mock_genai.return_value.models.generate_content.call_args
         generation_config = call_kwargs["config"]
@@ -57,15 +57,15 @@ def test_make_api_call_with_tool_choice_auto(tool_choice: str, expected_mode: st
         assert generation_config.tool_config.function_calling_config.mode.value == expected_mode
 
 
-def test_make_api_call_without_tool_choice() -> None:
-    """Test that _make_api_call works correctly without tool_choice."""
+def testcompletion_without_tool_choice() -> None:
+    """Test that completion works correctly without tool_choice."""
     api_key = "test-api-key"
     model = "gemini-pro"
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider() as mock_genai:
         provider = GoogleProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call(model, messages)
+        provider.completion(model, messages)
 
         _, call_kwargs = mock_genai.return_value.models.generate_content.call_args
         generation_config = call_kwargs["config"]
@@ -73,7 +73,7 @@ def test_make_api_call_without_tool_choice() -> None:
         assert generation_config.tool_config is None
 
 
-def test_make_api_call_with_stream_and_response_format_raises() -> None:
+def testcompletion_with_stream_and_response_format_raises() -> None:
     api_key = "test-api-key"
     model = "gemini-pro"
     messages = [{"role": "user", "content": "Hello"}]
@@ -81,7 +81,7 @@ def test_make_api_call_with_stream_and_response_format_raises() -> None:
     with mock_google_provider():
         provider = GoogleProvider(ApiConfig(api_key=api_key))
         with pytest.raises(UnsupportedParameterError):
-            provider._make_api_call(
+            provider.completion(
                 model,
                 messages,
                 stream=True,
@@ -89,7 +89,7 @@ def test_make_api_call_with_stream_and_response_format_raises() -> None:
             )
 
 
-def test_make_api_call_with_parallel_tool_calls_raises() -> None:
+def testcompletion_with_parallel_tool_calls_raises() -> None:
     api_key = "test-api-key"
     model = "gemini-pro"
     messages = [{"role": "user", "content": "Hello"}]
@@ -97,7 +97,7 @@ def test_make_api_call_with_parallel_tool_calls_raises() -> None:
     with mock_google_provider():
         provider = GoogleProvider(ApiConfig(api_key=api_key))
         with pytest.raises(UnsupportedParameterError):
-            provider._make_api_call(
+            provider.completion(
                 model,
                 messages,
                 parallel_tool_calls=True,

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -31,7 +31,7 @@ def test_huggingface_with_api_key() -> None:
 
     with mock_huggingface_provider() as mock_huggingface:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call("model-id", messages)
+        provider.completion("model-id", messages)
 
         mock_huggingface.assert_called_with(token=api_key, timeout=None)
 
@@ -44,7 +44,7 @@ def test_huggingface_with_tools(tools: list[dict[str, Any]]) -> None:
 
     with mock_huggingface_provider() as mock_huggingface:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call("model-id", messages, tools=tools)
+        provider.completion("model-id", messages, tools=tools)
 
         mock_huggingface.assert_called_with(token=api_key, timeout=None)
 
@@ -59,7 +59,7 @@ def test_huggingface_with_max_tokens() -> None:
 
     with mock_huggingface_provider() as mock_huggingface:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
-        provider._make_api_call("model-id", messages, max_tokens=100)
+        provider.completion("model-id", messages, max_tokens=100)
 
         mock_huggingface.assert_called_with(token=api_key, timeout=None)
 

--- a/tests/unit/providers/test_watsonx_provider.py
+++ b/tests/unit/providers/test_watsonx_provider.py
@@ -50,7 +50,7 @@ def test_watsonx_non_streaming() -> None:
 
     with mock_watsonx_provider() as (mock_model_instance, mock_convert_response, mock_model_inference):
         provider = WatsonxProvider(ApiConfig(api_key=api_key))
-        result = provider._make_api_call("test-model", messages)
+        result = provider.completion("test-model", messages)
 
         # Verify ModelInference was created with correct parameters
         mock_model_inference.assert_called_once()
@@ -72,7 +72,7 @@ def test_watsonx_streaming() -> None:
 
     with mock_watsonx_streaming_provider() as (mock_model_instance, mock_convert_streaming_chunk, mock_model_inference):
         provider = WatsonxProvider(ApiConfig(api_key=api_key))
-        result = provider._make_api_call("test-model", messages, stream=True)
+        result = provider.completion("test-model", messages, stream=True)
 
         mock_model_inference.assert_called_once()
         call_kwargs = mock_model_inference.call_args[1]
@@ -80,7 +80,7 @@ def test_watsonx_streaming() -> None:
 
         result_list = list(result)
 
-        mock_model_instance.chat_stream.assert_called_once_with(messages=messages, params={"stream": True})
+        mock_model_instance.chat_stream.assert_called_once_with(messages=messages, params={})
 
         assert mock_convert_streaming_chunk.call_count == 2
 


### PR DESCRIPTION
As we've expanded any-llm functionality, the _make_api_call function name no longer makes sense.