### PR TITLE
fix(huggingface): Handle `config.api_base`.

### DIFF
--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -35,7 +35,7 @@ class HuggingfaceProvider(Provider):
 
     PROVIDER_NAME = "huggingface"
     ENV_API_KEY_NAME = "HF_TOKEN"
-    PROVIDER_DOCUMENTATION_URL = "https://huggingface.co/inference-endpoints"
+    PROVIDER_DOCUMENTATION_URL = "https://huggingface.co/docs/huggingface_hub/package_reference/inference_client"
 
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True
@@ -67,7 +67,9 @@ class HuggingfaceProvider(Provider):
         **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """Create a chat completion using HuggingFace."""
-        client = InferenceClient(token=self.config.api_key, timeout=kwargs.get("timeout"))
+        client = InferenceClient(
+            base_url=self.config.api_base, token=self.config.api_key, timeout=kwargs.get("timeout")
+        )
 
         if params.max_tokens is not None:
             kwargs["max_new_tokens"] = params.max_tokens

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -29,6 +29,18 @@ def mock_huggingface_provider():  # type: ignore[no-untyped-def]
         yield mock_huggingface
 
 
+def test_huggingface_with_api_base() -> None:
+    api_key = "test-api-key"
+    api_base = "https://test.huggingface.co"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_huggingface_provider() as mock_huggingface:
+        provider = HuggingfaceProvider(ApiConfig(api_key=api_key, api_base=api_base))
+        provider.completion(CompletionParams(model_id="model-id", messages=messages))
+
+        mock_huggingface.assert_called_with(base_url=api_base, token=api_key, timeout=None)
+
+
 def test_huggingface_with_api_key() -> None:
     api_key = "test-api-key"
     messages = [{"role": "user", "content": "Hello"}]
@@ -37,7 +49,7 @@ def test_huggingface_with_api_key() -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
-        mock_huggingface.assert_called_with(token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(model="model-id", messages=messages)
 
@@ -50,7 +62,7 @@ def test_huggingface_with_tools(tools: list[dict[str, Any]]) -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, tools=tools))
 
-        mock_huggingface.assert_called_with(token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(
             model="model-id", messages=messages, tools=tools
@@ -65,7 +77,7 @@ def test_huggingface_with_max_tokens() -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, max_tokens=100))
 
-        mock_huggingface.assert_called_with(token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(
             model="model-id", messages=messages, max_new_tokens=100


### PR DESCRIPTION
Argument was being ignored. Needs to be passed as `base_url` to the client.