### PR TITLE
fix(dep): add missing requests dependency for platform build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ platform = [
   "bcrypt>=5.0.0",
   "cryptography>=46.0.3",
   "pynacl>=1.6.0",
+  "requests>=2.32.5",
 ]
 
 perplexity = []


### PR DESCRIPTION
## Description

This adds the requests dependency in the build for platform. Requests is used in the utils.py file and on a fresh run of any-llm on a clean environment, it is not working 😢 

## PR Type

🐛 Bug Fix

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist
- [ ] I have added unit tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
