### PR TITLE
fix(Groq): Remove unsupported params from integration tests

### DIFF
--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -27,12 +27,6 @@ def test_responses(
             **extra_kwargs,
             input_data="What's the capital of France? Please think step by step.",
             instructions="Talk like a pirate.",
-            max_tool_calls=3,
-            parallel_tool_calls=True,
-            reasoning={"effort": "medium"},
-            text={
-                "verbosity": "low",
-            },
         )
     except MissingApiKeyError:
         pytest.skip(f"{provider.value} API key not provided, skipping")


### PR DESCRIPTION
## Description

This PR removes unsupported fields (e.g., `max_tool_calls`, `text`, etc.) from Responses API integration tests. See https://github.com/mozilla-ai/any-llm/issues/177 for discussion on what parameters to test for each provider.


## PR Type

🐛 Bug Fix

## Relevant issues

Fixes #186

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
