### PR TITLE
Allow override of allow_running_loop parameter 

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -304,7 +304,8 @@ class AnyLLM(ABC):
 
         See [AnyLLM.acompletion][any_llm.any_llm.AnyLLM.acompletion]
         """
-        response = run_async_in_sync(self.acompletion(**kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        allow_running_loop = kwargs.pop("allow_running_loop", INSIDE_NOTEBOOK)
+        response = run_async_in_sync(self.acompletion(**kwargs), allow_running_loop=allow_running_loop)
         if isinstance(response, ChatCompletion):
             return response
 
@@ -398,7 +399,8 @@ class AnyLLM(ABC):
 
         See [AnyLLM.aresponses][any_llm.any_llm.AnyLLM.aresponses]
         """
-        response = run_async_in_sync(self.aresponses(**kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        allow_running_loop = kwargs.pop("allow_running_loop", INSIDE_NOTEBOOK)
+        response = run_async_in_sync(self.aresponses(**kwargs), allow_running_loop=allow_running_loop)
         if isinstance(response, Response):
             return response
         return async_iter_to_sync_iter(response)
@@ -473,7 +475,8 @@ class AnyLLM(ABC):
         raise NotImplementedError(msg)
 
     def _embedding(self, model: str, inputs: str | list[str], **kwargs: Any) -> CreateEmbeddingResponse:
-        return run_async_in_sync(self.aembedding(model, inputs, **kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        allow_running_loop = kwargs.pop("allow_running_loop", INSIDE_NOTEBOOK)
+        return run_async_in_sync(self.aembedding(model, inputs, **kwargs), allow_running_loop=allow_running_loop)
 
     async def aembedding(self, model: str, inputs: str | list[str], **kwargs: Any) -> CreateEmbeddingResponse:
         return await self._aembedding(model, inputs, **kwargs)
@@ -486,7 +489,8 @@ class AnyLLM(ABC):
         raise NotImplementedError(msg)
 
     def list_models(self, **kwargs: Any) -> Sequence[Model]:
-        return run_async_in_sync(self.alist_models(**kwargs), allow_running_loop=INSIDE_NOTEBOOK)
+        allow_running_loop = kwargs.pop("allow_running_loop", INSIDE_NOTEBOOK)
+        return run_async_in_sync(self.alist_models(**kwargs), allow_running_loop=allow_running_loop)
 
     async def alist_models(self, **kwargs: Any) -> Sequence[Model]:
         return await self._alist_models(**kwargs)


### PR DESCRIPTION
## Description

With @daavoo when debugging the failing integration tests for smolagents + any_llm (PR-), we found that `test_run_agent_concurrently[SMOLAGENTS] ` [was failing](https://github.com/mozilla-ai/any-agent/actions/runs/17827893793/job/50685347617).
This could be fixed by letting users to override `allow_running_loop` instead of setting it always to the global variable `INSIDE_NOTEBOOK` when calling `run_async_in_sync`.

Note that the default behavior remains to use `INSIDE_NOTEBOOK`, hence it should be backward compatible. 
