### PR TITLE
feat: integration testing for multiturn tool usage, patch mistral

### DIFF
--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -330,3 +330,16 @@ def _create_openai_embedding_response_from_mistral(
         object="list",
         usage=usage,
     )
+
+
+def _patch_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Similar to github.com/pydantic/pydantic-ai/blob/851df07566a339cd0318e933464b971b0fc79d53/pydantic_ai_slim/pydantic_ai/models/mistral.py#L524,
+    we work around mistral requiring an non-user message after a tool message"""
+    processed_msg = []
+    for i, msg in enumerate(messages):
+        processed_msg.append(msg)
+        if msg.get("role") == "tool" and i + 1 < len(messages) and messages[i + 1].get("role") == "user":
+            # Mistral expects an assistant message after a tool message
+            processed_msg.append({"role": "assistant", "content": "OK"})
+
+    return processed_msg

--- a/src/any_llm/utils/api.py
+++ b/src/any_llm/utils/api.py
@@ -53,7 +53,8 @@ def _process_completion_params(
 
     for i, message in enumerate(messages):
         if isinstance(message, ChatCompletionMessage):
-            messages[i] = {"role": message.role, "content": message.content}
+            # Dump the message but exclude the extra field that we extend from OpenAI Spec
+            messages[i] = message.model_dump(exclude_none=True, exclude={"reasoning"})
 
     completion_params = CompletionParams(
         model_id=model_name,

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -1,0 +1,63 @@
+from any_llm.providers.mistral.utils import _patch_messages
+
+
+def test_patch_messages_noop_when_no_tool_before_user() -> None:
+    messages = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a"},
+    ]
+    out = _patch_messages(messages)
+    assert out == messages
+
+
+def test_patch_messages_inserts_assistant_ok_between_tool_and_user() -> None:
+    messages = [
+        {"role": "tool", "content": "tool-output"},
+        {"role": "user", "content": "next-question"},
+    ]
+    out = _patch_messages(messages)
+    assert out == [
+        {"role": "tool", "content": "tool-output"},
+        {"role": "assistant", "content": "OK"},
+        {"role": "user", "content": "next-question"},
+    ]
+
+
+def test_patch_messages_multiple_insertions() -> None:
+    messages = [
+        {"role": "tool", "content": "t1"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "t2"},
+        {"role": "user", "content": "u2"},
+    ]
+    out = _patch_messages(messages)
+    assert out == [
+        {"role": "tool", "content": "t1"},
+        {"role": "assistant", "content": "OK"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "t2"},
+        {"role": "assistant", "content": "OK"},
+        {"role": "user", "content": "u2"},
+    ]
+
+
+def test_patch_messages_no_insertion_when_tool_at_end() -> None:
+    messages = [
+        {"role": "user", "content": "u"},
+        {"role": "tool", "content": "t"},
+    ]
+    out = _patch_messages(messages)
+    assert out == messages
+
+
+def test_patch_messages_no_insertion_when_next_not_user() -> None:
+    messages = [
+        {"role": "tool", "content": "t"},
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "u"},
+    ]
+    out = _patch_messages(messages)
+    assert out == messages


### PR DESCRIPTION
- Added _patch_messages function to ensure an assistant message follows a tool message when a user message comes next.
- Updated MistralProvider to utilize _patch_messages for message handling in chat completions.
- Added unit tests for _patch_messages to verify correct behavior in various scenarios.

## Description

We didn't have any testing or handling for passing a tool back into the LLM! There's also a pretty well known mistral implementation quirk that we need to handle. 


## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix
💅 Refactor

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
