### PR TITLE
chore: fix anthropic integration test

### DIFF
--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -7,6 +7,7 @@ from openai import APIConnectionError
 
 from any_llm import AnyLLM, LLMProvider
 from any_llm.exceptions import MissingApiKeyError
+from any_llm.providers.anthropic.utils import DEFAULT_MAX_TOKENS
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
@@ -43,7 +44,7 @@ async def test_completion_reasoning(
                 LLMProvider.PORTKEY,
             )
             else "auto",
-            max_tokens=100,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
+            max_tokens=DEFAULT_MAX_TOKENS,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
         )
     except MissingApiKeyError:
         if provider in EXPECTED_PROVIDERS:
@@ -96,7 +97,7 @@ async def test_completion_reasoning_streaming(
                 LLMProvider.TOGETHER,
             )
             else "auto",
-            max_tokens=100,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
+            max_tokens=DEFAULT_MAX_TOKENS,  # Portkey with anthropic needed a max tokens value to be set (because it's an anthropic model)
         )
         assert isinstance(results, AsyncIterable)
         async for result in results:


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
Integration tests didn't like my max_tokens setting nthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': '`max_tokens` must be greater than `thinking.budget_tokens`

## PR Type

<!-- Delete the types that don't apply --!>

🆕 New Feature
🐛 Bug Fix
💅 Refactor
📚 Documentation
🚦 Infrastructure

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
