### PR TITLE
Make any_llm.__version__ attribute available

### DIFF
--- a/src/any_llm/__init__.py
+++ b/src/any_llm/__init__.py
@@ -1,6 +1,16 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from any_llm.any_llm import AnyLLM
 from any_llm.api import acompletion, aembedding, alist_models, aresponses, completion, embedding, list_models, responses
 from any_llm.constants import LLMProvider
+
+try:
+    __version__ = version("any-llm-sdk")
+except PackageNotFoundError:
+    # In the case of local development
+    # i.e., running directly from the source directory without package being installed
+    __version__ = "0.0.0-dev"
+
 
 __all__ = [
     "AnyLLM",


### PR DESCRIPTION
Can be tested in the env where any-llm is installed by doing:
```
python -c "import any_llm; print(any_llm.__version__)"
```