### PR TITLE
chore(anthropic): Increase `DEFAULT_MAX_TOKENS` from `4096` to `8192`.

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -26,7 +26,7 @@ from any_llm.types.completion import (
     Function,
 )
 
-DEFAULT_MAX_TOKENS = 4096
+DEFAULT_MAX_TOKENS = 8192
 
 
 def _is_tool_call(message: dict[str, Any]) -> bool:


### PR DESCRIPTION
The current default is way below the capacity of any of the provided models:

https://docs.anthropic.com/en/docs/about-claude/models/overview#model-comparison-table

I updated the value to match the smallest model capacity (claude-3-5-haiku).

## Description
<!-- What does this PR do? -->


## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix
💅 Refactor
📚 Documentation
🚦 Infrastructure

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
