### PR TITLE
chore: Wake up HuggingFace endpoint before running integration tests.

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -27,6 +27,10 @@ jobs:
         run: |
           uv sync --group tests --extra all
 
+      - env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: python scripts/wake_up_hf_endpoint.py
+
       # cache the ~/.ollama/models directory
       - uses: actions/cache@v4
         with:
@@ -42,6 +46,10 @@ jobs:
           ollama serve &
           ollama pull llama3.2:1b
           ollama pull qwen3:0.6b
+
+      - env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: python scripts/wake_up_hf_endpoint.py --retry=5
 
       - name: Run Integration tests (parallel with xdist)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ extend-select = ["ALL"]
 "src/any_llm/provider.py" = ["D"]
 "src/any_llm/types/**" = ["A005", "D"]
 "demos/**" = ["T201", "S104"]
+"scripts/**" = ["D", "T201"]
 
 [tool.mypy]
 strict = true

--- a/scripts/wake_up_hf_endpoint.py
+++ b/scripts/wake_up_hf_endpoint.py
@@ -1,0 +1,33 @@
+import argparse
+import time
+
+from huggingface_hub.errors import HfHubHTTPError
+
+from any_llm import completion
+
+HF_ENDPOINT = "https://y0okp71n85ezo5nr.us-east-1.aws.endpoints.huggingface.cloud/v1/"
+
+
+def wake_up_hf_endpoint(retry: int = 0):
+    while True:
+        try:
+            completion(
+                model="huggingface:tgi", messages=[{"role": "user", "content": "Are you awake?"}], api_base=HF_ENDPOINT
+            )
+            break
+        except HfHubHTTPError as e:
+            if not retry:
+                print(f"Endpoint not ready, giving up...\n{e}")
+                return
+
+            print(f"Endpoint not ready, retrying...\n{e}")
+            time.sleep(retry)
+
+    print("Endpoint ready")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Wake up Hugging Face endpoint")
+    parser.add_argument("--retry", type=int, default=0, help="Retry interval in seconds (0 means no retry)")
+    args = parser.parse_args()
+    wake_up_hf_endpoint(retry=args.retry)


### PR DESCRIPTION
If the endpoint has been scaled down to zero because of inactivity, the tests fail with 503 service unavailable.
