### PR TITLE
fix: new hf package has stricter typing

### DIFF
--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -131,7 +131,7 @@ async def test_huggingface_extracts_think_tags_streaming() -> None:
                 choices=[
                     ChatCompletionStreamOutputChoice(
                         index=0,
-                        delta=ChatCompletionStreamOutputDelta(content=chunk_text, role="assistant" if i == 0 else None),
+                        delta=ChatCompletionStreamOutputDelta(content=chunk_text, role="assistant"),
                         finish_reason="stop" if i == len(chunks) - 1 else None,
                     )
                 ],


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
A new HF version has stricter typing and a unit test was trying to set role to None which is no longer allowed. That line doesn't have an impact on the test so it can be fixed.

## PR Type
<!-- Delete the types that don't apply -->

- 💅 Refactor

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Opus 4.5
- AI Developer Tool used: Cursor
- Any other info you'd like to share:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts unit test to comply with newer HuggingFace typing rules.
> 
> - In `test_huggingface_extracts_think_tags_streaming`, set `role="assistant"` on every streamed `delta` chunk instead of `None` for subsequent chunks
> - No production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be00357bbeeec7ccf8e8bec72767d91d0759eb5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->