### PR TITLE
refactor(api): Expose and handle `client_args`.

### DIFF
--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -39,6 +39,7 @@ def completion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: Literal["minimal", "low", "medium", "high", "auto"] | None = "auto",
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
     """Create a chat completion.
@@ -73,7 +74,8 @@ def completion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         The completion response from the provider
@@ -106,6 +108,7 @@ def completion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        client_args=client_args,
         **kwargs,
     )
 
@@ -140,6 +143,7 @@ async def acompletion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: Literal["minimal", "low", "medium", "high", "auto"] | None = "auto",
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
     """Create a chat completion asynchronously.
@@ -174,7 +178,8 @@ async def acompletion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         The completion response from the provider
@@ -207,6 +212,7 @@ async def acompletion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        client_args=client_args,
         **kwargs,
     )
 
@@ -233,6 +239,7 @@ def responses(
     parallel_tool_calls: int | None = None,
     reasoning: Any | None = None,
     text: Any | None = None,
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> Response | Iterator[ResponseStreamEvent]:
     """Create a response using the OpenAI-style Responses API.
@@ -262,8 +269,8 @@ def responses(
         parallel_tool_calls: Whether to allow the model to run tool calls in parallel.
         reasoning: Configuration options for reasoning models.
         text: Configuration options for a text response from the model. Can be plain text or structured JSON data.
-
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         Either a `Response` object (non-streaming) or an iterator of
@@ -316,7 +323,7 @@ def responses(
     if text is not None:
         responses_kwargs["text"] = text
 
-    return provider_instance.responses(model_name, input_data, **responses_kwargs)
+    return provider_instance.responses(model_name, input_data, client_args=client_args, **responses_kwargs)
 
 
 async def aresponses(
@@ -339,6 +346,7 @@ async def aresponses(
     parallel_tool_calls: int | None = None,
     reasoning: Any | None = None,
     text: Any | None = None,
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> Response | AsyncIterator[ResponseStreamEvent]:
     """Create a response using the OpenAI-style Responses API.
@@ -368,8 +376,8 @@ async def aresponses(
         parallel_tool_calls: Whether to allow the model to run tool calls in parallel.
         reasoning: Configuration options for reasoning models.
         text: Configuration options for a text response from the model. Can be plain text or structured JSON data.
-
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         Either a `Response` object (non-streaming) or an iterator of
@@ -432,6 +440,7 @@ def embedding(
     provider: str | ProviderName | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> CreateEmbeddingResponse:
     """Create an embedding.
@@ -445,7 +454,8 @@ def embedding(
         inputs: The input text to embed
         api_key: API key for the provider
         api_base: Base URL for the provider API
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         The embedding of the input text
@@ -466,7 +476,7 @@ def embedding(
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
-    return provider_instance.embedding(model_name, inputs, **kwargs)
+    return provider_instance.embedding(model_name, inputs, client_args=client_args, **kwargs)
 
 
 async def aembedding(
@@ -476,6 +486,7 @@ async def aembedding(
     provider: str | ProviderName | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> CreateEmbeddingResponse:
     """Create an embedding asynchronously.
@@ -486,7 +497,8 @@ async def aembedding(
         inputs: The input text to embed
         api_key: API key for the provider
         api_base: Base URL for the provider API
-        **kwargs: Additional provider-specific parameters
+        client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
+        **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
     Returns:
         The embedding of the input text
@@ -507,11 +519,15 @@ async def aembedding(
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
-    return await provider_instance.aembedding(model_name, inputs, **kwargs)
+    return await provider_instance.aembedding(model_name, inputs, client_args=client_args, **kwargs)
 
 
 def list_models(
-    provider: str | ProviderName, api_key: str | None = None, api_base: str | None = None, **kwargs: Any
+    provider: str | ProviderName,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    client_args: dict[str, Any] | None = None,
+    **kwargs: Any,
 ) -> Sequence[Model]:
     """List available models for a provider."""
     provider_key = ProviderName.from_string(provider)
@@ -522,11 +538,15 @@ def list_models(
         config["api_base"] = str(api_base)
     api_config = ApiConfig(**config)
     prov_instance = ProviderFactory.create_provider(provider_key, api_config)
-    return prov_instance.list_models(**kwargs)
+    return prov_instance.list_models(client_args=client_args, **kwargs)
 
 
 async def list_models_async(
-    provider: str | ProviderName, api_key: str | None = None, api_base: str | None = None, **kwargs: Any
+    provider: str | ProviderName,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    client_args: dict[str, Any] | None = None,
+    **kwargs: Any,
 ) -> Sequence[Model]:
     """List available models for a provider asynchronously."""
     provider_key = ProviderName.from_string(provider)
@@ -537,4 +557,4 @@ async def list_models_async(
         config["api_base"] = str(api_base)
     api_config = ApiConfig(**config)
     prov_instance = ProviderFactory.create_provider(provider_key, api_config)
-    return await prov_instance.list_models_async(**kwargs)
+    return await prov_instance.list_models_async(client_args=client_args, **kwargs)

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from any_llm.provider import ApiConfig, ProviderFactory, ProviderName
+from any_llm.provider import ClientConfig, ProviderFactory, ProviderName
 from any_llm.tools import prepare_tools
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage, CreateEmbeddingResponse
 from any_llm.types.model import Model
@@ -286,12 +286,7 @@ def responses(
         provider_key = ProviderName.from_string(provider)
         model_name = model
 
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
@@ -323,7 +318,7 @@ def responses(
     if text is not None:
         responses_kwargs["text"] = text
 
-    return provider_instance.responses(model_name, input_data, client_args=client_args, **responses_kwargs)
+    return provider_instance.responses(model_name, input_data, **responses_kwargs)
 
 
 async def aresponses(
@@ -393,12 +388,7 @@ async def aresponses(
         provider_key = ProviderName.from_string(provider)
         model_name = model
 
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
@@ -467,16 +457,11 @@ def embedding(
         provider_key = ProviderName.from_string(provider)
         model_name = model
 
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
-    return provider_instance.embedding(model_name, inputs, client_args=client_args, **kwargs)
+    return provider_instance.embedding(model_name, inputs, **kwargs)
 
 
 async def aembedding(
@@ -510,16 +495,11 @@ async def aembedding(
         provider_key = ProviderName.from_string(provider)
         model_name = model
 
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
-    return await provider_instance.aembedding(model_name, inputs, client_args=client_args, **kwargs)
+    return await provider_instance.aembedding(model_name, inputs, **kwargs)
 
 
 def list_models(
@@ -531,14 +511,9 @@ def list_models(
 ) -> Sequence[Model]:
     """List available models for a provider."""
     provider_key = ProviderName.from_string(provider)
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
     prov_instance = ProviderFactory.create_provider(provider_key, api_config)
-    return prov_instance.list_models(client_args=client_args, **kwargs)
+    return prov_instance.list_models(**kwargs)
 
 
 async def list_models_async(
@@ -550,11 +525,6 @@ async def list_models_async(
 ) -> Sequence[Model]:
     """List available models for a provider asynchronously."""
     provider_key = ProviderName.from_string(provider)
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
     prov_instance = ProviderFactory.create_provider(provider_key, api_config)
-    return await prov_instance.list_models_async(client_args=client_args, **kwargs)
+    return await prov_instance.list_models_async(**kwargs)

--- a/src/any_llm/provider.py
+++ b/src/any_llm/provider.py
@@ -198,20 +198,22 @@ class Provider(ABC):
         raise NotImplementedError(msg)
 
     def responses(
-        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+        self, model: str, input_data: str | ResponseInputParam, client_args: dict[str, Any] | None = None, **kwargs: Any
     ) -> Response | Iterator[ResponseStreamEvent]:
         """Create a response using the provider's Responses API if supported.
 
         Default implementation raises NotImplementedError. Providers that set
         SUPPORTS_RESPONSES to True must override this method.
         """
-        response = run_async_in_sync(self.aresponses(model, input_data, **kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        response = run_async_in_sync(
+            self.aresponses(model, input_data, client_args=client_args, **kwargs), allow_running_loop=INSIDE_NOTEBOOK
+        )
         if isinstance(response, Response):
             return response
         return async_iter_to_sync_iter(response)
 
     async def aresponses(
-        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+        self, model: str, input_data: str | ResponseInputParam, client_args: dict[str, Any] | None = None, **kwargs: Any
     ) -> Response | AsyncIterator[ResponseStreamEvent]:
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
@@ -220,20 +222,24 @@ class Provider(ABC):
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
-        return run_async_in_sync(self.aembedding(model, inputs, **kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        return run_async_in_sync(
+            self.aembedding(model, inputs, client_args=client_args, **kwargs), allow_running_loop=INSIDE_NOTEBOOK
+        )
 
     async def aembedding(
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Return a list of Model if the provider supports listing models.
         Should be overridden by subclasses.
@@ -243,8 +249,8 @@ class Provider(ABC):
             raise NotImplementedError(msg)
         raise NotImplementedError(msg)
 
-    async def list_models_async(self, **kwargs: Any) -> Sequence[Model]:
-        return await asyncio.to_thread(self.list_models, **kwargs)
+    async def list_models_async(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+        return await asyncio.to_thread(self.list_models, client_args=client_args, **kwargs)
 
 
 class ProviderFactory:

--- a/src/any_llm/providers/anthropic/anthropic.py
+++ b/src/any_llm/providers/anthropic/anthropic.py
@@ -55,7 +55,11 @@ class AnthropicProvider(Provider):
         **kwargs: Any,
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Create a chat completion using Anthropic with instructor support."""
-        client = AsyncAnthropic(api_key=self.config.api_key, base_url=self.config.api_base)
+        client = AsyncAnthropic(
+            api_key=self.config.api_key,
+            base_url=self.config.api_base,
+            **(params.client_args if params.client_args else {}),
+        )
 
         kwargs["provider_name"] = self.PROVIDER_NAME
         converted_kwargs = _convert_params(params, **kwargs)
@@ -67,8 +71,10 @@ class AnthropicProvider(Provider):
 
         return _convert_response(message)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """List available models from Anthropic."""
-        client = Anthropic(api_key=self.config.api_key, base_url=self.config.api_base)
+        client = Anthropic(
+            api_key=self.config.api_key, base_url=self.config.api_base, **(client_args if client_args else {})
+        )
         models_list = client.models.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/anthropic/anthropic.py
+++ b/src/any_llm/providers/anthropic/anthropic.py
@@ -58,7 +58,7 @@ class AnthropicProvider(Provider):
         client = AsyncAnthropic(
             api_key=self.config.api_key,
             base_url=self.config.api_base,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         kwargs["provider_name"] = self.PROVIDER_NAME
@@ -71,10 +71,12 @@ class AnthropicProvider(Provider):
 
         return _convert_response(message)
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """List available models from Anthropic."""
         client = Anthropic(
-            api_key=self.config.api_key, base_url=self.config.api_base, **(client_args if client_args else {})
+            api_key=self.config.api_key,
+            base_url=self.config.api_base,
+            **(self.config.client_args if self.config.client_args else {}),
         )
         models_list = client.models.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -298,7 +298,6 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         params.model_dump(
             exclude_none=True,
             exclude={
-                "client_args",
                 "model_id",
                 "messages",
                 "reasoning_effort",

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -297,7 +297,14 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
     result_kwargs.update(
         params.model_dump(
             exclude_none=True,
-            exclude={"model_id", "messages", "reasoning_effort", "response_format", "parallel_tool_calls"},
+            exclude={
+                "client_args",
+                "model_id",
+                "messages",
+                "reasoning_effort",
+                "response_format",
+                "parallel_tool_calls",
+            },
         )
     )
     result_kwargs["model"] = params.model_id

--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -16,18 +16,11 @@ class AzureopenaiProvider(BaseOpenAIProvider):
     SUPPORTS_RESPONSES = True
     SUPPORTS_LIST_MODELS = True
 
-    @property
-    def openai_client(self) -> OpenAI:
-        return OpenAI(
+    def _get_client(self, sync: bool = False) -> AsyncOpenAI | OpenAI:
+        _client_class = OpenAI if sync else AsyncOpenAI
+        return _client_class(
             base_url=self.config.api_base or self.API_BASE or os.getenv("AZURE_OPENAI_API_BASE"),
             api_key=self.config.api_key,
-            default_query={"api-version": "preview"},
-        )
-
-    @property
-    def async_openai_client(self) -> AsyncOpenAI:
-        return AsyncOpenAI(
-            base_url=self.config.api_base or self.API_BASE or os.getenv("AZURE_OPENAI_API_BASE"),
-            api_key=self.config.api_key,
+            **(self.config.client_args if self.config.client_args else {}),
             default_query={"api-version": "preview"},
         )

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -39,9 +39,11 @@ class CohereProvider(Provider):
     MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
 
     async def _stream_completion_async(
-        self, model: str, messages: list[dict[str, Any]], client_args: dict[str, Any] | None = None, **kwargs: Any
+        self, model: str, messages: list[dict[str, Any]], **kwargs: Any
     ) -> AsyncIterator[ChatCompletionChunk]:
-        client = cohere.AsyncClientV2(api_key=self.config.api_key, **(client_args if client_args else {}))
+        client = cohere.AsyncClientV2(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
 
         cohere_stream = client.chat_stream(
             model=model,
@@ -89,30 +91,30 @@ class CohereProvider(Provider):
             return self._stream_completion_async(
                 params.model_id,
                 patched_messages,
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
                 **kwargs,
             )
 
-        client = cohere.AsyncClientV2(api_key=self.config.api_key, **(params.client_args if params.client_args else {}))
+        client = cohere.AsyncClientV2(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
 
         # note: ClientV2.chat does not have a `stream` parameter
         response = await client.chat(
             model=params.model_id,
             messages=patched_messages,  # type: ignore[arg-type]
-            **params.model_dump(
-                exclude_none=True, exclude={"client_args", "model_id", "messages", "stream", "response_format"}
-            ),
+            **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "stream", "response_format"}),
             **kwargs,
         )
 
         return _convert_response(response, params.model_id)
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = cohere.ClientV2(api_key=self.config.api_key, **(client_args if client_args else {}))
+        client = cohere.ClientV2(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
         model_list = client.models.list(**kwargs)
         return _convert_models_list(model_list)

--- a/src/any_llm/providers/fireworks/fireworks.py
+++ b/src/any_llm/providers/fireworks/fireworks.py
@@ -22,10 +22,10 @@ class FireworksProvider(BaseOpenAIProvider):
     SUPPORTS_LIST_MODELS = True
 
     async def aresponses(
-        self, model: str, input_data: Any, **kwargs: Any
+        self, model: str, input_data: Any, client_args: dict[str, Any] | None = None, **kwargs: Any
     ) -> Response | AsyncIterator[ResponseStreamEvent]:
         """Call Fireworks Responses API and normalize into ChatCompletion/Chunks."""
-        response = await super().aresponses(model, input_data, **kwargs)
+        response = await super().aresponses(model, input_data, client_args=client_args, **kwargs)
 
         if isinstance(response, Response) and not isinstance(response, AsyncStream):
             # See https://fireworks.ai/blog/response-api for details about Fireworks Responses API support

--- a/src/any_llm/providers/fireworks/fireworks.py
+++ b/src/any_llm/providers/fireworks/fireworks.py
@@ -22,10 +22,10 @@ class FireworksProvider(BaseOpenAIProvider):
     SUPPORTS_LIST_MODELS = True
 
     async def aresponses(
-        self, model: str, input_data: Any, client_args: dict[str, Any] | None = None, **kwargs: Any
+        self, model: str, input_data: Any, **kwargs: Any
     ) -> Response | AsyncIterator[ResponseStreamEvent]:
         """Call Fireworks Responses API and normalize into ChatCompletion/Chunks."""
-        response = await super().aresponses(model, input_data, client_args=client_args, **kwargs)
+        response = await super().aresponses(model, input_data, **kwargs)
 
         if isinstance(response, Response) and not isinstance(response, AsyncStream):
             # See https://fireworks.ai/blog/response-api for details about Fireworks Responses API support

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -59,7 +59,7 @@ class GroqProvider(Provider):
         stream: GroqAsyncStream[GroqChatCompletionChunk] = await client.chat.completions.create(
             model=params.model_id,
             messages=cast("Any", params.messages),
-            **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages"}),
+            **params.model_dump(exclude_none=True, exclude={"model_id", "messages"}),
             **kwargs,
         )
 
@@ -73,7 +73,9 @@ class GroqProvider(Provider):
         self, params: CompletionParams, **kwargs: Any
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Create a chat completion using Groq."""
-        client = groq.AsyncGroq(api_key=self.config.api_key, **(params.client_args if params.client_args else {}))
+        client = groq.AsyncGroq(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
 
         if params.reasoning_effort == "auto":
             params.reasoning_effort = None
@@ -99,16 +101,14 @@ class GroqProvider(Provider):
         response: GroqChatCompletion = await client.chat.completions.create(
             model=params.model_id,
             messages=cast("Any", params.messages),
-            **params.model_dump(
-                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-            ),
+            **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
             **kwargs,
         )
 
         return to_chat_completion(response)
 
     async def aresponses(
-        self, model: str, input_data: Any, client_args: dict[str, Any] | None = None, **kwargs: Any
+        self, model: str, input_data: Any, **kwargs: Any
     ) -> Response | AsyncIterator[ResponseStreamEvent]:
         """Call Groq Responses API and normalize into ChatCompletion/Chunks."""
         # Python SDK doesn't yet support it: https://community.groq.com/feature-requests-6/groq-python-sdk-support-for-responses-api-262
@@ -120,7 +120,7 @@ class GroqProvider(Provider):
         client = AsyncOpenAI(
             base_url="https://api.groq.com/openai/v1",
             api_key=self.config.api_key,
-            **(client_args if client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         response = await client.responses.create(
@@ -135,10 +135,10 @@ class GroqProvider(Provider):
 
         return response
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = groq.Groq(api_key=self.config.api_key, **(client_args if client_args else {}))
+        client = groq.Groq(api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {}))
         models_list = client.models.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -78,7 +78,7 @@ class HuggingfaceProvider(Provider):
         client = AsyncInferenceClient(
             base_url=self.config.api_base,
             token=self.config.api_key,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         converted_kwargs = _convert_params(params, **kwargs)
@@ -127,7 +127,7 @@ class HuggingfaceProvider(Provider):
         client = InferenceClient(
             base_url=self.config.api_base,
             token=self.config.api_key,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         converted_kwargs = _convert_params(params, **kwargs)
@@ -167,14 +167,14 @@ class HuggingfaceProvider(Provider):
             usage=usage,
         )
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
         if not self.SUPPORTS_LIST_MODELS:
             message = f"{self.PROVIDER_NAME} does not support listing models."
             raise NotImplementedError(message)
-        client = HfApi(token=self.config.api_key, **(client_args if client_args else {}))
+        client = HfApi(token=self.config.api_key, **(self.config.client_args if self.config.client_args else {}))
         if kwargs.get("inference") is None and kwargs.get("inference_provider") is None:
             kwargs["inference"] = "warm"
         if kwargs.get("limit") is None:

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -76,7 +76,9 @@ class HuggingfaceProvider(Provider):
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Create a chat completion using HuggingFace."""
         client = AsyncInferenceClient(
-            base_url=self.config.api_base, token=self.config.api_key, timeout=kwargs.get("timeout")
+            base_url=self.config.api_base,
+            token=self.config.api_key,
+            **(params.client_args if params.client_args else {}),
         )
 
         converted_kwargs = _convert_params(params, **kwargs)
@@ -123,7 +125,9 @@ class HuggingfaceProvider(Provider):
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """Create a chat completion using HuggingFace."""
         client = InferenceClient(
-            base_url=self.config.api_base, token=self.config.api_key, timeout=kwargs.get("timeout")
+            base_url=self.config.api_base,
+            token=self.config.api_key,
+            **(params.client_args if params.client_args else {}),
         )
 
         converted_kwargs = _convert_params(params, **kwargs)
@@ -163,14 +167,14 @@ class HuggingfaceProvider(Provider):
             usage=usage,
         )
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
         if not self.SUPPORTS_LIST_MODELS:
             message = f"{self.PROVIDER_NAME} does not support listing models."
             raise NotImplementedError(message)
-        client = HfApi(token=self.config.api_key)
+        client = HfApi(token=self.config.api_key, **(client_args if client_args else {}))
         if kwargs.get("inference") is None and kwargs.get("inference_provider") is None:
             kwargs["inference"] = "warm"
         if kwargs.get("limit") is None:

--- a/src/any_llm/providers/huggingface/utils.py
+++ b/src/any_llm/providers/huggingface/utils.py
@@ -92,7 +92,7 @@ def _convert_params(params: CompletionParams, **kwargs: dict[str, Any]) -> dict[
     result_kwargs.update(
         params.model_dump(
             exclude_none=True,
-            exclude={"max_tokens", "model_id", "messages", "response_format", "parallel_tool_calls"},
+            exclude={"client_args", "max_tokens", "model_id", "messages", "response_format", "parallel_tool_calls"},
         )
     )
 

--- a/src/any_llm/providers/llamafile/llamafile.py
+++ b/src/any_llm/providers/llamafile/llamafile.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
 
@@ -18,7 +18,7 @@ class LlamafileProvider(BaseOpenAIProvider):
     SUPPORTS_COMPLETION_REASONING = False
     SUPPORTS_COMPLETION_STREAMING = False
 
-    def __init__(self, config: ApiConfig) -> None:
+    def __init__(self, config: ClientConfig) -> None:
         """We don't use the Provider init because by default we don't require an API key."""
 
         self.url = config.api_base or os.getenv("LLAMAFILE_API_URL")

--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -1,6 +1,6 @@
 from typing_extensions import override
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
 # LM Studio has a python sdk, but per their docs they are compliant with OpenAI spec
@@ -18,7 +18,7 @@ class LmstudioProvider(BaseOpenAIProvider):
     SUPPORTS_LIST_MODELS = True
 
     @override
-    def _verify_and_set_api_key(self, config: ApiConfig) -> ApiConfig:
+    def _verify_and_set_api_key(self, config: ClientConfig) -> ClientConfig:
         # LM Studio doesn't require an API Key,
         # so we can skip the verification step and return directly
         return config

--- a/src/any_llm/providers/mistral/mistral.py
+++ b/src/any_llm/providers/mistral/mistral.py
@@ -70,21 +70,29 @@ class MistralProvider(Provider):
         ):
             kwargs["response_format"] = response_format_from_pydantic_model(params.response_format)
 
-        client = Mistral(api_key=self.config.api_key, server_url=self.config.api_base)
+        client = Mistral(
+            api_key=self.config.api_key,
+            server_url=self.config.api_base,
+            **(params.client_args if params.client_args else {}),
+        )
 
         if params.stream:
             return self._stream_completion_async(
                 client,
                 params.model_id,
                 patched_messages,
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+                ),
                 **kwargs,
             )
 
         response = await client.chat.complete_async(
             model=params.model_id,
             messages=patched_messages,  # type: ignore[arg-type]
-            **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+            **params.model_dump(
+                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+            ),
             **kwargs,
         )
 
@@ -97,9 +105,12 @@ class MistralProvider(Provider):
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
-        client = Mistral(api_key=self.config.api_key, server_url=self.config.api_base)
+        client = Mistral(
+            api_key=self.config.api_key, server_url=self.config.api_base, **(client_args if client_args else {})
+        )
         result: EmbeddingResponse = await client.embeddings.create_async(
             model=model,
             inputs=inputs,
@@ -108,10 +119,12 @@ class MistralProvider(Provider):
 
         return _create_openai_embedding_response_from_mistral(result)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = Mistral(api_key=self.config.api_key, server_url=self.config.api_base)
+        client = Mistral(
+            api_key=self.config.api_key, server_url=self.config.api_base, **(client_args if client_args else {})
+        )
         models_list = client.models.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -57,6 +57,7 @@ class OllamaProvider(Provider):
         self._verify_no_missing_packages()
 
         self.url = config.api_base or os.getenv("OLLAMA_API_URL")
+        self.config = config
 
     async def _stream_completion_async(
         self,

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -127,7 +127,7 @@ class OllamaProvider(Provider):
         if params.reasoning_effort is not None:
             kwargs["think"] = True
 
-        client = AsyncClient(host=self.url, **(params.client_args if params.client_args else {}))
+        client = AsyncClient(host=self.url, **(self.config.client_args if self.config.client_args else {}))
 
         if params.stream:
             return self._stream_completion_async(client, params.model_id, cleaned_messages, **kwargs)
@@ -146,11 +146,10 @@ class OllamaProvider(Provider):
         self,
         model: str,
         inputs: str | list[str],
-        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         """Generate embeddings using Ollama."""
-        client = AsyncClient(host=self.url, **(client_args if client_args else {}))
+        client = AsyncClient(host=self.url, **(self.config.client_args if self.config.client_args else {}))
 
         response = await client.embed(
             model=model,
@@ -159,10 +158,10 @@ class OllamaProvider(Provider):
         )
         return _create_openai_embedding_response_from_ollama(response)
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = Client(host=self.url, **(client_args if client_args else {}))
+        client = Client(host=self.url, **(self.config.client_args if self.config.client_args else {}))
         models_list = client.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -127,7 +127,7 @@ class OllamaProvider(Provider):
         if params.reasoning_effort is not None:
             kwargs["think"] = True
 
-        client = AsyncClient(host=self.url, timeout=kwargs.pop("timeout", None))
+        client = AsyncClient(host=self.url, **(params.client_args if params.client_args else {}))
 
         if params.stream:
             return self._stream_completion_async(client, params.model_id, cleaned_messages, **kwargs)
@@ -146,10 +146,11 @@ class OllamaProvider(Provider):
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         """Generate embeddings using Ollama."""
-        client = AsyncClient(host=self.url, timeout=kwargs.pop("timeout", None))
+        client = AsyncClient(host=self.url, **(client_args if client_args else {}))
 
         response = await client.embed(
             model=model,
@@ -158,10 +159,10 @@ class OllamaProvider(Provider):
         )
         return _create_openai_embedding_response_from_ollama(response)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = Client(host=self.url, timeout=kwargs.pop("timeout", None))
+        client = Client(host=self.url, **(client_args if client_args else {}))
         models_list = client.list(**kwargs)
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from any_llm.provider import ApiConfig, Provider
+from any_llm.provider import ClientConfig, Provider
 
 MISSING_PACKAGES_ERROR = None
 try:
@@ -52,7 +52,7 @@ class OllamaProvider(Provider):
 
     MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
 
-    def __init__(self, config: ApiConfig) -> None:
+    def __init__(self, config: ClientConfig) -> None:
         """We don't use the Provider init because by default we don't require an API key."""
         self._verify_no_missing_packages()
 

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -37,18 +37,12 @@ class BaseOpenAIProvider(Provider, ABC):
 
     _DEFAULT_REASONING_EFFORT: Literal["minimal", "low", "medium", "high", "auto"] | None = None
 
-    @property
-    def openai_client(self) -> OpenAI:
-        return OpenAI(
+    def _get_client(self, client_args: dict[str, Any] | None = None, sync: bool = False) -> AsyncOpenAI | OpenAI:
+        _client_class = OpenAI if sync else AsyncOpenAI
+        return _client_class(
             base_url=self.config.api_base or self.API_BASE or os.getenv("OPENAI_API_BASE"),
             api_key=self.config.api_key,
-        )
-
-    @property
-    def async_openai_client(self) -> AsyncOpenAI:
-        return AsyncOpenAI(
-            base_url=self.config.api_base or self.API_BASE or os.getenv("OPENAI_API_BASE"),
-            api_key=self.config.api_key,
+            **(client_args if client_args else {}),
         )
 
     def _convert_completion_response_async(
@@ -75,7 +69,7 @@ class BaseOpenAIProvider(Provider, ABC):
     async def acompletion(
         self, params: CompletionParams, **kwargs: Any
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
-        client = self.async_openai_client
+        client = cast("AsyncOpenAI", self._get_client(params.client_args, sync=False))
 
         if params.reasoning_effort == "auto":
             params.reasoning_effort = self._DEFAULT_REASONING_EFFORT
@@ -88,23 +82,23 @@ class BaseOpenAIProvider(Provider, ABC):
             response = await client.chat.completions.parse(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "stream"}),
+                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages", "stream"}),
                 **kwargs,
             )
         else:
             response = await client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages"}),
+                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages"}),
                 **kwargs,
             )
         return self._convert_completion_response_async(response)
 
     async def aresponses(
-        self, model: str, input_data: Any, **kwargs: Any
+        self, model: str, input_data: Any, client_args: dict[str, Any] | None = None, **kwargs: Any
     ) -> Response | AsyncIterator[ResponseStreamEvent]:
         """Call OpenAI Responses API"""
-        client = self.async_openai_client
+        client = self._get_client(client_args=client_args)
 
         response = await client.responses.create(
             model=model,
@@ -120,6 +114,7 @@ class BaseOpenAIProvider(Provider, ABC):
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         # Classes that inherit from BaseOpenAIProvider may override SUPPORTS_EMBEDDING
@@ -127,7 +122,7 @@ class BaseOpenAIProvider(Provider, ABC):
             msg = "This provider does not support embeddings."
             raise NotImplementedError(msg)
 
-        client = self.async_openai_client
+        client = cast("AsyncOpenAI", self._get_client(client_args=client_args))
 
         return await client.embeddings.create(
             model=model,
@@ -136,13 +131,12 @@ class BaseOpenAIProvider(Provider, ABC):
             **kwargs,
         )
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
         if not self.SUPPORTS_LIST_MODELS:
             message = f"{self.PROVIDER_NAME} does not support listing models."
             raise NotImplementedError(message)
-        client = self.openai_client
-
+        client = cast("OpenAI", self._get_client(client_args=client_args, sync=True))
         return client.models.list(**kwargs).data

--- a/src/any_llm/providers/perplexity/perplexity.py
+++ b/src/any_llm/providers/perplexity/perplexity.py
@@ -1,6 +1,6 @@
 import os
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
 
@@ -20,7 +20,7 @@ class PerplexityProvider(BaseOpenAIProvider):
     SUPPORTS_COMPLETION_REASONING = False
     SUPPORTS_EMBEDDING = False
 
-    def __init__(self, config: ApiConfig) -> None:
+    def __init__(self, config: ClientConfig) -> None:
         super().__init__(config)
         # Override API_BASE if provided in config or environment
         base = config.api_base or os.getenv("PERPLEXITY_API_BASE")

--- a/src/any_llm/providers/sambanova/sambanova.py
+++ b/src/any_llm/providers/sambanova/sambanova.py
@@ -32,6 +32,7 @@ class SambanovaProvider(BaseOpenAIProvider):
         client = AsyncOpenAI(
             base_url=self.config.api_base or self.API_BASE or os.getenv("OPENAI_API_BASE"),
             api_key=self.config.api_key,
+            **(params.client_args if params.client_args else {}),
         )
 
         if params.reasoning_effort == "auto":
@@ -46,7 +47,9 @@ class SambanovaProvider(BaseOpenAIProvider):
                 model=params.model_id,
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
+                ),
                 **kwargs,
             )
             return _convert_instructor_response(response, params.model_id, self.PROVIDER_NAME)
@@ -54,7 +57,7 @@ class SambanovaProvider(BaseOpenAIProvider):
             await client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages"}),
+                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages"}),
                 **kwargs,
             )
         )

--- a/src/any_llm/providers/sambanova/sambanova.py
+++ b/src/any_llm/providers/sambanova/sambanova.py
@@ -32,7 +32,7 @@ class SambanovaProvider(BaseOpenAIProvider):
         client = AsyncOpenAI(
             base_url=self.config.api_base or self.API_BASE or os.getenv("OPENAI_API_BASE"),
             api_key=self.config.api_key,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         if params.reasoning_effort == "auto":
@@ -48,7 +48,7 @@ class SambanovaProvider(BaseOpenAIProvider):
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
                 **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
+                    exclude_none=True, exclude={"model_id", "messages", "response_format"}
                 ),
                 **kwargs,
             )
@@ -57,7 +57,7 @@ class SambanovaProvider(BaseOpenAIProvider):
             await client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages"}),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages"}),
                 **kwargs,
             )
         )

--- a/src/any_llm/providers/sambanova/sambanova.py
+++ b/src/any_llm/providers/sambanova/sambanova.py
@@ -47,9 +47,7 @@ class SambanovaProvider(BaseOpenAIProvider):
                 model=params.model_id,
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
-                **params.model_dump(
-                    exclude_none=True, exclude={"model_id", "messages", "response_format"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
                 **kwargs,
             )
             return _convert_instructor_response(response, params.model_id, self.PROVIDER_NAME)

--- a/src/any_llm/providers/together/together.py
+++ b/src/any_llm/providers/together/together.py
@@ -90,10 +90,11 @@ class TogetherProvider(Provider):
         **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
         """Make the API call to Together AI with instructor support for structured outputs."""
-        if self.config.api_base:
-            client = together.Together(api_key=self.config.api_key, base_url=self.config.api_base)
-        else:
-            client = together.Together(api_key=self.config.api_key)
+        client = together.Together(
+            api_key=self.config.api_key,
+            base_url=self.config.api_base,
+            **(params.client_args if params.client_args else {}),
+        )
 
         if params.reasoning_effort == "auto":
             params.reasoning_effort = None
@@ -105,7 +106,9 @@ class TogetherProvider(Provider):
                 model=params.model_id,
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
+                ),
                 **kwargs,
             )
 
@@ -116,7 +119,7 @@ class TogetherProvider(Provider):
                 client,
                 params.model_id,
                 params.messages,
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "stream"}),
+                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages", "stream"}),
                 **kwargs,
             )
 
@@ -125,7 +128,9 @@ class TogetherProvider(Provider):
             client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
+                ),
                 **kwargs,
             ),
         )
@@ -138,10 +143,11 @@ class TogetherProvider(Provider):
         **kwargs: Any,
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Make the API call to Together AI with instructor support for structured outputs."""
-        if self.config.api_base:
-            client = together.AsyncTogether(api_key=self.config.api_key, base_url=self.config.api_base)
-        else:
-            client = together.AsyncTogether(api_key=self.config.api_key)
+        client = together.AsyncTogether(
+            api_key=self.config.api_key,
+            base_url=self.config.api_base,
+            **(params.client_args if params.client_args else {}),
+        )
 
         if params.reasoning_effort == "auto":
             params.reasoning_effort = None
@@ -154,7 +160,8 @@ class TogetherProvider(Provider):
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
                 **params.model_dump(
-                    exclude_none=True, exclude={"model_id", "messages", "reasoning_effort", "response_format"}
+                    exclude_none=True,
+                    exclude={"client_args", "model_id", "messages", "reasoning_effort", "response_format"},
                 ),
                 **kwargs,
             )
@@ -166,7 +173,9 @@ class TogetherProvider(Provider):
                 client,
                 params.model_id,
                 params.messages,
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "reasoning_effort", "stream"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "reasoning_effort", "stream"}
+                ),
                 **kwargs,
             )
 
@@ -175,7 +184,9 @@ class TogetherProvider(Provider):
             await client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
+                ),
                 **kwargs,
             ),
         )

--- a/src/any_llm/providers/together/together.py
+++ b/src/any_llm/providers/together/together.py
@@ -93,7 +93,7 @@ class TogetherProvider(Provider):
         client = together.Together(
             api_key=self.config.api_key,
             base_url=self.config.api_base,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         if params.reasoning_effort == "auto":
@@ -106,9 +106,7 @@ class TogetherProvider(Provider):
                 model=params.model_id,
                 messages=cast("Any", params.messages),
                 response_model=params.response_format,
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
                 **kwargs,
             )
 
@@ -119,7 +117,7 @@ class TogetherProvider(Provider):
                 client,
                 params.model_id,
                 params.messages,
-                **params.model_dump(exclude_none=True, exclude={"client_args", "model_id", "messages", "stream"}),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "stream"}),
                 **kwargs,
             )
 
@@ -128,9 +126,7 @@ class TogetherProvider(Provider):
             client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
                 **kwargs,
             ),
         )
@@ -146,7 +142,7 @@ class TogetherProvider(Provider):
         client = together.AsyncTogether(
             api_key=self.config.api_key,
             base_url=self.config.api_base,
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         if params.reasoning_effort == "auto":
@@ -161,7 +157,7 @@ class TogetherProvider(Provider):
                 response_model=params.response_format,
                 **params.model_dump(
                     exclude_none=True,
-                    exclude={"client_args", "model_id", "messages", "reasoning_effort", "response_format"},
+                    exclude={"model_id", "messages", "reasoning_effort", "response_format"},
                 ),
                 **kwargs,
             )
@@ -173,9 +169,7 @@ class TogetherProvider(Provider):
                 client,
                 params.model_id,
                 params.messages,
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "reasoning_effort", "stream"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "reasoning_effort", "stream"}),
                 **kwargs,
             )
 
@@ -184,9 +178,7 @@ class TogetherProvider(Provider):
             await client.chat.completions.create(
                 model=params.model_id,
                 messages=cast("Any", params.messages),
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"}),
                 **kwargs,
             ),
         )

--- a/src/any_llm/providers/voyage/voyage.py
+++ b/src/any_llm/providers/voyage/voyage.py
@@ -37,12 +37,13 @@ class VoyageProvider(Provider):
         self,
         model: str,
         inputs: str | list[str],
+        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         if isinstance(inputs, str):
             inputs = [inputs]
 
-        client = AsyncClient(api_key=self.config.api_key)
+        client = AsyncClient(api_key=self.config.api_key, **(client_args if client_args else {}))
         result = await client.embed(
             texts=inputs,
             model=model,

--- a/src/any_llm/providers/voyage/voyage.py
+++ b/src/any_llm/providers/voyage/voyage.py
@@ -37,13 +37,14 @@ class VoyageProvider(Provider):
         self,
         model: str,
         inputs: str | list[str],
-        client_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         if isinstance(inputs, str):
             inputs = [inputs]
 
-        client = AsyncClient(api_key=self.config.api_key, **(client_args if client_args else {}))
+        client = AsyncClient(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
         result = await client.embed(
             texts=inputs,
             model=model,

--- a/src/any_llm/providers/watsonx/watsonx.py
+++ b/src/any_llm/providers/watsonx/watsonx.py
@@ -89,7 +89,7 @@ class WatsonxProvider(Provider):
                 url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL"),
             ),
             project_id=kwargs.get("project_id") or os.getenv("WATSONX_PROJECT_ID"),
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         # Handle response_format by inlining schema guidance into the prompt
@@ -102,18 +102,14 @@ class WatsonxProvider(Provider):
 
         if params.stream:
             kwargs = {
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
                 **kwargs,
             }
             return self._stream_completion_async(model_inference, params.messages, **kwargs)
 
         response = await model_inference.achat(
             messages=params.messages,
-            params=params.model_dump(
-                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-            ),
+            params=params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
         )
 
         return _convert_response(response)
@@ -132,7 +128,7 @@ class WatsonxProvider(Provider):
                 url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL"),
             ),
             project_id=kwargs.get("project_id") or os.getenv("WATSONX_PROJECT_ID"),
-            **(params.client_args if params.client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
 
         # Handle response_format by inlining schema guidance into the prompt
@@ -145,23 +141,19 @@ class WatsonxProvider(Provider):
 
         if params.stream:
             kwargs = {
-                **params.model_dump(
-                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-                ),
+                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
                 **kwargs,
             }
             return self._stream_completion(model_inference, params.messages, **kwargs)
 
         response = model_inference.chat(
             messages=params.messages,
-            params=params.model_dump(
-                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
-            ),
+            params=params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
         )
 
         return _convert_response(response)
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
@@ -170,7 +162,7 @@ class WatsonxProvider(Provider):
             credentials=Credentials(
                 api_key=self.config.api_key, url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL")
             ),
-            **(client_args if client_args else {}),
+            **(self.config.client_args if self.config.client_args else {}),
         )
         models_response = client.foundation_models.get_model_specs(**kwargs)
 

--- a/src/any_llm/providers/watsonx/watsonx.py
+++ b/src/any_llm/providers/watsonx/watsonx.py
@@ -89,6 +89,7 @@ class WatsonxProvider(Provider):
                 url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL"),
             ),
             project_id=kwargs.get("project_id") or os.getenv("WATSONX_PROJECT_ID"),
+            **(params.client_args if params.client_args else {}),
         )
 
         # Handle response_format by inlining schema guidance into the prompt
@@ -101,14 +102,18 @@ class WatsonxProvider(Provider):
 
         if params.stream:
             kwargs = {
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+                ),
                 **kwargs,
             }
             return self._stream_completion_async(model_inference, params.messages, **kwargs)
 
         response = await model_inference.achat(
             messages=params.messages,
-            params=params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+            params=params.model_dump(
+                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+            ),
         )
 
         return _convert_response(response)
@@ -127,6 +132,7 @@ class WatsonxProvider(Provider):
                 url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL"),
             ),
             project_id=kwargs.get("project_id") or os.getenv("WATSONX_PROJECT_ID"),
+            **(params.client_args if params.client_args else {}),
         )
 
         # Handle response_format by inlining schema guidance into the prompt
@@ -139,19 +145,23 @@ class WatsonxProvider(Provider):
 
         if params.stream:
             kwargs = {
-                **params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+                **params.model_dump(
+                    exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+                ),
                 **kwargs,
             }
             return self._stream_completion(model_inference, params.messages, **kwargs)
 
         response = model_inference.chat(
             messages=params.messages,
-            params=params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}),
+            params=params.model_dump(
+                exclude_none=True, exclude={"client_args", "model_id", "messages", "response_format", "stream"}
+            ),
         )
 
         return _convert_response(response)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
@@ -160,6 +170,7 @@ class WatsonxProvider(Provider):
             credentials=Credentials(
                 api_key=self.config.api_key, url=self.config.api_base or os.getenv("WATSONX_SERVICE_URL")
             ),
+            **(client_args if client_args else {}),
         )
         models_response = client.foundation_models.get_model_specs(**kwargs)
 

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -43,7 +43,9 @@ class XaiProvider(Provider):
         self, params: CompletionParams, **kwargs: Any
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Call the XAI Python SDK Chat Completions API and convert to AnyLLM types."""
-        client = XaiAsyncClient(api_key=self.config.api_key, **(params.client_args if params.client_args else {}))
+        client = XaiAsyncClient(
+            api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {})
+        )
 
         xai_messages = []
         for message in params.messages:
@@ -80,7 +82,6 @@ class XaiProvider(Provider):
             **params.model_dump(
                 exclude_none=True,
                 exclude={
-                    "client_args",
                     "model_id",
                     "messages",
                     "stream",
@@ -110,10 +111,10 @@ class XaiProvider(Provider):
 
         return _convert_xai_completion_to_anyllm_response(response)
 
-    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = XaiClient(api_key=self.config.api_key, **(client_args if client_args else {}))
+        client = XaiClient(api_key=self.config.api_key, **(self.config.client_args if self.config.client_args else {}))
         models_list = client.models.list_language_models()
         return _convert_models_list(models_list)

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -43,7 +43,7 @@ class XaiProvider(Provider):
         self, params: CompletionParams, **kwargs: Any
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Call the XAI Python SDK Chat Completions API and convert to AnyLLM types."""
-        client = XaiAsyncClient(api_key=self.config.api_key)
+        client = XaiAsyncClient(api_key=self.config.api_key, **(params.client_args if params.client_args else {}))
 
         xai_messages = []
         for message in params.messages:
@@ -80,6 +80,7 @@ class XaiProvider(Provider):
             **params.model_dump(
                 exclude_none=True,
                 exclude={
+                    "client_args",
                     "model_id",
                     "messages",
                     "stream",
@@ -109,10 +110,10 @@ class XaiProvider(Provider):
 
         return _convert_xai_completion_to_anyllm_response(response)
 
-    def list_models(self, **kwargs: Any) -> Sequence[Model]:
+    def list_models(self, client_args: dict[str, Any] | None = None, **kwargs: Any) -> Sequence[Model]:
         """
         Fetch available models from the /v1/models endpoint.
         """
-        client = XaiClient(api_key=self.config.api_key)
+        client = XaiClient(api_key=self.config.api_key, **(client_args if client_args else {}))
         models_list = client.models.list_language_models()
         return _convert_models_list(models_list)

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -148,6 +148,3 @@ class CompletionParams(BaseModel):
 
     reasoning_effort: Literal["minimal", "low", "medium", "high", "auto"] | None = "auto"
     """Reasoning effort level for models that support it. "auto" will map to each provider's default."""
-
-    client_args: dict[str, Any] | None = None
-    """ Additional provider-specific arguments that will be passed to the provider's client instantiation."""

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -148,3 +148,6 @@ class CompletionParams(BaseModel):
 
     reasoning_effort: Literal["minimal", "low", "medium", "high", "auto"] | None = "auto"
     """Reasoning effort level for models that support it. "auto" will map to each provider's default."""
+
+    client_args: dict[str, Any] | None = None
+    """ Additional provider-specific arguments that will be passed to the provider's client instantiation."""

--- a/src/any_llm/utils/api.py
+++ b/src/any_llm/utils/api.py
@@ -35,6 +35,7 @@ def _process_completion_params(
     stream_options: dict[str, Any] | None,
     max_completion_tokens: int | None,
     reasoning_effort: Literal["minimal", "low", "medium", "high", "auto"] | None,
+    client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> tuple[Provider, CompletionParams]:
     if provider is None:
@@ -84,5 +85,6 @@ def _process_completion_params(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        client_args=client_args,
     )
     return provider_instance, completion_params

--- a/src/any_llm/utils/api.py
+++ b/src/any_llm/utils/api.py
@@ -3,7 +3,7 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel
 
-from any_llm.provider import ApiConfig, Provider, ProviderFactory, ProviderName
+from any_llm.provider import ClientConfig, Provider, ProviderFactory, ProviderName
 from any_llm.tools import prepare_tools
 from any_llm.types.completion import ChatCompletionMessage, CompletionParams
 
@@ -44,12 +44,7 @@ def _process_completion_params(
         provider_key = ProviderName.from_string(provider)
         model_name = model
 
-    config: dict[str, str] = {}
-    if api_key:
-        config["api_key"] = str(api_key)
-    if api_base:
-        config["api_base"] = str(api_base)
-    api_config = ApiConfig(**config)
+    api_config = ClientConfig(api_key=api_key, api_base=api_base, client_args=client_args)
 
     provider_instance = ProviderFactory.create_provider(provider_key, api_config)
 
@@ -85,6 +80,5 @@ def _process_completion_params(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
-        client_args=client_args,
     )
     return provider_instance, completion_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def provider_extra_kwargs_map() -> dict[ProviderName, dict[str, Any]]:
         ProviderName.COHERE: {"client_args": {"timeout": 10}},
         ProviderName.DATABRICKS: {"api_base": "https://dbc-40d03128-ecae.cloud.databricks.com/serving-endpoints"},
         ProviderName.GROQ: {"client_args": {"timeout": 10}},
-        ProviderName.MISTRAL: {"client_args": {"timeout_ms": 10000}},
+        ProviderName.MISTRAL: {"client_args": {"timeout_ms": 100000}},
         ProviderName.HUGGINGFACE: {
             "api_base": "https://y0okp71n85ezo5nr.us-east-1.aws.endpoints.huggingface.cloud/v1/"
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def provider_extra_kwargs_map() -> dict[ProviderName, dict[str, Any]]:
             "api_base": "https://us-south.ml.cloud.ibm.com",
             "project_id": "5b083ace-95a6-4f95-a0a0-d4c5d9e98ca0",
         },
-        ProviderName.XAI: {"client_args": {"timeout": 10}},
+        ProviderName.XAI: {"client_args": {"timeout": 100}},
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,17 +84,26 @@ def embedding_provider_model_map() -> dict[ProviderName, str]:
 @pytest.fixture
 def provider_extra_kwargs_map() -> dict[ProviderName, dict[str, Any]]:
     return {
+        ProviderName.ANTHROPIC: {"client_args": {"timeout": 10}},
         ProviderName.AZURE: {
             "api_base": "https://models.github.ai/inference",
         },
+        ProviderName.CEREBRAS: {"client_args": {"timeout": 10}},
+        ProviderName.COHERE: {"client_args": {"timeout": 10}},
         ProviderName.DATABRICKS: {"api_base": "https://dbc-40d03128-ecae.cloud.databricks.com/serving-endpoints"},
+        ProviderName.GROQ: {"client_args": {"timeout": 10}},
+        ProviderName.MISTRAL: {"client_args": {"timeout_ms": 10000}},
         ProviderName.HUGGINGFACE: {
             "api_base": "https://y0okp71n85ezo5nr.us-east-1.aws.endpoints.huggingface.cloud/v1/"
         },
+        ProviderName.OPENAI: {"client_args": {"timeout": 10}},
+        ProviderName.TOGETHER: {"client_args": {"timeout": 10}},
+        ProviderName.VOYAGE: {"client_args": {"timeout": 10}},
         ProviderName.WATSONX: {
             "api_base": "https://us-south.ml.cloud.ibm.com",
             "project_id": "5b083ace-95a6-4f95-a0a0-d4c5d9e98ca0",
         },
+        ProviderName.XAI: {"client_args": {"timeout": 10}},
     }
 
 

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.anthropic.anthropic import AnthropicProvider
 from any_llm.providers.anthropic.utils import DEFAULT_MAX_TOKENS, REASONING_EFFORT_TO_THINKING_BUDGETS
 from any_llm.types.completion import CompletionParams
@@ -30,7 +30,7 @@ async def test_anthropic_client_created_with_api_key_and_api_base() -> None:
     custom_endpoint = "https://custom-anthropic-endpoint"
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key, api_base=custom_endpoint))
         await provider.acompletion(
             CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}])
         )
@@ -44,7 +44,7 @@ async def test_anthropic_client_created_without_api_base() -> None:
     api_key = "test-api-key"
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(
             CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}])
         )
@@ -63,7 +63,7 @@ async def test_completion_with_system_message() -> None:
     ]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
@@ -86,7 +86,7 @@ async def test_completion_with_multiple_system_messages() -> None:
     ]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
@@ -105,7 +105,7 @@ async def test_completion_with_kwargs() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages, max_tokens=100, temperature=0.5))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
@@ -121,7 +121,7 @@ async def test_completion_with_tool_choice_required() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages, tool_choice="required"))
 
         expected_kwargs = {"tool_choice": {"type": "any", "disable_parallel_tool_use": False}}
@@ -143,7 +143,7 @@ async def test_completion_with_tool_choice_and_parallel_tool_calls(parallel_tool
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(
             CompletionParams(
                 model_id=model, messages=messages, tool_choice="auto", parallel_tool_calls=parallel_tool_calls
@@ -166,7 +166,7 @@ async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, 
     model = "model-id"
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=agent_loop_messages))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
@@ -203,7 +203,7 @@ async def test_completion_with_custom_reasoning_effort(
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_anthropic_provider() as mock_anthropic:
-        provider = AnthropicProvider(ApiConfig(api_key=api_key))
+        provider = AnthropicProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(
             CompletionParams(model_id=model, messages=messages, reasoning_effort=reasoning_effort)
         )
@@ -227,7 +227,7 @@ async def test_response_format_raises_error() -> None:
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
 
-    provider = AnthropicProvider(ApiConfig(api_key=api_key))
+    provider = AnthropicProvider(ClientConfig(api_key=api_key))
 
     with pytest.raises(UnsupportedParameterError, match="Check the following links:"):
         await provider.acompletion(

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -3,7 +3,7 @@ import os
 from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.aws.aws import AwsProvider
 from any_llm.types.completion import CompletionParams
 
@@ -30,7 +30,7 @@ def test_boto3_client_created_with_api_base() -> None:
     region = "us-east-1"
 
     with mock_aws_provider(region) as mock_boto3_client:
-        provider = AwsProvider(ApiConfig(api_base=custom_endpoint, api_key="test_key"))
+        provider = AwsProvider(ClientConfig(api_base=custom_endpoint, api_key="test_key"))
         provider.completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=custom_endpoint, region_name=region)
@@ -41,7 +41,7 @@ def test_boto3_client_created_without_api_base() -> None:
     region = "us-west-2"
 
     with mock_aws_provider(region) as mock_boto3_client:
-        provider = AwsProvider(ApiConfig(api_key="test_key"))
+        provider = AwsProvider(ClientConfig(api_key="test_key"))
         provider.completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None, region_name=region)
@@ -71,7 +71,7 @@ def test_embedding_single_string() -> None:
     with mock_aws_embedding_provider(region) as (mock_boto3_client, mock_client):
         mock_client.invoke_model.return_value = {"body": Mock(read=Mock(return_value=json.dumps(mock_response_body)))}
 
-        provider = AwsProvider(ApiConfig(api_key="test_key"))
+        provider = AwsProvider(ClientConfig(api_key="test_key"))
         response = provider.embedding(model_id, input_text)
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None, region_name=region)
@@ -105,7 +105,7 @@ def test_embedding_list_of_strings() -> None:
             {"body": Mock(read=Mock(return_value=json.dumps(mock_response_bodies[1])))},
         ]
 
-        provider = AwsProvider(ApiConfig(api_key="test_key"))
+        provider = AwsProvider(ClientConfig(api_key="test_key"))
         response = provider.embedding(model_id, input_texts)
 
         mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None, region_name=region)

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.azure.azure import AzureProvider
 from any_llm.types.completion import CompletionParams
 
@@ -46,7 +46,7 @@ async def test_azure_with_api_key_and_api_base() -> None:
 
     messages = [{"role": "user", "content": "Hello"}]
     with mock_azure_provider() as (mock_client, mock_convert_response, mock_chat_client):
-        provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
+        provider = AzureProvider(ClientConfig(api_key=api_key, api_base=custom_endpoint))
         await provider.acompletion(CompletionParams(model_id="model-id", messages=messages))
 
         mock_chat_client.assert_called_once()
@@ -67,7 +67,7 @@ async def test_azure_with_api_version() -> None:
     messages = [{"role": "user", "content": "Hello"}]
     with mock_azure_provider() as (_, _, mock_chat_client):
         with patch("any_llm.providers.azure.azure.AzureKeyCredential") as mock_azure_key_credential:
-            provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
+            provider = AzureProvider(ClientConfig(api_key=api_key, api_base=custom_endpoint))
             await provider.acompletion(
                 CompletionParams(model_id="model-id", messages=messages), api_version="2025-04-01-preview"
             )
@@ -88,7 +88,7 @@ async def test_azure_with_tools() -> None:
     tools = {"type": "function", "function": "foo"}
     tool_choice = "auto"
     with mock_azure_provider() as (mock_client, mock_convert_response, mock_chat_client):
-        provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
+        provider = AzureProvider(ClientConfig(api_key=api_key, api_base=custom_endpoint))
         await provider.acompletion(
             CompletionParams(
                 model_id="model-id",
@@ -115,7 +115,7 @@ async def test_azure_streaming() -> None:
 
     messages = [{"role": "user", "content": "Hello"}]
 
-    provider = AzureProvider(ApiConfig(api_key=api_key, api_base=custom_endpoint))
+    provider = AzureProvider(ClientConfig(api_key=api_key, api_base=custom_endpoint))
 
     with patch.object(provider, "_stream_completion_async") as mock_stream_completion:
         mock_openai_chunk1 = MagicMock()

--- a/tests/unit/providers/test_cerebras_provider.py
+++ b/tests/unit/providers/test_cerebras_provider.py
@@ -1,7 +1,7 @@
 import pytest
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.cerebras.cerebras import CerebrasProvider
 
 
@@ -11,7 +11,7 @@ async def test_stream_with_response_format_raises() -> None:
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
 
-    provider = CerebrasProvider(ApiConfig(api_key=api_key))
+    provider = CerebrasProvider(ClientConfig(api_key=api_key))
 
     chunks = provider._stream_completion_async(
         model=model,

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.cohere.utils import _patch_messages
 from any_llm.types.completion import CompletionParams
 
@@ -13,7 +13,7 @@ def _mk_provider() -> Any:
     pytest.importorskip("cohere")
     from any_llm.providers.cohere.cohere import CohereProvider
 
-    return CohereProvider(ApiConfig(api_key="test-api-key"))
+    return CohereProvider(ClientConfig(api_key="test-api-key"))
 
 
 def test_preprocess_response_format() -> None:

--- a/tests/unit/providers/test_google_provider.py
+++ b/tests/unit/providers/test_google_provider.py
@@ -6,7 +6,7 @@ import pytest
 from google.genai import types
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.google.google import REASONING_EFFORT_TO_THINKING_BUDGETS, GoogleProvider
 from any_llm.types.completion import CompletionParams
 
@@ -46,7 +46,7 @@ async def test_completion_with_system_instruction() -> None:
     messages = [{"role": "system", "content": "You are a helpful assistant"}, {"role": "user", "content": "Hello"}]
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages))
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
@@ -72,7 +72,7 @@ async def test_completion_with_tool_choice_auto(tool_choice: str, expected_mode:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages, tool_choice=tool_choice))
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
@@ -89,7 +89,7 @@ async def test_completion_without_tool_choice() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages))
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
@@ -105,7 +105,7 @@ async def test_completion_with_stream_and_response_format_raises() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider():
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         with pytest.raises(UnsupportedParameterError):
             await provider.acompletion(
                 CompletionParams(
@@ -124,7 +124,7 @@ async def test_completion_with_parallel_tool_calls_raises() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider():
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         with pytest.raises(UnsupportedParameterError):
             await provider.acompletion(
                 CompletionParams(
@@ -141,7 +141,7 @@ async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, 
     model = "gemini-pro"
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=agent_loop_messages))
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
@@ -171,7 +171,7 @@ async def test_completion_with_custom_reasoning_effort(
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(
             CompletionParams(model_id=model, messages=messages, reasoning_effort=reasoning_effort)
         )
@@ -195,7 +195,7 @@ async def test_completion_with_max_tokens_conversion() -> None:
     max_tokens = 100
 
     with mock_google_provider() as mock_genai:
-        provider = GoogleProvider(ApiConfig(api_key=api_key))
+        provider = GoogleProvider(ClientConfig(api_key=api_key))
         await provider.acompletion(CompletionParams(model_id=model, messages=messages, max_tokens=max_tokens))
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args

--- a/tests/unit/providers/test_groq_provider.py
+++ b/tests/unit/providers/test_groq_provider.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.types.completion import CompletionParams
 
 
@@ -13,7 +13,7 @@ async def test_stream_with_response_format_raises() -> None:
     pytest.importorskip("groq")
     from any_llm.providers.groq.groq import GroqProvider
 
-    provider = GroqProvider(ApiConfig(api_key="test-api-key"))
+    provider = GroqProvider(ClientConfig(api_key="test-api-key"))
 
     with pytest.raises(UnsupportedParameterError, match="stream and response_format"):
         await provider.acompletion(
@@ -31,7 +31,7 @@ async def test_unsupported_max_tool_calls_parameter() -> None:
     pytest.importorskip("groq")
     from any_llm.providers.groq.groq import GroqProvider
 
-    provider = GroqProvider(ApiConfig(api_key="test-api-key"))
+    provider = GroqProvider(ClientConfig(api_key="test-api-key"))
 
     with pytest.raises(UnsupportedParameterError):
         await provider.aresponses("test_model", "test_data", max_tool_calls=3)
@@ -45,7 +45,7 @@ async def test_completion_with_response_format_basemodel() -> None:
     class TestOutput(BaseModel):
         foo: str
 
-    provider = GroqProvider(ApiConfig(api_key="test-api-key"))
+    provider = GroqProvider(ClientConfig(api_key="test-api-key"))
 
     with (
         patch("any_llm.providers.groq.groq.groq.AsyncGroq") as mocked_groq,

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.huggingface.huggingface import HuggingfaceProvider
 from any_llm.types.completion import CompletionParams
 
@@ -32,7 +32,7 @@ def test_huggingface_with_api_base() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_huggingface_provider() as mock_huggingface:
-        provider = HuggingfaceProvider(ApiConfig(api_key=api_key, api_base=api_base))
+        provider = HuggingfaceProvider(ClientConfig(api_key=api_key, api_base=api_base))
         provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
         mock_huggingface.assert_called_with(base_url=api_base, token=api_key)
@@ -43,7 +43,7 @@ def test_huggingface_with_api_key() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_huggingface_provider() as mock_huggingface:
-        provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
+        provider = HuggingfaceProvider(ClientConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
         mock_huggingface.assert_called_with(base_url=None, token=api_key)
@@ -56,7 +56,7 @@ def test_huggingface_with_tools(tools: list[dict[str, Any]]) -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_huggingface_provider() as mock_huggingface:
-        provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
+        provider = HuggingfaceProvider(ClientConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, tools=tools))
 
         mock_huggingface.assert_called_with(base_url=None, token=api_key)
@@ -71,7 +71,7 @@ def test_huggingface_with_max_tokens() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_huggingface_provider() as mock_huggingface:
-        provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
+        provider = HuggingfaceProvider(ClientConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, max_tokens=100))
 
         mock_huggingface.assert_called_with(base_url=None, token=api_key)
@@ -86,8 +86,8 @@ def test_huggingface_with_timeout() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_huggingface_provider() as mock_huggingface:
-        provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
-        provider.completion(CompletionParams(model_id="model-id", messages=messages, client_args={"timeout": 10}))
+        provider = HuggingfaceProvider(ClientConfig(api_key=api_key, client_args={"timeout": 10}))
+        provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
         mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=10)
 

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -35,7 +35,7 @@ def test_huggingface_with_api_base() -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key, api_base=api_base))
         provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
-        mock_huggingface.assert_called_with(base_url=api_base, token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=api_base, token=api_key)
 
 
 def test_huggingface_with_api_key() -> None:
@@ -46,7 +46,7 @@ def test_huggingface_with_api_key() -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages))
 
-        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(model="model-id", messages=messages)
 
@@ -59,7 +59,7 @@ def test_huggingface_with_tools(tools: list[dict[str, Any]]) -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, tools=tools))
 
-        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(
             model="model-id", messages=messages, tools=tools
@@ -74,7 +74,7 @@ def test_huggingface_with_max_tokens() -> None:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
         provider.completion(CompletionParams(model_id="model-id", messages=messages, max_tokens=100))
 
-        mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=None)
+        mock_huggingface.assert_called_with(base_url=None, token=api_key)
 
         mock_huggingface.return_value.chat_completion.assert_called_with(
             model="model-id", messages=messages, max_new_tokens=100
@@ -87,7 +87,7 @@ def test_huggingface_with_timeout() -> None:
 
     with mock_huggingface_provider() as mock_huggingface:
         provider = HuggingfaceProvider(ApiConfig(api_key=api_key))
-        provider.completion(CompletionParams(model_id="model-id", messages=messages), timeout=10)
+        provider.completion(CompletionParams(model_id="model-id", messages=messages, client_args={"timeout": 10}))
 
         mock_huggingface.assert_called_with(base_url=None, token=api_key, timeout=10)
 

--- a/tests/unit/providers/test_llamafile.py
+++ b/tests/unit/providers/test_llamafile.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.llamafile.llamafile import LlamafileProvider
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import CompletionParams
@@ -11,7 +11,7 @@ from any_llm.types.completion import CompletionParams
 
 @pytest.mark.asyncio
 async def test_response_format_dict_raises() -> None:
-    provider = LlamafileProvider(ApiConfig())
+    provider = LlamafileProvider(ClientConfig())
     with pytest.raises(UnsupportedParameterError):
         await provider.acompletion(
             CompletionParams(
@@ -24,7 +24,7 @@ async def test_response_format_dict_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_calls_completion() -> None:
-    provider = LlamafileProvider(ApiConfig())
+    provider = LlamafileProvider(ClientConfig())
     params = CompletionParams(model_id="llama3.1", messages=[{"role": "user", "content": "Hi"}])
     sentinel = object()
     with patch.object(BaseOpenAIProvider, "acompletion", autospec=True, return_value=sentinel) as mock_super:
@@ -35,7 +35,7 @@ async def test_calls_completion() -> None:
 
 @pytest.mark.asyncio
 async def test_tools_raises() -> None:
-    provider = LlamafileProvider(ApiConfig())
+    provider = LlamafileProvider(ClientConfig())
     tools = [
         {
             "type": "function",

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.model import Model
 
@@ -23,7 +23,7 @@ def test_list_models_returns_model_list_when_supported(mock_openai_class: MagicM
     mock_client.models.list.return_value.data = mock_model_data
     mock_openai_class.return_value = mock_client
 
-    config = ApiConfig(api_key="test-key", api_base="https://custom.api.com/v1")
+    config = ClientConfig(api_key="test-key", api_base="https://custom.api.com/v1")
     provider = ListModelsProvider(config=config)
 
     result = provider.list_models()
@@ -46,7 +46,7 @@ def test_list_models_uses_default_api_base_when_not_configured(mock_openai_class
     mock_client.models.list.return_value.data = []
     mock_openai_class.return_value = mock_client
 
-    config = ApiConfig(api_key="test-key")
+    config = ClientConfig(api_key="test-key")
     provider = ListModelsProvider(config=config)
 
     provider.list_models()
@@ -66,7 +66,7 @@ def test_list_models_passes_kwargs_to_client(mock_openai_class: MagicMock) -> No
     mock_client.models.list.return_value.data = []
     mock_openai_class.return_value = mock_client
 
-    config = ApiConfig(api_key="test-key")
+    config = ClientConfig(api_key="test-key")
     provider = ListModelsProvider(config=config)
 
     provider.list_models(limit=10, after="model-123")

--- a/tests/unit/providers/test_perplexity_provider.py
+++ b/tests/unit/providers/test_perplexity_provider.py
@@ -1,6 +1,6 @@
 import pytest
 
-from any_llm.provider import ApiConfig, ProviderFactory
+from any_llm.provider import ClientConfig, ProviderFactory
 from any_llm.providers.perplexity import PerplexityProvider
 
 
@@ -11,7 +11,7 @@ def _env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_provider_basics() -> None:
     """Test provider instantiation and basic attributes."""
-    p = PerplexityProvider(ApiConfig(api_key="sk-test"))
+    p = PerplexityProvider(ClientConfig(api_key="sk-test"))
     assert p.PROVIDER_NAME == "perplexity"
     assert p.API_BASE == "https://api.perplexity.ai"  # No override, just default
     assert p.SUPPORTS_COMPLETION is True
@@ -23,7 +23,7 @@ def test_provider_basics() -> None:
 def test_factory_integration() -> None:
     """Test that the provider factory can create and discover the provider."""
     # Test provider creation
-    p = ProviderFactory.create_provider("perplexity", ApiConfig(api_key="sk-1"))
+    p = ProviderFactory.create_provider("perplexity", ClientConfig(api_key="sk-1"))
     assert isinstance(p, PerplexityProvider)
     assert p.PROVIDER_NAME == "perplexity"
 
@@ -54,5 +54,5 @@ def test_provider_metadata() -> None:
 def test_perplexity_api_base_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that PERPLEXITY_API_BASE environment variable overrides the default API base."""
     monkeypatch.setenv("PERPLEXITY_API_BASE", "https://example-proxy.local")
-    p = ProviderFactory.create_provider("perplexity", ApiConfig(api_key="dummy"))
+    p = ProviderFactory.create_provider("perplexity", ClientConfig(api_key="dummy"))
     assert getattr(p, "API_BASE", "") == "https://example-proxy.local"

--- a/tests/unit/providers/test_watsonx_provider.py
+++ b/tests/unit/providers/test_watsonx_provider.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.providers.watsonx.watsonx import WatsonxProvider
 from any_llm.types.completion import CompletionParams
 
@@ -59,7 +59,7 @@ async def test_watsonx_non_streaming() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_watsonx_provider() as (mock_model_instance, mock_convert_response, mock_model_inference):
-        provider = WatsonxProvider(ApiConfig(api_key=api_key))
+        provider = WatsonxProvider(ClientConfig(api_key=api_key))
         result = await provider.acompletion(CompletionParams(model_id="test-model", messages=messages))
 
         mock_model_inference.assert_called_once()
@@ -79,7 +79,7 @@ async def test_watsonx_streaming() -> None:
     messages = [{"role": "user", "content": "Hello"}]
 
     with mock_watsonx_streaming_provider() as (mock_model_instance, mock_convert_streaming_chunk, mock_model_inference):
-        provider = WatsonxProvider(ApiConfig(api_key=api_key))
+        provider = WatsonxProvider(ClientConfig(api_key=api_key))
         result = await provider.acompletion(CompletionParams(model_id="test-model", messages=messages, stream=True))
 
         mock_model_inference.assert_called_once()
@@ -101,5 +101,5 @@ async def test_watsonx_streaming() -> None:
 
 def test_watsonx_SUPPORTS_COMPLETION_STREAMING() -> None:
     """Test that WatsonxProvider correctly advertises streaming support."""
-    provider = WatsonxProvider(ApiConfig(api_key="test-key"))
+    provider = WatsonxProvider(ClientConfig(api_key="test-key"))
     assert provider.SUPPORTS_COMPLETION_STREAMING is True

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from any_llm.provider import ApiConfig
+from any_llm.provider import ClientConfig
 from any_llm.types.completion import ChatCompletion, CompletionParams
 
 
@@ -36,7 +36,7 @@ async def test_response_function_call_id_is_preserved() -> None:
         tool_call.function.arguments = '{"key": "value"}'
         mock_response.tool_calls = [tool_call]
 
-        provider = XaiProvider(ApiConfig(api_key="test-api-key"))
+        provider = XaiProvider(ClientConfig(api_key="test-api-key"))
         response = await provider.acompletion(
             CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}])
         )
@@ -51,7 +51,7 @@ async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, 
     from any_llm.providers.xai.xai import XaiProvider
 
     with mock_xai_provider() as (mock_xai, _):
-        provider = XaiProvider(ApiConfig(api_key="test-api-key"))
+        provider = XaiProvider(ClientConfig(api_key="test-api-key"))
         await provider.acompletion(CompletionParams(model_id="model", messages=agent_loop_messages))
         _, call_kwargs = mock_xai.return_value.chat.create.call_args
 

--- a/tests/unit/test_api_config.py
+++ b/tests/unit/test_api_config.py
@@ -2,7 +2,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from any_llm import completion
-from any_llm.provider import ApiConfig, ProviderName
+from any_llm.provider import ClientConfig, ProviderName
 from any_llm.types.completion import CompletionParams
 
 
@@ -28,7 +28,7 @@ def test_completion_extracts_all_config_from_kwargs() -> None:
         )
 
         mock_factory.create_provider.assert_called_once_with(
-            ProviderName.MISTRAL, ApiConfig(api_key="test_key", api_base="https://test.com")
+            ProviderName.MISTRAL, ClientConfig(api_key="test_key", api_base="https://test.com")
         )
 
         mock_provider.completion.assert_called_once()
@@ -57,7 +57,7 @@ def test_completion_extracts_partial_config_from_kwargs() -> None:
             other_param="value",
         )
 
-        mock_factory.create_provider.assert_called_once_with(ProviderName.MISTRAL, ApiConfig(api_key="test_key"))
+        mock_factory.create_provider.assert_called_once_with(ProviderName.MISTRAL, ClientConfig(api_key="test_key"))
 
         mock_provider.completion.assert_called_once()
         args, kwargs = mock_provider.completion.call_args
@@ -83,7 +83,7 @@ def test_completion_no_config_extraction() -> None:
         }
         completion(model="mistral/mistral-small", messages=[{"role": "user", "content": "Hello"}], **kwargs)
 
-        mock_factory.create_provider.assert_called_once_with(ProviderName.MISTRAL, ApiConfig())
+        mock_factory.create_provider.assert_called_once_with(ProviderName.MISTRAL, ClientConfig())
 
         mock_provider.completion.assert_called_once()
         args, kwargs = mock_provider.completion.call_args
@@ -111,7 +111,7 @@ def test_completion_extracts_api_base_only() -> None:
         )
 
         mock_factory.create_provider.assert_called_once_with(
-            ProviderName.OLLAMA, ApiConfig(api_base="https://custom-endpoint.com")
+            ProviderName.OLLAMA, ClientConfig(api_base="https://custom-endpoint.com")
         )
 
         mock_provider.completion.assert_called_once()

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from any_llm import acompletion
-from any_llm.provider import ApiConfig, Provider, ProviderFactory, ProviderName
+from any_llm.provider import ClientConfig, Provider, ProviderFactory, ProviderName
 from any_llm.types.completion import ChatCompletionMessage, CompletionParams, Reasoning
 
 
@@ -86,7 +86,7 @@ async def test_all_providers_can_be_loaded(provider: str) -> None:
     This test will automatically include new providers when they're added
     without requiring any code changes.
     """
-    provider_instance = ProviderFactory.create_provider(provider, ApiConfig(api_key="test_key"))
+    provider_instance = ProviderFactory.create_provider(provider, ClientConfig(api_key="test_key"))
 
     assert isinstance(provider_instance, Provider), f"Provider {provider} did not create a valid Provider instance"
 
@@ -101,7 +101,7 @@ async def test_all_providers_can_be_loaded_with_config(provider: str) -> None:
     This test verifies that providers can handle common configuration parameters
     like api_key and api_base without throwing errors during instantiation.
     """
-    sample_config = ApiConfig(api_key="test_key", api_base="https://test.example.com")
+    sample_config = ClientConfig(api_key="test_key", api_base="https://test.example.com")
 
     provider_instance = ProviderFactory.create_provider(provider, sample_config)
 
@@ -116,6 +116,6 @@ async def test_provider_factory_can_create_all_supported_providers() -> None:
     supported_providers = ProviderFactory.get_supported_providers()
 
     for provider_name in supported_providers:
-        provider_instance = ProviderFactory.create_provider(provider_name, ApiConfig(api_key="test_key"))
+        provider_instance = ProviderFactory.create_provider(provider_name, ClientConfig(api_key="test_key"))
 
         assert isinstance(provider_instance, Provider), f"Failed to create valid Provider instance for {provider_name}"

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -32,7 +32,7 @@ async def test_embedding_with_api_config() -> None:
         assert call_args[0][1].api_key == "test_key"
         assert call_args[0][1].api_base == "https://test.example.com"
 
-        mock_provider.aembedding.assert_called_once_with("test-model", "Hello world", client_args=None)
+        mock_provider.aembedding.assert_called_once_with("test-model", "Hello world")
         assert result == mock_embedding_response
 
 

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -32,7 +32,7 @@ async def test_embedding_with_api_config() -> None:
         assert call_args[0][1].api_key == "test_key"
         assert call_args[0][1].api_base == "https://test.example.com"
 
-        mock_provider.aembedding.assert_called_once_with("test-model", "Hello world")
+        mock_provider.aembedding.assert_called_once_with("test-model", "Hello world", client_args=None)
         assert result == mock_embedding_response
 
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from any_llm.exceptions import MissingApiKeyError, UnsupportedProviderError
-from any_llm.provider import ApiConfig, ProviderFactory, ProviderName
+from any_llm.provider import ClientConfig, ProviderFactory, ProviderName
 
 
 def test_all_providers_in_enum() -> None:
@@ -114,7 +114,7 @@ def test_all_providers_have_required_attributes(provider: str) -> None:
     This test verifies that providers can handle common configuration parameters
     like api_key and api_base without throwing errors during instantiation.
     """
-    sample_config = ApiConfig(api_key="test_key", api_base="https://test.example.com")
+    sample_config = ClientConfig(api_key="test_key", api_base="https://test.example.com")
 
     provider_instance = ProviderFactory.create_provider(provider, sample_config)
 
@@ -133,7 +133,7 @@ def test_providers_raise_MissingApiKeyError(provider: str) -> None:
         pytest.skip("This provider handles `api_key` differently.")
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(MissingApiKeyError):
-            ProviderFactory.create_provider(provider, ApiConfig())
+            ProviderFactory.create_provider(provider, ClientConfig())
 
 
 @pytest.mark.parametrize(
@@ -162,7 +162,7 @@ def test_providers_raise_ImportError_from_original(provider_name: str, module_na
             if mod.startswith((f"any_llm.providers.{provider_name}", f"{module_name}.")):
                 sys.modules.pop(mod)
         with pytest.raises(ImportError) as e:
-            ProviderFactory.create_provider(provider_name, ApiConfig(api_key="test_key"))
+            ProviderFactory.create_provider(provider_name, ClientConfig(api_key="test_key"))
         original_error = e.value.__cause__
         assert any(
             msg in str(original_error)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -129,7 +129,7 @@ def test_all_providers_have_required_attributes(provider: str) -> None:
 
 
 def test_providers_raise_MissingApiKeyError(provider: str) -> None:
-    if provider in ("aws", "ollama", "lmstudio", "llamafile"):
+    if provider in ("aws", "google", "ollama", "lmstudio", "llamafile"):
         pytest.skip("This provider handles `api_key` differently.")
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(MissingApiKeyError):


### PR DESCRIPTION
Users were not able to pass custom args to the client instantiation.

Make it part of `CompletionParams` for `(a)completion` and a explicit kwarg for the rest of methods.