### PR TITLE
Fix the minimal config example in gateway documentation

### DIFF
--- a/docs/gateway/quickstart.md
+++ b/docs/gateway/quickstart.md
@@ -46,6 +46,8 @@ cp docker/config.example.yml docker/config.yml
 At a minimum you'll need to fill out the value for the master_key, and also enter credential information for at least one provider. You can browse supported providers [here](https://mozilla-ai.github.io/any-llm/providers/). If you would like to track usage cost, you'll also need to configure model pricing, as explained in the config template file.
 
 ```yaml
+database_url: "postgresql://gateway:gateway@postgres:5432/gateway"
+
 master_key: 09kS0xTiz6JqO....
 
 providers:


### PR DESCRIPTION
## Description

It adds the `database_url` in the minimal config example to build a gateway server from docker compose.

If not provided, the gateway server logs errors:

```
gateway_1   | sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: Connection refused
gateway_1   | 	Is the server running on that host and accepting TCP/IP connections?
gateway_1   | connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
gateway_1   | 	Is the server running on that host and accepting TCP/IP connections?
```

## PR Type

<!-- Delete the types that don't apply --!>

📚 Documentation

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
