### PR TITLE
feat(deepseek): add reasoning support

### DIFF
--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -15,6 +15,7 @@ class DeepseekProvider(BaseOpenAIProvider):
     SUPPORTS_COMPLETION_IMAGE = False
     SUPPORTS_COMPLETION_PDF = False
     SUPPORTS_EMBEDDING = False  # DeepSeek doesn't host an embedding model
+    SUPPORTS_COMPLETION_REASONING = True
 
     async def _acompletion(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.LMSTUDIO: "openai/gpt-oss-20b",  # You must have LM Studio running and the server enabled
         LLMProvider.AZUREOPENAI: "azure/<your_deployment_name>",
         LLMProvider.COHERE: "command-a-reasoning-08-2025",
+        LLMProvider.DEEPSEEK: "deepseek-reasoner",
     }
 
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
The base openai `_normalize_reasoning_on_message` already handles Deepseek, all we needed to do is flip it on and add the test

## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [x] I have added unit tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
