### PR TITLE
feat(tools): Enhance callable_to_tool to support complex types

### DIFF
--- a/src/any_llm/providers/llama/llama.py
+++ b/src/any_llm/providers/llama/llama.py
@@ -1,4 +1,9 @@
+from collections.abc import Iterator
+from typing import Any
+
+from any_llm.providers.llama.utils import _patch_json_schema
 from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
 
 
 class LlamaProvider(BaseOpenAIProvider):
@@ -14,3 +19,8 @@ class LlamaProvider(BaseOpenAIProvider):
     SUPPORTS_RESPONSES = False
     SUPPORTS_COMPLETION_REASONING = False
     SUPPORTS_EMBEDDING = False
+
+    def completion(self, params: CompletionParams, **kwargs: Any) -> ChatCompletion | Iterator[ChatCompletionChunk]:
+        if params.tools:
+            params.tools = [_patch_json_schema(tool) for tool in params.tools]
+        return super().completion(params, **kwargs)

--- a/src/any_llm/providers/llama/utils.py
+++ b/src/any_llm/providers/llama/utils.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+
+def _patch_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Patch the JSON schema to be compatible with Llama's API."""
+    # Llama requires that the 'union_specified' has a parameter type specified
+    # so we need to patch the schema to include the type of the parameter
+    # if any of the function call parameter properties have 'oneOf' set, make sure the property has type set. If not, set it to string. This is a quirk with Llama API currently.
+    props = schema["function"]["parameters"]["properties"]
+    for prop in props:
+        if "oneOf" in props[prop] and "type" not in props[prop]:
+            props[prop]["type"] = "string"
+
+    return schema

--- a/src/any_llm/tools.py
+++ b/src/any_llm/tools.py
@@ -1,8 +1,19 @@
 """Tools utilities for converting Python callables to OpenAI tools format."""
 
+from __future__ import annotations
+
+import dataclasses
+import enum
 import inspect
-from collections.abc import Callable
-from typing import Any, get_type_hints
+import types as _types
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, time
+from typing import Annotated as _Annotated
+from typing import Any, get_args, get_origin, get_type_hints
+from typing import Literal as _Literal
+
+from pydantic import BaseModel as PydanticBaseModel
+from typing_extensions import is_typeddict as _is_typeddict
 
 
 def callable_to_tool(func: Callable[..., Any]) -> dict[str, Any]:
@@ -26,29 +37,27 @@ def callable_to_tool(func: Callable[..., Any]) -> dict[str, Any]:
         >>> # Returns OpenAI tools format dict
 
     """
-    # Validate the function has a docstring
     if not func.__doc__:
         msg = f"Function {func.__name__} must have a docstring"
         raise ValueError(msg)
 
     sig = inspect.signature(func)
-
     type_hints = get_type_hints(func)
 
-    properties = {}
-    required = []
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
 
     for param_name, param in sig.parameters.items():
         if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
             continue
 
-        param_type = type_hints.get(param_name, str)
+        annotated_type = type_hints.get(param_name, str)
+        param_schema = _python_type_to_json_schema(annotated_type)
 
-        json_type = _python_type_to_json_schema_type(param_type)
-
+        type_name = getattr(annotated_type, "__name__", str(annotated_type))
         properties[param_name] = {
-            "type": json_type,
-            "description": f"Parameter {param_name} of type {param_type.__name__}",
+            **param_schema,
+            "description": f"Parameter {param_name} of type {type_name}",
         }
 
         if param.default == inspect.Parameter.empty:
@@ -64,21 +73,167 @@ def callable_to_tool(func: Callable[..., Any]) -> dict[str, Any]:
     }
 
 
-def _python_type_to_json_schema_type(python_type: type) -> str:
-    """Convert Python type to JSON Schema type string."""
-    if python_type is str:
-        return "string"
-    if python_type is int:
-        return "integer"
-    if python_type is float:
-        return "number"
-    if python_type is bool:
-        return "boolean"
+def _python_type_to_json_schema(python_type: Any) -> dict[str, Any]:
+    """Convert Python type annotation to a JSON Schema for a parameter.
+
+    Supported mappings (subset tailored for LLM tool schemas):
+    - Primitives: str/int/float/bool -> string/integer/number/boolean
+    - bytes -> string with contentEncoding base64
+    - datetime/date/time -> string with format date-time/date/time
+    - list[T] / Sequence[T] / set[T] / frozenset[T] -> array with items=schema(T)
+      - set/frozenset include uniqueItems=true
+      - list without type args defaults items to string
+    - dict[K,V] / Mapping[K,V] -> object with additionalProperties=schema(V)
+      - dict without type args defaults additionalProperties to string
+    - tuple[T1, T2, ...] -> array with prefixItems per element and min/maxItems
+    - tuple[T, ...] -> array with items=schema(T)
+    - Union[X, Y] and X | Y -> oneOf=[schema(X), schema(Y)] (without top-level type)
+    - Optional[T] (Union[T, None]) -> schema(T) (nullability not encoded)
+    - Literal[...]/Enum -> enum with appropriate type inference when uniform
+    - TypedDict -> object with properties/required per annotations
+    - dataclass/Pydantic BaseModel -> object with nested properties inferred from fields
+    """
+    origin = get_origin(python_type)
+    args = get_args(python_type)
+
+    if _Annotated is not None and origin is _Annotated and len(args) >= 1:
+        python_type = args[0]
+        origin = get_origin(python_type)
+        args = get_args(python_type)
+
+    if python_type is Any:
+        return {"type": "string"}
+
+    primitive_map = {str: "string", int: "integer", float: "number", bool: "boolean"}
+    if python_type in primitive_map:
+        return {"type": primitive_map[python_type]}
+
+    if python_type is bytes:
+        return {"type": "string", "contentEncoding": "base64"}
+    if python_type is datetime:
+        return {"type": "string", "format": "date-time"}
+    if python_type is date:
+        return {"type": "string", "format": "date"}
+    if python_type is time:
+        return {"type": "string", "format": "time"}
+
     if python_type is list:
-        return "array"
+        return {"type": "array", "items": {"type": "string"}}
     if python_type is dict:
-        return "object"
-    return "string"
+        return {"type": "object", "additionalProperties": {"type": "string"}}
+
+    if origin is _Literal:
+        literal_values = list(args)
+        schema_lit: dict[str, Any] = {"enum": literal_values}
+        if all(isinstance(v, bool) for v in literal_values):
+            schema_lit["type"] = "boolean"
+        elif all(isinstance(v, str) for v in literal_values):
+            schema_lit["type"] = "string"
+        elif all(isinstance(v, int) and not isinstance(v, bool) for v in literal_values):
+            schema_lit["type"] = "integer"
+        elif all(isinstance(v, int | float) and not isinstance(v, bool) for v in literal_values):
+            schema_lit["type"] = "number"
+        return schema_lit
+
+    if inspect.isclass(python_type) and issubclass(python_type, enum.Enum):
+        enum_values = [e.value for e in python_type]
+        value_types = {type(v) for v in enum_values}
+        schema: dict[str, Any] = {"enum": enum_values}
+        if value_types == {str}:
+            schema["type"] = "string"
+        elif value_types == {int}:
+            schema["type"] = "integer"
+        elif value_types <= {int, float}:
+            schema["type"] = "number"
+        elif value_types == {bool}:
+            schema["type"] = "boolean"
+        return schema
+
+    if _is_typeddict(python_type):
+        annotations: dict[str, Any] = getattr(python_type, "__annotations__", {}) or {}
+        required_keys = set(getattr(python_type, "__required_keys__", set()))
+        td_properties: dict[str, Any] = {}
+        td_required: list[str] = []
+        for field_name, field_type in annotations.items():
+            td_properties[field_name] = _python_type_to_json_schema(field_type)
+            if field_name in required_keys:
+                td_required.append(field_name)
+        schema_td: dict[str, Any] = {
+            "type": "object",
+            "properties": td_properties,
+        }
+        if td_required:
+            schema_td["required"] = td_required
+        return schema_td
+
+    if inspect.isclass(python_type) and dataclasses.is_dataclass(python_type):
+        type_hints = get_type_hints(python_type)
+        dc_properties: dict[str, Any] = {}
+        dc_required: list[str] = []
+        for field in dataclasses.fields(python_type):
+            field_type = type_hints.get(field.name, Any)
+            dc_properties[field.name] = _python_type_to_json_schema(field_type)
+            if (
+                field.default is dataclasses.MISSING
+                and getattr(field, "default_factory", dataclasses.MISSING) is dataclasses.MISSING
+            ):
+                dc_required.append(field.name)
+        schema_dc: dict[str, Any] = {"type": "object", "properties": dc_properties}
+        if dc_required:
+            schema_dc["required"] = dc_required
+        return schema_dc
+
+    if inspect.isclass(python_type) and issubclass(python_type, PydanticBaseModel):
+        model_type_hints = get_type_hints(python_type)
+        pd_properties: dict[str, Any] = {}
+        pd_required: list[str] = []
+        model_fields = getattr(python_type, "model_fields", {})
+        for name, field_info in model_fields.items():
+            pd_properties[name] = _python_type_to_json_schema(model_type_hints.get(name, Any))
+            is_required = getattr(field_info, "is_required", None)
+            if callable(is_required) and is_required():
+                pd_required.append(name)
+        schema_pd: dict[str, Any] = {"type": "object", "properties": pd_properties}
+        if pd_required:
+            schema_pd["required"] = pd_required
+        return schema_pd
+
+    if origin in (list, Sequence, set, frozenset):
+        item_type = args[0] if args else Any
+        item_schema = _python_type_to_json_schema(item_type)
+        schema_arr: dict[str, Any] = {"type": "array", "items": item_schema or {"type": "string"}}
+        if origin in (set, frozenset):
+            schema_arr["uniqueItems"] = True
+        return schema_arr
+    if origin is tuple:
+        if not args:
+            return {"type": "array", "items": {"type": "string"}}
+        if len(args) == 2 and args[1] is Ellipsis:
+            return {"type": "array", "items": _python_type_to_json_schema(args[0])}
+        prefix_items = [_python_type_to_json_schema(a) for a in args]
+        return {
+            "type": "array",
+            "prefixItems": prefix_items,
+            "minItems": len(prefix_items),
+            "maxItems": len(prefix_items),
+        }
+
+    if origin in (dict, Mapping):
+        value_type = args[1] if len(args) >= 2 else Any
+        value_schema = _python_type_to_json_schema(value_type)
+        return {"type": "object", "additionalProperties": value_schema or {"type": "string"}}
+
+    typing_union = getattr(__import__("typing"), "Union", None)
+    if origin in (typing_union, _types.UnionType):
+        non_none_args = [a for a in args if a is not type(None)]
+        if len(non_none_args) > 1:
+            schemas = [_python_type_to_json_schema(arg) for arg in non_none_args]
+            return {"oneOf": schemas}
+        if non_none_args:
+            return _python_type_to_json_schema(non_none_args[0])
+        return {"type": "string"}
+
+    return {"type": "string"}
 
 
 def prepare_tools(tools: list[dict[str, Any] | Callable[..., Any]]) -> list[dict[str, Any]]:

--- a/tests/unit/providers/test_google_utils.py
+++ b/tests/unit/providers/test_google_utils.py
@@ -1,0 +1,41 @@
+from any_llm.providers.google.utils import _convert_tool_spec
+
+
+def test_convert_tool_spec_basic_mapping() -> None:
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search things",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The query"},
+                        # Array without items → should default items to {"type": "string"}
+                        "opts": {"type": "array"},
+                        # Array with items → should be preserved
+                        "count_list": {"type": "array", "items": {"type": "integer"}},
+                        # Enum should be preserved
+                        "mode": {"type": "string", "enum": ["a", "b"]},
+                        # additionalProperties should be dropped
+                        "config": {"type": "object", "additionalProperties": {"type": "integer"}},
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+
+    tools = _convert_tool_spec(openai_tools)
+
+    assert len(tools) == 1
+    assert tools[0].function_declarations[0].name == "search"  # type: ignore[index]
+    assert tools[0].function_declarations[0].description == "Search things"  # type: ignore[index]
+    assert tools[0].function_declarations[0].parameters.type == "OBJECT"  # type: ignore[index, union-attr]
+    assert tools[0].function_declarations[0].parameters.properties["query"].type == "STRING"  # type: ignore[union-attr, index]
+    assert tools[0].function_declarations[0].parameters.properties["opts"].type == "ARRAY"  # type: ignore[union-attr, index]
+    assert tools[0].function_declarations[0].parameters.properties["count_list"].type == "ARRAY"  # type: ignore[union-attr, index]
+    assert tools[0].function_declarations[0].parameters.properties["mode"].type == "STRING"  # type: ignore[union-attr, index]
+    assert tools[0].function_declarations[0].parameters.properties["config"].type == "OBJECT"  # type: ignore[union-attr, index]
+    assert "additionalProperties" not in tools[0].function_declarations[0].parameters.properties["config"]  # type: ignore[union-attr, index]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,4 +1,8 @@
-from typing import Any
+import enum
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from typing import Annotated, Any, Literal, NotRequired, TypedDict
 
 import pytest
 from pydantic import BaseModel
@@ -75,11 +79,24 @@ def test_prepare_tools_mixed() -> None:
     assert tools[1]["function"]["name"] == "existing_tool"
 
 
-def test_callable_to_tool_with_list_and_dict_types() -> None:
+def test_callable_to_tool() -> None:
     """Ensure list/dict annotations produce items/additionalProperties."""
 
     class AnArg(BaseModel):
         thing: str
+
+    class UserTD(TypedDict):
+        id: int
+        name: NotRequired[str]
+
+    @dataclass
+    class UserDC:
+        a: int
+        b: str = "x"
+
+    class Color(enum.Enum):
+        RED = "red"
+        BLUE = "blue"
 
     def another_tool(
         country: str,
@@ -91,6 +108,29 @@ def test_callable_to_tool_with_list_and_dict_types() -> None:
         union_specified: str | int,
         maybe_text: str | None = None,
         maybe_anything: Any = None,
+        text: str = "t",
+        number: int = 1,
+        real: float = 1.0,
+        flag: bool = False,
+        data: bytes = b"x",
+        ts: datetime = datetime(2000, 1, 1),  # noqa: DTZ001
+        d: date = date(2000, 1, 1),
+        t: time = time(0, 0, 0),
+        set_nums: set[int] = frozenset({1}),  # type: ignore[assignment]
+        frozenset_text: frozenset[str] = frozenset({"a"}),
+        seq_nums: Sequence[int] = (),
+        tup_any: tuple = tuple(),  # type: ignore[type-arg]  # noqa: C408
+        tup_var: tuple[int, ...] = (1, 2, 3),
+        tup_fixed: tuple[int, str] = (1, "a"),
+        mapping_generic: Mapping[str, bool] = {},
+        typed: UserTD = {"id": 1},  # noqa: B006
+        data_class: UserDC = UserDC(1),  # noqa: B008
+        literal_meta: Annotated[str, "meta"] | None = None,
+        literal_ab: Literal["a", "b"] = "a",
+        enum_color: Color = Color.RED,
+        annotated_int: Annotated[int, "meta"] = 1,
+        opt_int: int | None = None,
+        union_three: str | float = 1,
     ) -> None:
         """This is a docstring"""
         return
@@ -127,3 +167,70 @@ def test_callable_to_tool_with_list_and_dict_types() -> None:
 
     assert props["pydantic_arg"]["type"] == "object"
     assert props["pydantic_arg"]["properties"]["thing"]["type"] == "string"
+
+    assert props["text"]["type"] == "string"
+    assert props["number"]["type"] == "integer"
+    assert props["real"]["type"] == "number"
+    assert props["flag"]["type"] == "boolean"
+
+    assert props["data"]["type"] == "string"
+    assert props["data"]["contentEncoding"] == "base64"
+
+    assert props["ts"]["type"] == "string"
+    assert props["ts"]["format"] == "date-time"
+    assert props["d"]["type"] == "string"
+    assert props["d"]["format"] == "date"
+    assert props["t"]["type"] == "string"
+    assert props["t"]["format"] == "time"
+
+    assert props["set_nums"]["type"] == "array"
+    assert props["set_nums"]["items"]["type"] == "integer"
+    assert props["set_nums"]["uniqueItems"] is True
+
+    assert props["frozenset_text"]["type"] == "array"
+    assert props["frozenset_text"]["items"]["type"] == "string"
+    assert props["frozenset_text"]["uniqueItems"] is True
+
+    assert props["seq_nums"]["type"] == "array"
+    assert props["seq_nums"]["items"]["type"] == "integer"
+
+    assert props["tup_any"]["type"] == "string"
+
+    assert props["tup_var"]["type"] == "array"
+    assert props["tup_var"]["items"]["type"] == "integer"
+
+    assert props["tup_fixed"]["type"] == "array"
+    assert len(props["tup_fixed"]["prefixItems"]) == 2
+    assert props["tup_fixed"]["prefixItems"][0]["type"] == "integer"
+    assert props["tup_fixed"]["prefixItems"][1]["type"] == "string"
+    assert props["tup_fixed"]["minItems"] == 2
+    assert props["tup_fixed"]["maxItems"] == 2
+
+    assert props["mapping_generic"]["type"] == "object"
+    assert props["mapping_generic"]["additionalProperties"]["type"] == "boolean"
+
+    assert props["typed"]["type"] == "object"
+    assert props["typed"]["properties"]["id"]["type"] == "integer"
+    assert "required" in props["typed"]
+    assert "id" in props["typed"]["required"]
+
+    assert props["data_class"]["type"] == "object"
+    assert props["data_class"]["properties"]["a"]["type"] == "integer"
+    assert props["data_class"]["properties"]["b"]["type"] == "string"
+    assert "a" in props["data_class"].get("required", [])
+
+    assert props["literal_meta"]["type"] == "string"
+
+    assert props["literal_ab"]["enum"] == ["a", "b"]
+    assert props["literal_ab"]["type"] == "string"
+
+    assert props["enum_color"]["enum"] == ["red", "blue"]
+    assert props["enum_color"]["type"] == "string"
+
+    assert props["annotated_int"]["type"] == "integer"
+
+    assert props["opt_int"]["type"] == "integer"
+
+    assert "oneOf" in props["union_three"]
+    assert len(props["union_three"]["oneOf"]) == 3
+    assert {s["type"] for s in props["union_three"]["oneOf"]} == {"integer", "string", "number"}

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -130,7 +130,7 @@ def test_callable_to_tool() -> None:
         enum_color: Color = Color.RED,
         annotated_int: Annotated[int, "meta"] = 1,
         opt_int: int | None = None,
-        union_three: str | float = 1,
+        union_three: str | float | bool = 1,
     ) -> None:
         """This is a docstring"""
         return
@@ -233,4 +233,4 @@ def test_callable_to_tool() -> None:
 
     assert "oneOf" in props["union_three"]
     assert len(props["union_three"]["oneOf"]) == 3
-    assert {s["type"] for s in props["union_three"]["oneOf"]} == {"integer", "string", "number"}
+    assert {s["type"] for s in props["union_three"]["oneOf"]} == {"string", "number", "boolean"}


### PR DESCRIPTION
## Description

Advanced callable conversion logic: handle poorly typed args (list vs list[str] etc), pydantic typed args, Optionals, and Unions.

Added a unit test to check that the conversions look reasonable and ran some integration style tests locally, but decided to avoid adding an integration test since I think I've got the important checks handled in the unit test.

## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
