### PR TITLE
fix(minimax): Skip chunk contents with no delta.

### DIFF
--- a/src/any_llm/providers/minimax/minimax.py
+++ b/src/any_llm/providers/minimax/minimax.py
@@ -41,7 +41,9 @@ class MinimaxProvider(BaseOpenAIProvider):
 
         async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
             async for chunk in response:
-                yield self._convert_completion_chunk_response(chunk)
+                if isinstance(chunk, OpenAIChatCompletionChunk):
+                    if chunk.choices and chunk.choices[0].delta:
+                        yield self._convert_completion_chunk_response(chunk)
 
         def get_content(chunk: ChatCompletionChunk) -> str | None:
             return chunk.choices[0].delta.content if len(chunk.choices) > 0 else None


### PR DESCRIPTION
Apparently the minimax API returns a final chunk for the `finish_reason` where the `delta` is None, which was causing our code to break while trying to validate the Pydantic model.