### PR TITLE
Remove extra backticks from the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@
 - [ ] I have added unit tests that prove my fix/feature works
 - [ ] New and existing tests pass locally
 - [ ] Documentation was updated where necessary
-- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)```
+- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Description

Looks like there are a couple of extra backticks in the PR template.


## PR Type

🚦 Infrastructure

## Relevant issues

N/A

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
