### PR TITLE
feat: Add `TypeAlias` for imported OpenAI Types

### DIFF
--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -54,7 +54,9 @@ class ChatCompletionChunk(OpenAIChatCompletionChunk):
 
 
 ChatCompletionMessageFunctionToolCall: TypeAlias = OpenAIChatCompletionMessageFunctionToolCall
-ChatCompletionMessageToolCall: TypeAlias = OpenAIChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
+ChatCompletionMessageToolCall: TypeAlias = (
+    OpenAIChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
+)
 Function: TypeAlias = OpenAIFunction
 CompletionUsage: TypeAlias = OpenAICompletionUsage
 CreateEmbeddingResponse: TypeAlias = OpenAICreateEmbeddingResponse

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -1,5 +1,3 @@
-from typing import TypeAlias
-
 from openai.types import CreateEmbeddingResponse as OpenAICreateEmbeddingResponse
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion import Choice as OpenAIChoice
@@ -53,14 +51,14 @@ class ChatCompletionChunk(OpenAIChatCompletionChunk):
     choices: list[ChunkChoice]  # type: ignore[assignment]
 
 
-ChatCompletionMessageFunctionToolCall: TypeAlias = OpenAIChatCompletionMessageFunctionToolCall
-ChatCompletionMessageToolCall: TypeAlias = (
+type ChatCompletionMessageFunctionToolCall = OpenAIChatCompletionMessageFunctionToolCall
+type ChatCompletionMessageToolCall = (
     OpenAIChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
 )
-Function: TypeAlias = OpenAIFunction
-CompletionUsage: TypeAlias = OpenAICompletionUsage
-CreateEmbeddingResponse: TypeAlias = OpenAICreateEmbeddingResponse
-Embedding: TypeAlias = OpenAIEmbedding
-Usage: TypeAlias = OpenAIUsage
-ChoiceDeltaToolCall: TypeAlias = OpenAIChoiceDeltaToolCall
-ChoiceDeltaToolCallFunction: TypeAlias = OpenAIChoiceDeltaToolCallFunction
+type Function = OpenAIFunction
+type CompletionUsage = OpenAICompletionUsage
+type CreateEmbeddingResponse = OpenAICreateEmbeddingResponse
+type Embedding = OpenAIEmbedding
+type Usage = OpenAIUsage
+type ChoiceDeltaToolCall = OpenAIChoiceDeltaToolCall
+type ChoiceDeltaToolCallFunction = OpenAIChoiceDeltaToolCallFunction

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 from openai.types import CreateEmbeddingResponse as OpenAICreateEmbeddingResponse
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion import Choice as OpenAIChoice
@@ -51,12 +53,12 @@ class ChatCompletionChunk(OpenAIChatCompletionChunk):
     choices: list[ChunkChoice]  # type: ignore[assignment]
 
 
-ChatCompletionMessageFunctionToolCall = OpenAIChatCompletionMessageFunctionToolCall
-ChatCompletionMessageToolCall = OpenAIChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
-Function = OpenAIFunction
-CompletionUsage = OpenAICompletionUsage
-CreateEmbeddingResponse = OpenAICreateEmbeddingResponse
-Embedding = OpenAIEmbedding
-Usage = OpenAIUsage
-ChoiceDeltaToolCall = OpenAIChoiceDeltaToolCall
-ChoiceDeltaToolCallFunction = OpenAIChoiceDeltaToolCallFunction
+ChatCompletionMessageFunctionToolCall: TypeAlias = OpenAIChatCompletionMessageFunctionToolCall
+ChatCompletionMessageToolCall: TypeAlias = OpenAIChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
+Function: TypeAlias = OpenAIFunction
+CompletionUsage: TypeAlias = OpenAICompletionUsage
+CreateEmbeddingResponse: TypeAlias = OpenAICreateEmbeddingResponse
+Embedding: TypeAlias = OpenAIEmbedding
+Usage: TypeAlias = OpenAIUsage
+ChoiceDeltaToolCall: TypeAlias = OpenAIChoiceDeltaToolCall
+ChoiceDeltaToolCallFunction: TypeAlias = OpenAIChoiceDeltaToolCallFunction

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -1,9 +1,11 @@
+from typing import TypeAlias
+
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import ResponseInputParam as OpenAIResponseInputParam
 from openai.types.responses import ResponseOutputMessage as OpenAIResponseOutputMessage
 from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEvent
 
-Response = OpenAIResponse
-ResponseStreamEvent = OpenAIResponseStreamEvent
-ResponseOutputMessage = OpenAIResponseOutputMessage
-ResponseInputParam = OpenAIResponseInputParam
+Response: TypeAlias = OpenAIResponse
+ResponseStreamEvent: TypeAlias = OpenAIResponseStreamEvent
+ResponseOutputMessage: TypeAlias = OpenAIResponseOutputMessage
+ResponseInputParam: TypeAlias = OpenAIResponseInputParam

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -1,11 +1,9 @@
-from typing import TypeAlias
-
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import ResponseInputParam as OpenAIResponseInputParam
 from openai.types.responses import ResponseOutputMessage as OpenAIResponseOutputMessage
 from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEvent
 
-Response: TypeAlias = OpenAIResponse
-ResponseStreamEvent: TypeAlias = OpenAIResponseStreamEvent
-ResponseOutputMessage: TypeAlias = OpenAIResponseOutputMessage
-ResponseInputParam: TypeAlias = OpenAIResponseInputParam
+type Response = OpenAIResponse
+type ResponseStreamEvent = OpenAIResponseStreamEvent
+type ResponseOutputMessage = OpenAIResponseOutputMessage
+type ResponseInputParam = OpenAIResponseInputParam


### PR DESCRIPTION
Python 3.11+ supports `TypeAlias`, good to keep explicit