### PR TITLE
refactor(sambanova): Drop `instructor` usage.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,6 @@ together = [
   "together",
 ]
 
-sambanova = [
-  "instructor",
-]
-
 ollama = [
   "ollama>=0.5.1"
 ]
@@ -94,19 +90,20 @@ sagemaker = [
 
 # These providers don't require any additional dependencies, but are included for completeness.
 azureopenai = []
-moonshot = []
-nebius = []
 databricks = []
 deepseek = []
 fireworks = []
 inception = []
-openai = []
-portkey = []
-openrouter = []
-lmstudio = []
 llama = []
-llamafile = []
 llamacpp = []
+llamafile = []
+lmstudio = []
+moonshot = []
+nebius = []
+openai = []
+openrouter = []
+portkey = []
+sambanova = []
 
 [project.urls]
 Documentation = "https://mozilla-ai.github.io/any-llm/"

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -166,7 +166,6 @@ def test_providers_raise_MissingApiKeyError(provider: LLMProvider) -> None:
         ("huggingface", "huggingface_hub"),
         ("mistral", "mistralai"),
         ("ollama", "ollama"),
-        ("sambanova", "instructor"),
         ("together", "together"),
         ("voyage", "voyageai"),
         ("watsonx", "ibm_watsonx_ai"),


### PR DESCRIPTION
Native `response_format` is supposed to work with the openai-compatible API: https://docs.sambanova.ai/docs/en/api-reference/endpoints/chat#function-calling-parameters
