### PR TITLE
fix: let pydantic ValidationError bubble up unchanged

### DIFF
--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,0 +1,27 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from any_llm.utils.exception_handler import _handle_exception
+
+
+def test_validation_error_bubbles_up_unchanged() -> None:
+    """Test that pydantic ValidationError bubbles up unchanged.
+
+    When using response_format with a Pydantic model, the SDK validates the response
+    internally. If the LLM produces output that doesn't conform to the schema, pydantic
+    raises ValidationError. This should bubble up unchanged.
+    See: https://github.com/mozilla-ai/any-llm/issues/799
+    """
+
+    class Sample(BaseModel):
+        value: str
+
+    with pytest.raises(ValidationError) as exc_info:
+        Sample.model_validate({"value": 123})
+
+    original = exc_info.value
+
+    with pytest.raises(ValidationError) as raised:
+        _handle_exception(original, "openai")
+
+    assert raised.value is original


### PR DESCRIPTION
## Description

When using `response_format` with a Pydantic model, the clients validate the response internally. If the LLM produces output that doesn't conform to the schema, it raises a `pydantic.ValidationError`. This was incorrectly being converted to `InvalidRequestError` because "validation" matched a regex in the exception translation layer.

Now `ValidationError` bubbles up unchanged.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #799

## Note

All existing exception handler tests were testing provider specific handling, this is the first "provider"-agnostic exception handling quirk so I created a dedicated testing module just for this, open to other testing strategies for this.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.