### PR TITLE
fix(vertexai): Don't use custom env vars.

### DIFF
--- a/src/any_llm/providers/vertexai/vertexai.py
+++ b/src/any_llm/providers/vertexai/vertexai.py
@@ -1,8 +1,6 @@
-import os
 from typing import TYPE_CHECKING
 
 from any_llm.config import ClientConfig
-from any_llm.exceptions import MissingApiKeyError
 from any_llm.providers.gemini.base import GoogleProvider
 
 if TYPE_CHECKING:
@@ -20,16 +18,7 @@ class VertexaiProvider(GoogleProvider):
         """Get Vertex AI client."""
         from google import genai
 
-        project_id = os.getenv("GOOGLE_PROJECT_ID")
-        location = os.getenv("GOOGLE_REGION", "us-central1")
-
-        if not project_id:
-            msg = "Google Vertex AI"
-            raise MissingApiKeyError(msg, "GOOGLE_PROJECT_ID")
-
         return genai.Client(
             vertexai=True,
-            project=project_id,
-            location=location,
             **(config.client_args if config.client_args else {}),
         )


### PR DESCRIPTION
The underlying `genai` library already handles getting the values from expected env vars .

In addition the values we are currently hardcoding don't match the ones used in the library:
- Us: `GOOGLE_PROJECT_ID` / They: `GOOGLE_CLOUD_PROJECT`
- Us: `GOOGLE_REGION` / They: `GOOGLE_CLOUD_LOCATION`
