### PR TITLE
Fix(provider): Correctly parse model names with tags

### DIFF
--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -344,9 +344,7 @@ class ProviderFactory:
         The legacy format will be deprecated in version 1.0.
         """
         # Check for new colon syntax first
-        if ":" in model:
-            provider, model_name = model.split(":", 1)
-        elif "/" in model:
+        if "/" in model:
             # Legacy slash syntax with deprecation warning
             warnings.warn(
                 f"Model format 'provider/model' is deprecated and will be removed in version 1.0. "
@@ -355,6 +353,8 @@ class ProviderFactory:
                 stacklevel=3,
             )
             provider, model_name = model.split("/", 1)
+        elif ":" in model:
+            provider, model_name = model.split(":", 1)
         else:
             msg = f"Invalid model format. Expected 'provider:model' or 'provider/model', got '{model}'"
             raise ValueError(msg)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -49,6 +49,19 @@ def test_provider_enum_values_match_directory_names() -> None:
     )
 
 
+def test_provider_model_split() -> None:
+    """Test that model strings are split correctly into provider and model name."""
+    model_str = "ollama:model:tag"
+    provider, model_name = ProviderFactory.split_model_provider(model_str)
+    assert provider == ProviderName.OLLAMA
+    assert model_name == "model:tag"
+
+    model_str = "ollama/model:tag"
+    provider, model_name = ProviderFactory.split_model_provider(model_str)
+    assert provider == ProviderName.OLLAMA
+    assert model_name == "model:tag"
+
+
 def test_get_provider_enum_valid_provider() -> None:
     """Test get_provider_enum returns correct enum for valid provider."""
     provider_enum = ProviderFactory.get_provider_enum("openai")


### PR DESCRIPTION
## Description

This pull request addresses a bug in the model parsing logic that caused incorrect parsing of model names that include a tag, such as `ollama/gemma3:4b`.

Problem:

The previous implementation split the model string at the first colon (:), which resulted in the provider being incorrectly identified as `ollama/gemma3` and the model name as `4b`.

Solution:

This patch modifies the parsing order to first check for the legacy `provider/model` separator (``/) before checking for the `provider:model` separator (`:`). This ensures that model names in the format `<provider><model_name>:<model_tag>` are parsed correctly.

This change is backward compatible and does not affect the parsing of model names that do not include a tag.

## PR Type

🐛 Bug Fix

## Relevant issues

Fixes #347

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
