### PR TITLE
Add max_completion_tokens to gateway ChatCompletionRequest

### DIFF
--- a/src/any_llm/gateway/routes/chat.py
+++ b/src/any_llm/gateway/routes/chat.py
@@ -29,6 +29,7 @@ class ChatCompletionRequest(BaseModel):
     user: str | None = None
     temperature: float | None = None
     max_tokens: int | None = None
+    max_completion_tokens: int | None = None
     top_p: float | None = None
     stream: bool = False
     tools: list[dict[str, Any]] | None = None


### PR DESCRIPTION
## Summary
- Adds `max_completion_tokens: int | None = None` to the `ChatCompletionRequest` Pydantic model in the gateway's chat route
- Newer OpenAI models (o-series, gpt-5-nano, etc.) use `max_completion_tokens` instead of the legacy `max_tokens` parameter
- The SDK's `acompletion()` already supports this kwarg, but the gateway schema was silently stripping it from incoming requests since it wasn't declared on the model

## Details
OpenAI's newer reasoning models (`o1`, `o3-mini`, `gpt-5-nano`, etc.) reject requests that use `max_tokens` and require `max_completion_tokens` instead. Clients sending this field to the gateway get it dropped by Pydantic validation, causing either unbounded generation or provider errors.

This one-line addition to `ChatCompletionRequest` allows the field to pass through `model_dump()` into the `acompletion(**completion_kwargs)` call, which already handles it correctly.

## Test plan
- [ ] Verify existing `max_tokens` behavior is unchanged
- [ ] Send a request with `max_completion_tokens` set and confirm it reaches the provider
- [ ] Confirm schema validation still rejects unknown fields

