### PR TITLE
fix(gateway): raise error for unresolved env var references in config

### DIFF
--- a/tests/gateway/test_env_var_resolution.py
+++ b/tests/gateway/test_env_var_resolution.py
@@ -1,0 +1,57 @@
+"""Tests for environment variable resolution in config."""
+
+import os
+
+import pytest
+
+from any_llm.gateway.config import _resolve_env_vars
+
+
+def test_resolve_existing_env_var() -> None:
+    """Test that existing env vars are resolved."""
+    os.environ["TEST_RESOLVE_VAR"] = "resolved_value"
+    try:
+        result = _resolve_env_vars({"key": "${TEST_RESOLVE_VAR}"})
+        assert result["key"] == "resolved_value"
+    finally:
+        del os.environ["TEST_RESOLVE_VAR"]
+
+
+def test_resolve_missing_env_var_raises() -> None:
+    """Test that missing env vars raise ValueError instead of using placeholder."""
+    # Ensure the var does not exist
+    os.environ.pop("DEFINITELY_MISSING_VAR", None)
+    with pytest.raises(ValueError, match="DEFINITELY_MISSING_VAR"):
+        _resolve_env_vars({"key": "${DEFINITELY_MISSING_VAR}"})
+
+
+def test_resolve_nested_dict() -> None:
+    """Test that env vars are resolved recursively in nested dicts."""
+    os.environ["TEST_NESTED_VAR"] = "nested_value"
+    try:
+        result = _resolve_env_vars({"outer": {"inner": "${TEST_NESTED_VAR}"}})
+        assert result["outer"]["inner"] == "nested_value"
+    finally:
+        del os.environ["TEST_NESTED_VAR"]
+
+
+def test_resolve_list_values() -> None:
+    """Test that env vars are resolved in list values."""
+    os.environ["TEST_LIST_VAR"] = "list_value"
+    try:
+        result = _resolve_env_vars({"items": ["${TEST_LIST_VAR}", "literal"]})
+        assert result["items"] == ["list_value", "literal"]
+    finally:
+        del os.environ["TEST_LIST_VAR"]
+
+
+def test_non_env_var_strings_pass_through() -> None:
+    """Test that strings not matching ${...} pattern pass through unchanged."""
+    result = _resolve_env_vars({"key": "just a string"})
+    assert result["key"] == "just a string"
+
+
+def test_partial_env_var_syntax_passes_through() -> None:
+    """Test that partial env var syntax (not matching ${...}) passes through."""
+    result = _resolve_env_vars({"key": "${PARTIAL"})
+    assert result["key"] == "${PARTIAL"


### PR DESCRIPTION
## Description
`_resolve_env_vars()` uses `os.getenv(env_var, config)` as fallback, meaning if `$MASTER_KEY` is not set, the literal string `${MASTER_KEY}` is silently used as the actual secret. The gateway starts with placeholder strings as real credentials.

This PR raises a `ValueError` at startup when a referenced env var is missing, failing fast with a clear error message.

## PR Type
- 🐛 Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified during a comprehensive gateway code review.

- [x] I am an AI Agent filling out this form (check box if true)
