### PR TITLE
fix: accept an expected_providers env var

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Run Integration tests (parallel with xdist)
         env:
+          # When you add a new key, also add the provider name to the EXPECTED_PROVIDERS environment variable
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
@@ -71,6 +72,7 @@ jobs:
           WATSONX_API_KEY: ${{ secrets.WATSONX_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          EXPECTED_PROVIDERS: "anthropic,bedrock,cohere,databricks,fireworks,gemini,huggingface,llama,mistral,openai,voyage,watsonx,xai,openrouter"
         run: |
           if [ -n "${{ inputs.filter }}" ]; then
             pytest tests/integration -v -n auto --cov --cov-report=xml -k "${{ inputs.filter }}"

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -60,8 +60,6 @@ jobs:
           # When you add a new key, also add the provider name to the EXPECTED_PROVIDERS environment variable
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          CO_API_KEY: ${{ secrets.CO_API_KEY }}
-          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -72,7 +70,7 @@ jobs:
           WATSONX_API_KEY: ${{ secrets.WATSONX_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          EXPECTED_PROVIDERS: "anthropic,bedrock,cohere,databricks,fireworks,gemini,huggingface,llama,mistral,openai,voyage,watsonx,xai,openrouter"
+          EXPECTED_PROVIDERS: "anthropic,bedrock,fireworks,gemini,huggingface,llama,mistral,openai,voyage,watsonx,xai,openrouter"
         run: |
           if [ -n "${{ inputs.filter }}" ]; then
             pytest tests/integration -v -n auto --cov --cov-report=xml -k "${{ inputs.filter }}"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,3 +1,6 @@
+import os
 from any_llm.provider import ProviderName
 
 LOCAL_PROVIDERS = [ProviderName.LLAMACPP, ProviderName.OLLAMA, ProviderName.LMSTUDIO, ProviderName.LLAMAFILE]
+
+EXPECTED_PROVIDERS = os.environ.get("EXPECTED_PROVIDERS", "").split(",")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,4 +1,5 @@
 import os
+
 from any_llm.provider import ProviderName
 
 LOCAL_PROVIDERS = [ProviderName.LLAMACPP, ProviderName.OLLAMA, ProviderName.LMSTUDIO, ProviderName.LLAMAFILE]

--- a/tests/integration/test_completion.py
+++ b/tests/integration/test_completion.py
@@ -9,8 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion, ChatCompletionMessage
-from tests.constants import LOCAL_PROVIDERS
-
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 @pytest.mark.asyncio
 async def test_async_completion(
@@ -37,6 +36,8 @@ async def test_async_completion(
             ],
         )
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:
@@ -79,6 +80,9 @@ async def test_async_completion_parallel(
         assert "paris" in results[0].choices[0].message.content.lower()
         assert "berlin" in results[1].choices[0].message.content.lower()
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
+        print(EXPECTED_PROVIDERS)
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_completion.py
+++ b/tests/integration/test_completion.py
@@ -9,7 +9,8 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion, ChatCompletionMessage
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
+
 
 @pytest.mark.asyncio
 async def test_async_completion(
@@ -82,7 +83,6 @@ async def test_async_completion_parallel(
     except MissingApiKeyError:
         if provider in EXPECTED_PROVIDERS:
             raise
-        print(EXPECTED_PROVIDERS)
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_embedding.py
+++ b/tests/integration/test_embedding.py
@@ -8,6 +8,7 @@ from any_llm import ProviderName, aembedding
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import CreateEmbeddingResponse
+from tests.constants import EXPECTED_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -26,6 +27,8 @@ async def test_embedding_providers_async(
     try:
         result = await aembedding(model=model_id, provider=provider, **extra_kwargs, inputs="Hello world")
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         pytest.skip(f"{provider.value} connection failed, skipping")

--- a/tests/integration/test_list_models.py
+++ b/tests/integration/test_list_models.py
@@ -8,7 +8,7 @@ from any_llm import list_models
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory, ProviderName
 from any_llm.types.model import Model
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 
 def test_list_models(provider: ProviderName, provider_extra_kwargs_map: dict[ProviderName, dict[str, Any]]) -> None:
@@ -23,6 +23,8 @@ def test_list_models(provider: ProviderName, provider_extra_kwargs_map: dict[Pro
         assert isinstance(available_models, list)
         assert all(isinstance(model, Model) for model in available_models)
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_list_models.py
+++ b/tests/integration/test_list_models.py
@@ -8,7 +8,7 @@ from any_llm import list_models
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory, ProviderName
 from any_llm.types.model import Model
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
 def test_list_models(provider: ProviderName, provider_extra_kwargs_map: dict[ProviderName, dict[str, Any]]) -> None:

--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -37,7 +37,7 @@ async def test_completion_reasoning(
         )
     except MissingApiKeyError:
         if provider in EXPECTED_PROVIDERS:
-                raise
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -36,6 +36,8 @@ async def test_completion_reasoning(
             messages=[{"role": "user", "content": "Please say hello! Think very briefly before you respond."}],
         )
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+                raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:
@@ -90,6 +92,8 @@ async def test_completion_reasoning_streaming(
 
         assert reasoning.strip() != "", f"Expected non-empty reasoning content for {provider.value}"
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_response_format.py
+++ b/tests/integration/test_response_format.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_response_format.py
+++ b/tests/integration/test_response_format.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletion
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -48,6 +48,8 @@ async def test_response_format(
         output = ResponseFormat.model_validate_json(result.choices[0].message.content)
         assert "paris" in output.city_name.lower()
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except UnsupportedParameterError:
         pytest.skip(f"{provider.value} does not support response_format, skipping")

--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -8,7 +8,7 @@ from any_llm import ProviderName, aresponses
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.responses import Response
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -8,7 +8,7 @@ from any_llm import ProviderName, aresponses
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
 from any_llm.types.responses import Response
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -31,6 +31,8 @@ async def test_responses_async(
             instructions="Talk like a pirate.",
         )
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletionChunk
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -9,7 +9,7 @@ from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.provider import ProviderFactory
 from any_llm.types.completion import ChatCompletionChunk
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 
 @pytest.mark.asyncio
@@ -53,6 +53,8 @@ async def test_streaming_completion_async(
             msg = f"Expected AsyncIterator[ChatCompletionChunk], not {type(stream)}"
             raise TypeError(msg)
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except UnsupportedParameterError:
         pytest.skip(f"Streaming is not supported for {provider.value}")

--- a/tests/integration/test_tool.py
+++ b/tests/integration/test_tool.py
@@ -8,7 +8,7 @@ from openai import APIConnectionError
 from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
-from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 if TYPE_CHECKING:
     from any_llm.types.completion import ChatCompletion, ChatCompletionMessage

--- a/tests/integration/test_tool.py
+++ b/tests/integration/test_tool.py
@@ -8,7 +8,7 @@ from openai import APIConnectionError
 from any_llm import ProviderName, acompletion
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.provider import ProviderFactory
-from tests.constants import LOCAL_PROVIDERS
+from tests.constants import LOCAL_PROVIDERS, EXPECTED_PROVIDERS
 
 if TYPE_CHECKING:
     from any_llm.types.completion import ChatCompletion, ChatCompletionMessage
@@ -77,6 +77,8 @@ async def test_tool(
         )
         assert second_result.choices[0].message
     except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
         pytest.skip(f"{provider.value} API key not provided, skipping")
     except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
         if provider in LOCAL_PROVIDERS:


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
This PR adds support for an env var that gets passed between integration test and the github action to not let tests fail if the key is expected to be there. This helps prevent tests being silently skipped. 

## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix
💅 Refactor

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
