### PR TITLE
fix(platform): Cleanup dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,7 @@ all = [
 ]
 
 platform = [
-  "typing-extensions",
-  "bcrypt>=5.0.0",
-  "cryptography>=46.0.3",
   "pynacl>=1.6.0",
-  "requests>=2.32.5",
 ]
 
 perplexity = []

--- a/src/any_llm/providers/platform/utils.py
+++ b/src/any_llm/providers/platform/utils.py
@@ -7,15 +7,13 @@ import re
 import uuid
 from typing import TYPE_CHECKING, Any
 
+import httpx
 import nacl.bindings
 import nacl.public
-import requests
 
 from any_llm.logging import logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from any_llm.any_llm import AnyLLM
     from any_llm.types.completion import ChatCompletion
 
@@ -60,7 +58,7 @@ def _create_challenge(public_key: str, any_api_url: str) -> Any:
     """Create an authentication challenge."""
     logger.info("Creating authentication challenge...")
 
-    response = requests.post(
+    response = httpx.post(
         f"{any_api_url}/auth/",
         json={
             "encryption_key": public_key,
@@ -131,7 +129,7 @@ def _fetch_provider_key(
     """Fetch the provider key using the solved challenge."""
     logger.info(f"Fetching provider key for {provider}...")
 
-    response = requests.get(
+    response = httpx.get(
         f"{any_api_url}/provider-keys/{provider}",
         headers={"encryption-key": public_key, "AnyLLM-Challenge-Response": str(solved_challenge)},
     )

--- a/tests/unit/providers/test_platform_provider.py
+++ b/tests/unit/providers/test_platform_provider.py
@@ -319,8 +319,8 @@ async def test_acompletion_streaming_success(
     assert call_args.kwargs["completion"].usage.total_tokens == 15
 
 
-@patch("any_llm.providers.platform.utils.requests.post")
-@patch("any_llm.providers.platform.utils.requests.get")
+@patch("any_llm.providers.platform.utils.httpx.post")
+@patch("any_llm.providers.platform.utils.httpx.get")
 @patch("any_llm.providers.platform.utils._solve_challenge")
 def test_get_provider_key_success(
     mock_solve_challenge: Mock,
@@ -363,7 +363,7 @@ def test_get_provider_key_success(
         mock_decrypt.assert_called_once()
 
 
-@patch("any_llm.providers.platform.utils.requests.post")
+@patch("any_llm.providers.platform.utils.httpx.post")
 def test_get_provider_key_invalid_api_key_format(mock_post: Mock) -> None:
     """Test error handling when ANY_LLM_KEY has invalid format."""
     invalid_key = "INVALID_KEY_FORMAT"
@@ -374,7 +374,7 @@ def test_get_provider_key_invalid_api_key_format(mock_post: Mock) -> None:
     mock_post.assert_not_called()
 
 
-@patch("any_llm.providers.platform.utils.requests.post")
+@patch("any_llm.providers.platform.utils.httpx.post")
 def test_get_provider_key_challenge_creation_failure(mock_post: Mock) -> None:
     """Test error handling when challenge creation fails."""
     any_llm_key = "ANY.v1.kid123.fingerprint456-YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY="
@@ -390,8 +390,8 @@ def test_get_provider_key_challenge_creation_failure(mock_post: Mock) -> None:
     mock_post.assert_called_once()
 
 
-@patch("any_llm.providers.platform.utils.requests.post")
-@patch("any_llm.providers.platform.utils.requests.get")
+@patch("any_llm.providers.platform.utils.httpx.post")
+@patch("any_llm.providers.platform.utils.httpx.get")
 @patch("any_llm.providers.platform.utils._solve_challenge")
 def test_get_provider_key_fetch_failure(
     mock_solve_challenge: Mock,
@@ -425,8 +425,8 @@ def test_get_provider_key_fetch_failure(
 
 
 @pytest.mark.asyncio
-@patch("any_llm.providers.platform.utils.requests.post")
-@patch("any_llm.providers.platform.utils.requests.get")
+@patch("any_llm.providers.platform.utils.httpx.post")
+@patch("any_llm.providers.platform.utils.httpx.get")
 @patch("any_llm.providers.platform.utils._solve_challenge")
 async def test_post_completion_usage_event_success(
     mock_solve_challenge: Mock,
@@ -515,7 +515,7 @@ async def test_post_completion_usage_event_success(
 
 
 @pytest.mark.asyncio
-@patch("any_llm.providers.platform.utils.requests.post")
+@patch("any_llm.providers.platform.utils.httpx.post")
 async def test_post_completion_usage_event_invalid_key_format(mock_post: Mock) -> None:
     """Test error handling when ANY_LLM_KEY has invalid format."""
     invalid_key = "INVALID_KEY_FORMAT"


### PR DESCRIPTION
- Drop unused dependencies. Requiring and pinning `bcrypt>5.0.0` causes problems with projects using `passlib` (i.e FastAPI templates).

- Replace `requests` with `httpx`. As it is a base dependency providing the same functionality we need.
