### PR TITLE
feat: Update BaseProvider to async-first implementation

### DIFF
--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -133,7 +133,7 @@ async def acompletion(
     max_completion_tokens: int | None = None,
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None,
     **kwargs: Any,
-) -> ChatCompletion | Iterator[ChatCompletionChunk]:
+) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
     """Create a chat completion asynchronously.
 
     Args:
@@ -320,7 +320,7 @@ async def aresponses(
     reasoning: Any | None = None,
     text: Any | None = None,
     **kwargs: Any,
-) -> Response | Iterator[ResponseStreamEvent]:
+) -> Response | AsyncIterator[ResponseStreamEvent]:
     """Create a response using the OpenAI-style Responses API.
 
     This follows the OpenAI Responses API shape and returns the aliased

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -1,9 +1,10 @@
 # Inspired by https://github.com/andrewyng/aisuite/tree/main/aisuite
 import asyncio
+import logging
 import importlib
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,8 @@ from any_llm.types.completion import (
 from any_llm.types.provider import ProviderMetadata
 from any_llm.types.responses import Response, ResponseInputParam, ResponseStreamEvent
 
+
+logger = logging.getLogger(__name__)
 
 class ProviderName(str, Enum):
     """String enum for supported providers."""
@@ -159,12 +162,29 @@ class Provider(ABC):
         self,
         params: CompletionParams,
         **kwargs: Any,
-    ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
-        return await asyncio.to_thread(
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        logger.warning(
+            "%s does not have a native async method and may block your event loop. Proceed with caution",
+            self.PROVIDER_NAME
+            )
+
+        response = await asyncio.to_thread(
             self.completion,
             params,
             **kwargs,
         )
+
+        # NOTE: This is temporary until all async-first providers are implemented
+        if isinstance(response, ChatCompletion):
+            return response
+
+        async def _inner() -> AsyncIterator[ChatCompletionChunk]:
+            for chunk in response:
+                yield chunk
+
+        return _inner()
+
+        # return response
 
     def responses(
         self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
@@ -179,8 +199,25 @@ class Provider(ABC):
 
     async def aresponses(
         self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
-    ) -> Response | Iterator[ResponseStreamEvent]:
-        return await asyncio.to_thread(self.responses, model, input_data, **kwargs)
+    ) -> Response | AsyncIterator[ResponseStreamEvent]:
+        logger.warning(
+            "%s does not have a native async method and may block your event loop. Proceed with caution",
+            self.PROVIDER_NAME
+            )
+
+        response = await asyncio.to_thread(self.responses, model, input_data, **kwargs)
+
+        # NOTE: This is temporary until all async-first providers are implemented
+        if isinstance(response, Response):
+            return response
+
+        async def _inner() -> AsyncIterator[ResponseStreamEvent]:
+            for chunk in response:
+                yield chunk
+
+        return _inner()
+
+        # return response
 
     def embedding(
         self,

--- a/tests/unit/test_api_signature.py
+++ b/tests/unit/test_api_signature.py
@@ -12,10 +12,6 @@ def test_completion_and_acompletion_have_same_signature() -> None:
         "completion and acompletion should have identical parameters"
     )
 
-    assert completion_sig.return_annotation == acompletion_sig.return_annotation, (
-        "completion and acompletion should have identical return annotations"
-    )
-
 
 def test_completion_and_acompletion_have_same_docstring() -> None:
     """Test that completion and acompletion have identical docstrings."""
@@ -64,10 +60,6 @@ def test_responses_and_aresponses_have_same_signature() -> None:
 
     assert responses_sig.parameters == aresponses_sig.parameters, (
         "responses and aresponses should have identical parameters"
-    )
-
-    assert responses_sig.return_annotation == aresponses_sig.return_annotation, (
-        "responses and aresponses should have identical return annotations"
     )
 
 


### PR DESCRIPTION
## Description
This PR updates the return type of `acompletion` and `aresponse` to `AsyncIterator` when `stream=True`.

‼️ THIS IS A BREAKING CHANGE ‼️

We need this in order to implement async-native `acompletion` and `aresponse` functions (it turns out that there is no easy way to do `AsyncIterator` -> `Iterator`).

## PR Type

🆕 New Feature

## Relevant issues

Closes #201
