### PR TITLE
fix(openai): Update default `_DEFAULT_REASONING_EFFORT` to `None`

### DIFF
--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -35,7 +35,7 @@ class BaseOpenAIProvider(Provider, ABC):
 
     PACKAGES_INSTALLED = True
 
-    _DEFAULT_REASONING_EFFORT: Literal["minimal", "low", "medium", "high", "auto"] | None = "medium"
+    _DEFAULT_REASONING_EFFORT: Literal["minimal", "low", "medium", "high", "auto"] | None = None
 
     def _convert_completion_response_async(
         self, response: OpenAIChatCompletion | AsyncStream[OpenAIChatCompletionChunk]


### PR DESCRIPTION
because we don't know if the model being inferenced supports it.

## Description
Gpt-4.1 doesn't support reasoning_effort in completion api, so we can't set it by default. I'm open to changes here if you have thoughts, @daavoo .


## PR Type

🐛 Bug Fix

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
