### PR TITLE
refactor(mistral, cohere): Improve message patching robustness

### DIFF
--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -126,3 +126,13 @@ def test_patch_messages_leaves_regular_assistant_messages_unchanged() -> None:
     assistant_message = next(msg for msg in result if msg["role"] == "assistant")
     assert assistant_message["content"] == "Hello! How can I help you?"
     assert "tool_plan" not in assistant_message
+
+
+def test_patch_messages_with_invalid_tool_sequence_raises_error() -> None:
+    """Test that an invalid tool message sequence raises a ValueError."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "What's the weather?"},
+        {"role": "tool", "name": "get_weather", "content": "It's sunny", "tool_call_id": "call_123"},
+    ]
+    with pytest.raises(ValueError, match="A tool message must be preceded by an assistant message with tool_calls."):
+        _patch_messages(messages)


### PR DESCRIPTION
## Description

This PR refactors the `_patch_messages` utility in the Cohere and Mistral provider modules (`src/any_llm/providers/cohere/utils.py` and `src/any_llm/providers/mistral/utils.py`).

The previous implementation did not handle certain edge cases in agentic loops, which could lead to errors when a `tool` message was not preceded by an `assistant` message. This update introduces validation to ensure the correct message sequence and improves the logic to handle more complex conversational flows.

Additionally, new unit tests have been added in `tests/unit/providers/test_cohere_provider.py` and `tests/unit/providers/test_mistral_provider.py` to cover these new edge cases and prevent future regressions.

## PR Type

-   💅 Refactor

## Relevant issues

Fixes #316

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
