### PR TITLE
tests: Fix `test_list_models` for `huggingface`.

### DIFF
--- a/tests/integration/test_list_models.py
+++ b/tests/integration/test_list_models.py
@@ -13,7 +13,11 @@ from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 def test_list_models(provider: LLMProvider, provider_client_config: dict[LLMProvider, dict[str, Any]]) -> None:
     """Test that all supported providers can be loaded successfully."""
     try:
-        llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
+        config = provider_client_config.get(provider, {})
+        if provider == "huggingface":
+            # We don't want to use the custom endpoint for listing models
+            config.pop("api_base")
+        llm = AnyLLM.create(provider, **config)
         if not llm.SUPPORTS_LIST_MODELS:
             pytest.skip(f"{provider.value} does not support listing models, skipping")
 


### PR DESCRIPTION
We don't want to use the `api_base` used for completion.