### PR TITLE
fix(google): Handle multiple input `messages` appropriately.

### DIFF
--- a/src/any_llm/providers/google/google.py
+++ b/src/any_llm/providers/google/google.py
@@ -123,29 +123,17 @@ class GoogleProvider(Provider):
 
         formatted_messages = _convert_messages(messages)
 
-        content_text = ""
-        if len(formatted_messages) == 1 and formatted_messages[0].role == "user":
-            # Single user message
-            parts = formatted_messages[0].parts
-            if parts and hasattr(parts[0], "text"):
-                content_text = parts[0].text or ""
-        else:
-            # Multiple messages - concatenate user messages for simplicity
-            content_parts = []
-            for content_item in formatted_messages:
-                if content_item.role == "user" and content_item.parts:
-                    if hasattr(content_item.parts[0], "text") and content_item.parts[0].text:
-                        content_parts.append(content_item.parts[0].text)
-
-            content_text = "\n".join(content_parts)
-
         if stream:
             response_stream = self.client.models.generate_content_stream(
-                model=model, contents=content_text, config=generation_config
+                model=model,
+                contents=formatted_messages,  # type: ignore[arg-type]
+                config=generation_config,
             )
             return map(_create_openai_chunk_from_google_chunk, response_stream)
         response: types.GenerateContentResponse = self.client.models.generate_content(
-            model=model, contents=content_text, config=generation_config
+            model=model,
+            contents=formatted_messages,  # type: ignore[arg-type]
+            config=generation_config,
         )
 
         response_dict = _convert_response_to_response_dict(response)

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -185,7 +185,7 @@ def test_call_to_provider_with_no_packages_installed() -> None:
             ProviderFactory.create_provider("anthropic", ApiConfig())
 
 
-def test_make_api_call_inside_agent_loop() -> None:
+def test_completion_inside_agent_loop() -> None:
     api_key = "test-api-key"
     model = "model-id"
     messages = [


### PR DESCRIPTION
We were concatenating the user messages into a single string (not sure why) and leaving out other messages (i.e. assistant responses and tool call results).

This was an incorrect implementation for both agent loops and multi-turn conversations (because assistant responses were not being fed back to the model).

See https://ai.google.dev/gemini-api/docs/text-generation#rest_6 for reference.
