### PR TITLE
feat: Add typing for responses API

### DIFF
--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from any_llm.provider import ApiConfig, Provider, ProviderFactory
 from any_llm.tools import prepare_tools
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CreateEmbeddingResponse
-from any_llm.types.responses import Response, ResponseStreamEvent, ResponseInputParam
+from any_llm.types.responses import Response, ResponseInputParam, ResponseStreamEvent
 
 
 def _prepare_completion_request(

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from any_llm.provider import ApiConfig, Provider, ProviderFactory
 from any_llm.tools import prepare_tools
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CreateEmbeddingResponse
-from any_llm.types.responses import Response, ResponseStreamEvent
+from any_llm.types.responses import Response, ResponseStreamEvent, ResponseInputParam
 
 
 def _prepare_completion_request(
@@ -240,7 +240,7 @@ async def acompletion(
 
 def responses(
     model: str,
-    input_data: Any,
+    input_data: str | ResponseInputParam,
     *,
     tools: list[dict[str, Any] | Callable[..., Any]] | None = None,
     tool_choice: str | dict[str, Any] | None = None,
@@ -319,7 +319,7 @@ def responses(
 
 async def aresponses(
     model: str,
-    input_data: Any,
+    input_data: str | ResponseInputParam,
     *,
     tools: list[dict[str, Any] | Callable[..., Any]] | None = None,
     tool_choice: str | dict[str, Any] | None = None,

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -176,7 +176,9 @@ class Provider(ABC):
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         return await asyncio.to_thread(self.completion, model, messages, **kwargs)
 
-    def responses(self, model: str, input_data: str | ResponseInputParam, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
+    def responses(
+        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+    ) -> Response | Iterator[ResponseStreamEvent]:
         """Create a response using the provider's Responses API if supported.
 
         Default implementation raises NotImplementedError. Providers that set
@@ -185,7 +187,7 @@ class Provider(ABC):
         msg = "This provider does not support the Responses API."
         raise NotImplementedError(msg)
 
-    async def aresponses(self, model: str, input_data: Any, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
+    async def aresponses(self, model: str, input_data: str | ResponseInputParam, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
         return await asyncio.to_thread(self.responses, model, input_data, **kwargs)
 
     def embedding(

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -19,7 +19,7 @@ from any_llm.types.completion import (
     Choice,
     CreateEmbeddingResponse,
 )
-from any_llm.types.responses import Response, ResponseStreamEvent, ResponseInputParam
+from any_llm.types.responses import Response, ResponseInputParam, ResponseStreamEvent
 
 
 def convert_instructor_response(instructor_response: Any, model: str, provider_name: str) -> ChatCompletion:

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -147,7 +147,9 @@ class Provider(ABC):
         msg = "This provider does not support the Responses API."
         raise NotImplementedError(msg)
 
-    async def aresponses(self, model: str, input_data: str | ResponseInputParam, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
+    async def aresponses(
+        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+    ) -> Response | Iterator[ResponseStreamEvent]:
         return await asyncio.to_thread(self.responses, model, input_data, **kwargs)
 
     def embedding(

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -19,7 +19,7 @@ from any_llm.types.completion import (
     Choice,
     CreateEmbeddingResponse,
 )
-from any_llm.types.responses import Response, ResponseStreamEvent
+from any_llm.types.responses import Response, ResponseStreamEvent, ResponseInputParam
 
 
 def convert_instructor_response(instructor_response: Any, model: str, provider_name: str) -> ChatCompletion:
@@ -176,7 +176,7 @@ class Provider(ABC):
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         return await asyncio.to_thread(self.completion, model, messages, **kwargs)
 
-    def responses(self, model: str, input_data: Any, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
+    def responses(self, model: str, input_data: str | ResponseInputParam, **kwargs: Any) -> Response | Iterator[ResponseStreamEvent]:
         """Create a response using the provider's Responses API if supported.
 
         Default implementation raises NotImplementedError. Providers that set

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -1,5 +1,7 @@
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEvent
+from openai.types.responses import ResponseInputParam as OpenAIResponseInputParam
 
 Response = OpenAIResponse
 ResponseStreamEvent = OpenAIResponseStreamEvent
+ResponseInputParam = OpenAIResponseInputParam

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -1,6 +1,6 @@
 from openai.types.responses import Response as OpenAIResponse
-from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEvent
 from openai.types.responses import ResponseInputParam as OpenAIResponseInputParam
+from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEvent
 
 Response = OpenAIResponse
 ResponseStreamEvent = OpenAIResponseStreamEvent


### PR DESCRIPTION
## Description

- Added typing for response API

## Testing
- Unit tests/integration tests pass

## Notes
- Python 3.11+ supports `TypeAlias` type hint, which we should probably use on any type aliases (unless we're targeting <=3.10 compatibility) in a separate PR. I'll raise an issue. (UPDATE: looks like we're >=3.11, I'll raise the issue.)
- I'm only adding aliases for the first level of OpenAI input models. Let me know if we want to go deeper than that