### PR TITLE
fix(huggingface): Properly handle `timeout`.

### DIFF
--- a/src/any_llm/providers/huggingface/utils.py
+++ b/src/any_llm/providers/huggingface/utils.py
@@ -74,6 +74,9 @@ def _convert_params(params: CompletionParams, **kwargs: dict[str, Any]) -> dict[
 
     result_kwargs: dict[str, Any] = kwargs.copy()
 
+    # timeout is passed to the client instantiation, should not reach the `client.chat_completion` call.
+    result_kwargs.pop("timeout", None)
+
     if params.max_tokens is not None:
         result_kwargs["max_new_tokens"] = params.max_tokens
 

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -101,3 +101,16 @@ def test_call_to_provider_with_no_packages_installed() -> None:
                 sys.modules.pop(mod)
         with pytest.raises(ImportError, match="huggingface required packages are not installed"):
             ProviderFactory.create_provider("huggingface", ApiConfig())
+
+
+def test_huggingface_with_timeout() -> None:
+    api_key = "test-api-key"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_huggingface_provider() as mock_huggingface:
+        provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
+        provider.completion(CompletionParams(model_id="model-id", messages=messages), timeout=10)
+
+        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=10)
+
+        mock_huggingface.return_value.chat_completion.assert_called_with(model="model-id", messages=messages)


### PR DESCRIPTION
The argument was not working before because it was being also passed to `client.chat_completion` causing a `TypeError` for unexpected argument.