### PR TITLE
fix(groq): Don't pass duplicated `response_format`.

### DIFF
--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -135,7 +135,7 @@ class GroqProvider(Provider):
 
         if params.response_format:
             if isinstance(params.response_format, type) and issubclass(params.response_format, BaseModel):
-                kwargs["response_format"] = {
+                params.response_format = {
                     "type": "json_schema",
                     "json_schema": {
                         "name": params.response_format.__name__,
@@ -143,7 +143,7 @@ class GroqProvider(Provider):
                     },
                 }
             else:
-                kwargs["response_format"] = params.response_format
+                params.response_format = params.response_format
 
         if params.stream:
             return self._stream_completion(


### PR DESCRIPTION
Missed in #331 that groq tests were being skipped.

Added an unit test for regression.