### PR TITLE
fix: allow for malformed messages to be passed to mistral

### DIFF
--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -340,10 +340,6 @@ def _patch_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for i, msg in enumerate(messages):
         processed_msg.append(msg)
         if msg.get("role") == "tool":
-            if i > 0 and messages[i - 1].get("role") != "assistant":
-                # Use a different variable name for the error message
-                error_msg = "A tool message must be preceded by an assistant message with tool_calls."
-                raise ValueError(error_msg)
             if i + 1 < len(messages) and messages[i + 1].get("role") == "user":
                 # Mistral expects an assistant message after a tool message
                 processed_msg.append({"role": "assistant", "content": "OK"})

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import pytest
-
 from any_llm.providers.mistral.utils import _patch_messages
 
 
@@ -73,16 +71,6 @@ def test_patch_messages_no_insertion_when_next_not_user() -> None:
     ]
     out = _patch_messages(messages)
     assert out == messages
-
-
-def test_patch_messages_with_invalid_tool_sequence_raises_error() -> None:
-    """Test that an invalid tool message sequence raises a ValueError."""
-    messages: list[dict[str, Any]] = [
-        {"role": "user", "content": "u1"},
-        {"role": "tool", "content": "t1"},
-    ]
-    with pytest.raises(ValueError, match="A tool message must be preceded by an assistant message with tool_calls."):
-        _patch_messages(messages)
 
 
 def test_patch_messages_with_multiple_valid_tool_calls() -> None:


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
In order to reduce confusion, any-llm won't prevent people from making a call to mistral with a tool message with no assistant message before it. Then, if Mistral throws an exception it is clear that it is not any-llm that has the limitation

## PR Type

<!-- Delete the types that don't apply --!>

🐛 Bug Fix
💅 Refactor

## Relevant issues

<!-- e.g. "Fixes #123" -->
Relates to https://github.com/mozilla-ai/any-agent/issues/787

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
