### PR TITLE
refactor: Drop `api_base` getenv for providers inheriting from `BaseO…

### DIFF
--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -1,5 +1,3 @@
-import os
-
 from any_llm.config import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
@@ -18,5 +16,4 @@ class LmstudioProvider(BaseOpenAIProvider):
 
     def _verify_and_set_api_key(self, config: ClientConfig) -> ClientConfig:
         config.api_key = ""
-        config.api_base = config.api_base or os.getenv("LMSTUDIO_API_URL")
         return config

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -27,7 +26,6 @@ if TYPE_CHECKING:
     from ollama import AsyncClient  # noqa: TC004
     from ollama import ChatResponse as OllamaChatResponse
 
-    from any_llm.config import ClientConfig
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
     from any_llm.types.model import Model
 
@@ -101,10 +99,6 @@ class OllamaProvider(AnyLLM):
         self.client = AsyncClient(
             host=self.config.api_base, **(self.config.client_args if self.config.client_args else {})
         )
-
-    def _verify_and_set_api_key(self, config: ClientConfig) -> ClientConfig:
-        config.api_base = config.api_base or os.getenv("OLLAMA_API_URL")
-        return config
 
     def _extract_images_from_message(self, message: dict[str, Any]) -> tuple[str, list[str]]:
         """

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import AsyncIterator, Sequence
 from typing import Any, Literal, cast
 
@@ -104,7 +103,7 @@ class BaseOpenAIProvider(AnyLLM):
 
     def _init_client(self) -> None:
         self.client = AsyncOpenAI(
-            base_url=self.config.api_base or self.API_BASE or os.getenv("OPENAI_API_BASE"),
+            base_url=self.config.api_base or self.API_BASE,
             api_key=self.config.api_key,
             **(self.config.client_args if self.config.client_args else {}),
         )

--- a/src/any_llm/providers/perplexity/perplexity.py
+++ b/src/any_llm/providers/perplexity/perplexity.py
@@ -1,6 +1,3 @@
-import os
-
-from any_llm.config import ClientConfig
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
 
@@ -19,10 +16,3 @@ class PerplexityProvider(BaseOpenAIProvider):
     SUPPORTS_RESPONSES = False
     SUPPORTS_COMPLETION_REASONING = False
     SUPPORTS_EMBEDDING = False
-
-    def __init__(self, config: ClientConfig) -> None:
-        super().__init__(config)
-        # Override API_BASE if provided in config or environment
-        base = config.api_base or os.getenv("PERPLEXITY_API_BASE")
-        if base:
-            self.API_BASE = base

--- a/tests/unit/providers/test_perplexity_provider.py
+++ b/tests/unit/providers/test_perplexity_provider.py
@@ -50,10 +50,3 @@ def test_provider_metadata() -> None:
     assert metadata.streaming is True
     assert metadata.embedding is False
     assert metadata.responses is False
-
-
-def test_perplexity_api_base_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that PERPLEXITY_API_BASE environment variable overrides the default API base."""
-    monkeypatch.setenv("PERPLEXITY_API_BASE", "https://example-proxy.local")
-    p = AnyLLM.create("perplexity", ClientConfig(api_key="dummy"))
-    assert getattr(p, "API_BASE", "") == "https://example-proxy.local"


### PR DESCRIPTION
…penAIProvider`
