### PR TITLE
chore(README): Use absolute URL for logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="docs/images/any-llm-logo-mark.png" width="20%" alt="Project logo"/>
+    <img src="https://raw.githubusercontent.com/mozilla-ai/any-llm/refs/heads/main/docs/images/any-llm-logo-mark.png" width="20%" alt="Project logo"/>
   </picture>
 </p>
 


### PR DESCRIPTION
## Description

Update the image logo in the README to use an absolute URL pointing to the raw GitHub content. This change ensures that the image is displayed correctly on external sites that render the README, such as PyPI.

## PR Type

📚 Documentation

