### PR TITLE
fix(GatewayConfig): Set `extra="ignore"`.

### DIFF
--- a/src/any_llm/gateway/config.py
+++ b/src/any_llm/gateway/config.py
@@ -23,6 +23,7 @@ class GatewayConfig(BaseSettings):
         env_prefix="GATEWAY_",
         env_file=".env",
         case_sensitive=False,
+        extra="ignore",
     )
 
     database_url: str = Field(


### PR DESCRIPTION
Allow to run tests locally with custom `.env` files.
