### PR TITLE
feat: response_format for cohere provider

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -51,6 +51,7 @@ jobs:
           LLAMA_API_KEY: ${{ secrets.LLAMA_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CO_API_KEY: ${{ secrets.CO_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -56,7 +56,7 @@ class CohereProvider(Provider):
             yield _create_openai_chunk_from_cohere_chunk(chunk)
 
     @staticmethod
-    def _preprocess_response_format(response_format: type[BaseModel] | dict) -> dict:
+    def _preprocess_response_format(response_format: type[BaseModel] | dict[str, Any]) -> dict[str, Any]:
         # if response format is a BaseModel, generate model json schema
         if isinstance(response_format, type) and issubclass(response_format, BaseModel):
             return {"type": "json_object", "schema": response_format.model_json_schema()}

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -76,6 +76,7 @@ class CohereProvider(Provider):
             # Note that Cohere has a bunch of limitations on JSON schemas (e.g., no oneOf, numeric/str ranges, weird regex limitations)
             # see docs here: https://docs.cohere.com/docs/structured-outputs#unsupported-schema-features
             else:
+                # Validation logic could/would eventually go here
                 kwargs["response_format"] = response_format
         if kwargs.get("stream", False) and kwargs.get("response_format", None) is not None:
             msg = "stream and response_format"

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterator
 from typing import Any
 
+from pydantic import BaseModel
+
 try:
     import cohere
 
@@ -61,8 +63,23 @@ class CohereProvider(Provider):
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """Create a chat completion using Cohere."""
         if kwargs.get("response_format", None) is not None:
-            msg = "response_format"
-            raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
+            response_format = kwargs.pop("response_format")
+            # if response format is a BaseModel, generate model json schema
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+                kwargs["response_format"] = {
+                    "type": "json_object",
+                    "schema": response_format.model_json_schema()
+                }
+            # can either be json schema already in dict
+            # or {"type": "json_object"} to just generate *a* JSON (JSON mode)
+            # see docs here: https://docs.cohere.com/docs/structured-outputs#json-mode
+            elif isinstance(response_format, dict):
+                kwargs["response_format"] = response_format
+            # For now, let Cohere API handle invalid schemas.
+            # Note that Cohere has a bunch of limitations on JSON schemas (e.g., no oneOf, numeric/str ranges, weird regex limitations)
+            # see docs here: https://docs.cohere.com/docs/structured-outputs#unsupported-schema-features
+            else:
+                kwargs["response_format"] = response_format
         if kwargs.get("stream", False) and kwargs.get("response_format", None) is not None:
             msg = "stream and response_format"
             raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
@@ -70,9 +87,12 @@ class CohereProvider(Provider):
             msg = "parallel_tool_calls"
             raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
 
-        if kwargs.get("stream", False):
-            kwargs.pop("stream")
+        stream = kwargs.pop("stream", False)
+
+        if stream:
             return self._stream_completion(model, messages, **kwargs)
+
+        # note: ClientV2.chat does not have a `stream` parameter
         response = self.client.chat(
             model=model,
             messages=messages,  # type: ignore[arg-type]

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -66,10 +66,7 @@ class CohereProvider(Provider):
             response_format = kwargs.pop("response_format")
             # if response format is a BaseModel, generate model json schema
             if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                kwargs["response_format"] = {
-                    "type": "json_object",
-                    "schema": response_format.model_json_schema()
-                }
+                kwargs["response_format"] = {"type": "json_object", "schema": response_format.model_json_schema()}
             # can either be json schema already in dict
             # or {"type": "json_object"} to just generate *a* JSON (JSON mode)
             # see docs here: https://docs.cohere.com/docs/structured-outputs#json-mode

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -54,7 +54,7 @@ class CohereProvider(Provider):
 
         for chunk in cohere_stream:
             yield _create_openai_chunk_from_cohere_chunk(chunk)
-    
+
     @staticmethod
     def _preprocess_response_format(response_format: type[BaseModel] | dict) -> dict:
         # if response format is a BaseModel, generate model json schema
@@ -63,14 +63,13 @@ class CohereProvider(Provider):
         # can either be json schema already in dict
         # or {"type": "json_object"} to just generate *a* JSON (JSON mode)
         # see docs here: https://docs.cohere.com/docs/structured-outputs#json-mode
-        elif isinstance(response_format, dict):
+        if isinstance(response_format, dict):
             return response_format
         # For now, let Cohere API handle invalid schemas.
         # Note that Cohere has a bunch of limitations on JSON schemas (e.g., no oneOf, numeric/str ranges, weird regex limitations)
         # see docs here: https://docs.cohere.com/docs/structured-outputs#unsupported-schema-features
-        else:
-            # Validation logic could/would eventually go here
-            return response_format
+        # Validation logic could/would eventually go here
+        return response_format
 
     def completion(
         self,

--- a/tests/integration/test_response_format.py
+++ b/tests/integration/test_response_format.py
@@ -21,9 +21,9 @@ def test_response_format(
     if not cls.SUPPORTS_COMPLETION:
         pytest.skip(f"{provider.value} does not support response_format, skipping")
     """Test that all supported providers can be loaded successfully."""
-    if provider in [ProviderName.COHERE]:
-        pytest.skip(f"{provider.value} does not support response_format")
-        return
+    # if provider in [ProviderName.COHERE]:
+    #     pytest.skip(f"{provider.value} does not support response_format")
+    #     return
     model_id = provider_model_map[provider]
     extra_kwargs = provider_extra_kwargs_map.get(provider, {})
 

--- a/tests/integration/test_response_format.py
+++ b/tests/integration/test_response_format.py
@@ -21,9 +21,6 @@ def test_response_format(
     if not cls.SUPPORTS_COMPLETION:
         pytest.skip(f"{provider.value} does not support response_format, skipping")
     """Test that all supported providers can be loaded successfully."""
-    # if provider in [ProviderName.COHERE]:
-    #     pytest.skip(f"{provider.value} does not support response_format")
-    #     return
     model_id = provider_model_map[provider]
     extra_kwargs = provider_extra_kwargs_map.get(provider, {})
 

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -2,6 +2,8 @@ from typing import Any
 
 import pytest
 
+from pydantic import BaseModel
+
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.provider import ApiConfig
 
@@ -12,6 +14,30 @@ def _mk_provider() -> Any:
 
     return CohereProvider(ApiConfig(api_key="test-api-key"))
 
+def test_preprocess_response_format() -> None:
+    provider = _mk_provider()
+
+    class StructuredOutput(BaseModel):
+        foo: str
+        bar: int
+    
+    json_schema = {
+        "type": "json_object",
+        "schema":StructuredOutput.model_json_schema()
+    }
+
+    # input BaseModel should output a dict
+    outp_basemodel = provider._preprocess_response_format(StructuredOutput)
+
+    # input dict should output a dict
+    outp_dict = provider._preprocess_response_format(json_schema)
+
+    # both should output a dict
+    assert isinstance(outp_basemodel, dict)
+    assert isinstance(outp_dict, dict)
+
+    # should equal each other
+    assert outp_basemodel == outp_dict
 
 def test_stream_and_response_format_combination_raises() -> None:
     provider = _mk_provider()

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import pytest
-
 from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
@@ -14,17 +13,15 @@ def _mk_provider() -> Any:
 
     return CohereProvider(ApiConfig(api_key="test-api-key"))
 
+
 def test_preprocess_response_format() -> None:
     provider = _mk_provider()
 
     class StructuredOutput(BaseModel):
         foo: str
         bar: int
-    
-    json_schema = {
-        "type": "json_object",
-        "schema":StructuredOutput.model_json_schema()
-    }
+
+    json_schema = {"type": "json_object", "schema": StructuredOutput.model_json_schema()}
 
     # input BaseModel should output a dict
     outp_basemodel = provider._preprocess_response_format(StructuredOutput)
@@ -38,6 +35,7 @@ def test_preprocess_response_format() -> None:
 
     # should equal each other
     assert outp_basemodel == outp_dict
+
 
 def test_stream_and_response_format_combination_raises() -> None:
     provider = _mk_provider()

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -13,17 +13,6 @@ def _mk_provider() -> Any:
     return CohereProvider(ApiConfig(api_key="test-api-key"))
 
 
-def test_response_format_raises_for_non_streaming() -> None:
-    provider = _mk_provider()
-
-    with pytest.raises(UnsupportedParameterError):
-        provider.completion(
-            model="model-id",
-            messages=[{"role": "user", "content": "Hello"}],
-            response_format={"type": "json_object"},
-        )
-
-
 def test_stream_and_response_format_combination_raises() -> None:
     provider = _mk_provider()
 


### PR DESCRIPTION
# Description
- Adds support for `response_format` for Cohere provider
- Enables `response_format` integration tests for Cohere

## Notes
- The way that Cohere handles structured outputs is significantly different than Fireworks so I wrote logic in the Cohere provider instead of making a universal helper function. I think that something like an abstract method or smaller formatting function for Pydantic models specifically could be helpful if/when we want to do things like validate desired JSON schemas on a per-provider basis.
- On that note, there's a ton of limitations in the way Cohere does structured outputs and I'm letting the Cohere client handle it.