### PR TITLE
feat(portkey): completion reasoning

### DIFF
--- a/src/any_llm/providers/portkey/portkey.py
+++ b/src/any_llm/providers/portkey/portkey.py
@@ -1,4 +1,17 @@
+from collections.abc import AsyncIterator
+from typing import Any
+
+from openai._streaming import AsyncStream
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
+from pydantic import BaseModel
+
 from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.providers.portkey.utils import _convert_chat_completion, _convert_chat_completion_chunk
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, Reasoning
+from any_llm.utils.reasoning import (
+    process_streaming_reasoning_chunks,
+)
 
 
 class PortkeyProvider(BaseOpenAIProvider):
@@ -17,3 +30,63 @@ class PortkeyProvider(BaseOpenAIProvider):
     SUPPORTS_LIST_MODELS = True
 
     _DEFAULT_REASONING_EFFORT = None
+
+    @staticmethod
+    def _convert_completion_response(response: Any) -> ChatCompletion:
+        if isinstance(response, OpenAIChatCompletion):
+            return _convert_chat_completion(response)
+        if isinstance(response, ChatCompletion):
+            return response
+        return ChatCompletion.model_validate(response)
+
+    @staticmethod
+    def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
+        if isinstance(response, OpenAIChatCompletionChunk):
+            return _convert_chat_completion_chunk(response)
+        if isinstance(response, ChatCompletionChunk):
+            return response
+        return ChatCompletionChunk.model_validate(response)
+
+    def _convert_completion_response_async(
+        self, response: OpenAIChatCompletion | AsyncStream[OpenAIChatCompletionChunk]
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        """Convert an OpenAI completion response with streaming reasoning support."""
+        if isinstance(response, OpenAIChatCompletion):
+            return self._convert_completion_response(response)
+
+        async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
+            async for chunk in response:
+                yield self._convert_completion_chunk_response(chunk)
+
+        def get_content(chunk: ChatCompletionChunk) -> str | None:
+            return chunk.choices[0].delta.content if len(chunk.choices) > 0 else None
+
+        def set_content(chunk: ChatCompletionChunk, content: str | None) -> ChatCompletionChunk:
+            chunk.choices[0].delta.content = content
+            return chunk
+
+        def set_reasoning(chunk: ChatCompletionChunk, reasoning: str) -> ChatCompletionChunk:
+            chunk.choices[0].delta.reasoning = Reasoning(content=reasoning)
+            return chunk
+
+        return process_streaming_reasoning_chunks(
+            chunk_iterator(),
+            get_content=get_content,
+            set_content=set_content,
+            set_reasoning=set_reasoning,
+        )
+
+    @staticmethod
+    def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
+        """Convert CompletionParams to kwargs for OpenAI API."""
+        if isinstance(params.response_format, type) and issubclass(params.response_format, BaseModel):
+            params.response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response_schema",
+                    "schema": params.response_format.model_json_schema(),
+                },
+            }
+        converted_params = params.model_dump(exclude_none=True, exclude={"model_id", "messages"})
+        converted_params.update(kwargs)
+        return converted_params

--- a/src/any_llm/providers/portkey/utils.py
+++ b/src/any_llm/providers/portkey/utils.py
@@ -1,0 +1,37 @@
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
+
+from any_llm.providers.openai.utils import _normalize_openai_dict_response
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
+from any_llm.utils.reasoning import normalize_reasoning_from_provider_fields_and_xml_tags
+
+
+def _convert_chat_completion(response: OpenAIChatCompletion) -> ChatCompletion:
+    response_dict = _normalize_openai_dict_response(response.model_dump())
+
+    choices = response_dict.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            message = choice.get("message") if isinstance(choice, dict) else None
+            if isinstance(message, dict):
+                normalize_reasoning_from_provider_fields_and_xml_tags(message)
+
+            delta = choice.get("delta") if isinstance(choice, dict) else None
+            if isinstance(delta, dict):
+                normalize_reasoning_from_provider_fields_and_xml_tags(delta)
+
+    return ChatCompletion.model_validate(response_dict)
+
+
+def _convert_chat_completion_chunk(response: OpenAIChatCompletionChunk) -> ChatCompletionChunk:
+    response_dict = _normalize_openai_dict_response(response.model_dump())
+
+    choices = response_dict.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            delta = choice.get("delta") if isinstance(choice, dict) else None
+            if isinstance(delta, dict):
+                normalize_reasoning_from_provider_fields_and_xml_tags(delta)
+
+    response_dict["object"] = "chat.completion.chunk"
+    return ChatCompletionChunk.model_validate(response_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.NEBIUS: "openai/gpt-oss-20b",
         LLMProvider.SAMBANOVA: "DeepSeek-R1-Distill-Llama-70B",
         LLMProvider.TOGETHER: "OpenAI/gpt-oss-20B",
+        LLMProvider.PORTKEY: "@anthropic/claude-3-7-sonnet-latest",
     }
 
 

--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -40,8 +40,10 @@ async def test_completion_reasoning(
                 LLMProvider.PORTKEY,
                 LLMProvider.SAMBANOVA,
                 LLMProvider.TOGETHER,
+                LLMProvider.PORTKEY,
             )
             else "auto",
+            max_tokens=100,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
         )
     except MissingApiKeyError:
         if provider in EXPECTED_PROVIDERS:
@@ -94,6 +96,7 @@ async def test_completion_reasoning_streaming(
                 LLMProvider.TOGETHER,
             )
             else "auto",
+            max_tokens=100,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
         )
         assert isinstance(results, AsyncIterable)
         async for result in results:


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
Portkey docs show that it supports returning:

https://portkey.ai/docs/product/ai-gateway/multimodal-capabilities/thinking-mode#understanding-response-format

I need to make some changes to support and test this but I'm waiting for our portkey account to support a model that outputs thinking, that way I can edit the portkey response as needed.

## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix
💅 Refactor
📚 Documentation
🚦 Infrastructure

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
