### PR TITLE
docs: fix broken image path in gateway overview

### DIFF
--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -35,7 +35,7 @@ The gateway acts as a transparent proxy between your applications and LLM provid
   > Learn how to set up your secure master key [here](authentication.md)  
 
 <p align="center" width="100%">
-  <img src="../../images/gateway.png" alt="Diagram showing application connecting to gateway, which then routes to multiple LLM providers (OpenAI, Anthropic, Google, etc). The gateway interfaces with a PostgreSQL database for storing usage, budgets, and keys." width="70%" align="center"/>
+  <img src="../images/gateway.png" alt="Diagram showing application connecting to gateway, which then routes to multiple LLM providers (OpenAI, Anthropic, Google, etc). The gateway interfaces with a PostgreSQL database for storing usage, budgets, and keys." width="70%" align="center"/>
 </p>
 
 ## Key Features


### PR DESCRIPTION
## Description
Fixed image path for the architecture diagram that was preventing the diagram from loading at docs/gateway/overview.md. Changed the relative path from '../../images/gateway.png' to '../images/gateway.png'.

## PR Type
- 📚 Documentation

## Relevant issues
None - saw this while reading the gateway documentation.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works (N/A - documentation fix)
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally (N/A - documentation fix)
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Sonnet 4.5
- AI Developer Tool used: Claude Code
