### PR TITLE
chore(deps): Bump "mistralai>=1.9.3".

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ all = [
 ]
 
 mistral = [
-  "mistralai",
+  "mistralai>=1.9.3",
 ]
 
 anthropic = [


### PR DESCRIPTION
We are using `ThinkChunk` which was introduced in that release.
