### PR TITLE
fix: Handle unsupported stream option in response format

### DIFF
--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -119,6 +119,11 @@ class BaseOpenAIProvider(Provider, ABC):
         )
 
         if "response_format" in kwargs:
+            stream = kwargs.pop("stream", False)
+            if stream:
+                msg = "stream is not supported for response_format"
+                raise ValueError(msg)
+
             response = client.chat.completions.parse(
                 model=model,
                 messages=messages,  # type: ignore[arg-type]

--- a/tests/integration/test_response_format.py
+++ b/tests/integration/test_response_format.py
@@ -27,6 +27,9 @@ def test_response_format(
     model_id = provider_model_map[provider]
     extra_kwargs = provider_extra_kwargs_map.get(provider, {})
 
+    # From https://github.com/mozilla-ai/any-llm/issues/150, should be ok to set stream=False
+    extra_kwargs["stream"] = False
+
     class ResponseFormat(BaseModel):
         city_name: str
 


### PR DESCRIPTION
* Added a check to raise a ValueError if the 'stream' option is provided with 'response_format', as it is not supported.
* Updated integration test to set 'stream' to False, ensuring compatibility with the new validation.