### PR TITLE
fix(cohere): Introduce _patch_messages function to process tool messages

### DIFF
--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.provider import ApiConfig
+from any_llm.providers.cohere.utils import _patch_messages
 from any_llm.types.completion import CompletionParams
 
 
@@ -59,3 +60,69 @@ def test_parallel_tool_calls_raises() -> None:
                 parallel_tool_calls=False,
             )
         )
+
+
+def test_patch_messages_removes_name_from_tool_messages() -> None:
+    """Test that _patch_messages removes 'name' field from tool messages."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": "I'll check the weather for you.",
+            "tool_calls": [{"id": "call_123", "function": {"name": "get_weather"}}],
+        },
+        {"role": "tool", "name": "get_weather", "content": "It's sunny", "tool_call_id": "call_123"},
+        {"role": "assistant", "content": "The weather is sunny."},
+    ]
+
+    result = _patch_messages(messages)
+
+    # Check that the tool message no longer has 'name' field
+    tool_message = next(msg for msg in result if msg["role"] == "tool")
+    assert "name" not in tool_message
+    assert tool_message["content"] == "It's sunny"
+    assert tool_message["tool_call_id"] == "call_123"
+
+    # Check that other messages are unchanged
+    user_message = next(msg for msg in result if msg["role"] == "user")
+    assert user_message == {"role": "user", "content": "What's the weather?"}
+
+
+def test_patch_messages_converts_assistant_content_to_tool_plan() -> None:
+    """Test that _patch_messages converts assistant content to tool_plan when tool_calls present."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Calculate 2+2"},
+        {
+            "role": "assistant",
+            "content": "I'll calculate that for you.",
+            "tool_calls": [{"id": "call_456", "function": {"name": "calculator"}}],
+        },
+        {"role": "tool", "content": "4", "tool_call_id": "call_456"},
+    ]
+
+    result = _patch_messages(messages)
+
+    # Check that assistant message with tool_calls has content moved to tool_plan
+    assistant_message = next(msg for msg in result if msg["role"] == "assistant" and msg.get("tool_calls"))
+    assert "content" not in assistant_message
+    assert assistant_message["tool_plan"] == "I'll calculate that for you."
+    assert assistant_message["tool_calls"] == [{"id": "call_456", "function": {"name": "calculator"}}]
+
+
+def test_patch_messages_leaves_regular_assistant_messages_unchanged() -> None:
+    """Test that _patch_messages doesn't modify assistant messages without tool_calls."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hello! How can I help you?"},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+    result = _patch_messages(messages)
+
+    # Messages should be unchanged
+    assert result == messages
+
+    # Verify assistant message still has content
+    assistant_message = next(msg for msg in result if msg["role"] == "assistant")
+    assert assistant_message["content"] == "Hello! How can I help you?"
+    assert "tool_plan" not in assistant_message


### PR DESCRIPTION


## Description
<!-- What does this PR do? -->
- Added _patch_messages to remove 'name' field from tool messages and convert assistant content to 'tool_plan' when tool_calls are present.
- Updated CohereProvider to utilize _patch_messages for message handling in chat completions.
- Added unit tests to verify the behavior of _patch_messages in various scenarios.

## PR Type

<!-- Delete the types that don't apply --!>

🐛 Bug Fix

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
