### PR TITLE
fix: local tests shouldnt run nonlocal providers

### DIFF
--- a/.github/workflows/tests-integration-local.yaml
+++ b/.github/workflows/tests-integration-local.yaml
@@ -82,6 +82,7 @@ jobs:
       - name: Run Local Provider Integration tests (parallel with xdist)
         env:
           INCLUDE_LOCAL_PROVIDERS: "true"
+          INCLUDE_NON_LOCAL_PROVIDERS: "false"
           EXPECTED_PROVIDERS: "ollama,llamafile"
         run: |
           if [ -n "${{ inputs.filter }}" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from any_llm.provider import ProviderName
-from tests.constants import INCLUDE_LOCAL_PROVIDERS, LOCAL_PROVIDERS
+from tests.constants import EXPECTED_PROVIDERS, INCLUDE_LOCAL_PROVIDERS, INCLUDE_NON_LOCAL_PROVIDERS, LOCAL_PROVIDERS
 
 
 @pytest.fixture
@@ -127,11 +127,20 @@ def provider_extra_kwargs_map() -> dict[ProviderName, dict[str, Any]]:
 
 
 def _get_providers_for_testing() -> list[ProviderName]:
-    """Get the list of providers to test based on INCLUDE_LOCAL_PROVIDERS setting."""
+    """Get the list of providers to test based on INCLUDE_LOCAL_PROVIDERS and INCLUDE_NON_LOCAL_PROVIDERS settings."""
     all_providers = list(ProviderName)
-    if INCLUDE_LOCAL_PROVIDERS:
-        return all_providers  # type: ignore[return-value]
-    return [provider for provider in all_providers if provider not in LOCAL_PROVIDERS]  # type: ignore[misc]
+
+    filtered = (
+        [provider for provider in all_providers if provider in LOCAL_PROVIDERS]
+        if INCLUDE_LOCAL_PROVIDERS
+        else [provider for provider in all_providers if provider not in LOCAL_PROVIDERS]
+    )
+
+    return (
+        [provider for provider in filtered if provider not in EXPECTED_PROVIDERS]
+        if INCLUDE_NON_LOCAL_PROVIDERS
+        else [provider for provider in filtered if provider in EXPECTED_PROVIDERS]
+    )
 
 
 @pytest.fixture(params=_get_providers_for_testing(), ids=lambda x: x.value)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -7,3 +7,5 @@ LOCAL_PROVIDERS = [ProviderName.LLAMACPP, ProviderName.OLLAMA, ProviderName.LMST
 EXPECTED_PROVIDERS = os.environ.get("EXPECTED_PROVIDERS", "").split(",")
 
 INCLUDE_LOCAL_PROVIDERS = os.getenv("INCLUDE_LOCAL_PROVIDERS", "true").lower() in ("true", "1", "t")
+
+INCLUDE_NON_LOCAL_PROVIDERS = os.getenv("INCLUDE_NON_LOCAL_PROVIDERS", "true").lower() in ("true", "1", "t")


### PR DESCRIPTION
Added INCLUDE_NON_LOCAL_PROVIDERS environment variable to control the inclusion of non-local providers in testing. Updated the provider selection logic to accommodate this new setting, ensuring more flexible and accurate testing scenarios.

## Description
<!-- What does this PR do? -->


## PR Type

<!-- Delete the types that don't apply --!>

💅 Refactor

🚦 Infrastructure

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
