### PR TITLE
Patch: Azure OpenAI ResourceNotFoundError

### DIFF
--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -18,6 +18,6 @@ class AzureopenaiProvider(BaseOpenAIProvider):
             kwargs = {}
         client: AsyncAzureOpenAI = AsyncAzureOpenAI(azure_endpoint=api_base,
                                                     api_key=api_key,
-                                                    api_version=kwargs.pop('api-version', 'preview'),
+                                                    api_version=kwargs.pop('api_version', 'preview'),
                                                     **kwargs)
         self.client = client


### PR DESCRIPTION
Suggested: azureopenai resource not found issue by ensuring parameters are correctly propagated

## Description
While testing azureopenai, I encountered a “resource not found” error. During debugging, I observed that certain parameters were not being propagated correctly within the library. I introduced a small change to ensure the parameters are correctly applied, after which the Azure OpenAI calls functioned as expected. I have included these changes as a proposed PR. Kindly review and let me know if you have any feedback or suggestions for improvement.


## PR Type
🐛 Bug Fix


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks Azure OpenAI client initialization to ensure required parameters are applied correctly.
> 
> - Replace base `_init_client` delegation with direct `AsyncAzureOpenAI` construction using `azure_endpoint`, `api_key`, and `api_version` (from `kwargs`, default `preview`)
> - Remove prior `default_query` approach; now assigns the constructed client to `self.client`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2a57db2fcaee74391b5cd65e3236ed3a417351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->