### PR TITLE
feat: Add support for `BUILT_IN_TOOLS`.

### DIFF
--- a/src/any_llm/tools.py
+++ b/src/any_llm/tools.py
@@ -236,11 +236,15 @@ def _python_type_to_json_schema(python_type: Any) -> dict[str, Any]:
     return {"type": "string"}
 
 
-def prepare_tools(tools: list[dict[str, Any] | Callable[..., Any]]) -> list[dict[str, Any]]:
+def prepare_tools(
+    tools: list[dict[str, Any] | Callable[..., Any] | Any], built_in_tools: list[Any] | None = None
+) -> list[dict[str, Any] | Any]:
     """Prepare tools for completion API by converting callables to OpenAI format.
 
     Args:
         tools: List of tools, can be mix of callables and already formatted tool dicts
+        built_in_tools: Optional list of built-in tool instances to include as-is
+            For example, in `gemini` provider, you can pass `types.Tool(google_search=types.GoogleSearch())`.
 
     Returns:
         List of tools in OpenAI format
@@ -257,7 +261,9 @@ def prepare_tools(tools: list[dict[str, Any] | Callable[..., Any]]) -> list[dict
     prepared_tools = []
 
     for tool in tools:
-        if callable(tool):
+        if built_in_tools and any(isinstance(tool, b) for b in built_in_tools):
+            prepared_tools.append(tool)
+        elif callable(tool):
             prepared_tools.append(callable_to_tool(tool))
         elif isinstance(tool, dict):
             prepared_tools.append(tool)

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -90,7 +90,7 @@ class CompletionParams(BaseModel):
             raise ValueError(msg)
         return v
 
-    tools: list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any] | Any] | None = None
     """List of tools for tool calling. Should be converted to OpenAI tool format dicts"""
 
     tool_choice: str | dict[str, Any] | None = None

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -234,3 +234,19 @@ def test_callable_to_tool() -> None:
     assert "oneOf" in props["union_three"]
     assert len(props["union_three"]["oneOf"]) == 3
     assert {s["type"] for s in props["union_three"]["oneOf"]} == {"string", "number", "boolean"}
+
+
+def test_prepare_tools_with_built_in() -> None:
+    """Test prepare_tools respects built-in tools."""
+
+    class BuiltInTool:
+        pass
+
+    def custom_tool(x: int) -> int:
+        """A custom tool."""
+        return x
+
+    tools = prepare_tools([BuiltInTool(), custom_tool], built_in_tools=[BuiltInTool])
+    assert len(tools) == 2
+    assert isinstance(tools[0], BuiltInTool)
+    assert tools[1]["function"]["name"] == "custom_tool"


### PR DESCRIPTION
Expose AnyLLM.BUILT_IN_TOOLS class var to allow providers to specify classes that will not be converted during prepare_tools.

This is pre-requisite for #490
