### PR TITLE
fix(gateway): add reset functions for global DB and config state

### DIFF
--- a/src/any_llm/gateway/auth/dependencies.py
+++ b/src/any_llm/gateway/auth/dependencies.py
@@ -26,6 +26,12 @@ def get_config() -> GatewayConfig:
     return _config
 
 
+def reset_config() -> None:
+    """Reset config state. Intended for testing only."""
+    global _config  # noqa: PLW0603
+    _config = None
+
+
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     """Extract and validate Bearer token from request header.
 

--- a/src/any_llm/gateway/db/__init__.py
+++ b/src/any_llm/gateway/db/__init__.py
@@ -1,4 +1,15 @@
 from any_llm.gateway.db.models import APIKey, Base, Budget, BudgetResetLog, ModelPricing, UsageLog, User
-from any_llm.gateway.db.session import get_db, init_db
+from any_llm.gateway.db.session import get_db, init_db, reset_db
 
-__all__ = ["APIKey", "Base", "Budget", "BudgetResetLog", "ModelPricing", "UsageLog", "User", "get_db", "init_db"]
+__all__ = [
+    "APIKey",
+    "Base",
+    "Budget",
+    "BudgetResetLog",
+    "ModelPricing",
+    "UsageLog",
+    "User",
+    "get_db",
+    "init_db",
+    "reset_db",
+]

--- a/src/any_llm/gateway/db/session.py
+++ b/src/any_llm/gateway/db/session.py
@@ -42,3 +42,17 @@ def get_db() -> Generator[Session]:
         yield db
     finally:
         db.close()
+
+
+def reset_db() -> None:
+    """Reset database state. Intended for testing only.
+
+    Disposes the engine connection pool and clears the module-level references
+    so that init_db() can be called again with different parameters.
+    """
+    global _engine, _SessionLocal  # noqa: PLW0603
+
+    if _engine is not None:
+        _engine.dispose()
+    _engine = None
+    _SessionLocal = None

--- a/tests/gateway/test_global_state_reset.py
+++ b/tests/gateway/test_global_state_reset.py
@@ -1,0 +1,37 @@
+"""Tests for global state reset functions."""
+
+import pytest
+
+from any_llm.gateway.auth.dependencies import get_config, reset_config, set_config
+from any_llm.gateway.config import GatewayConfig
+from any_llm.gateway.db.session import reset_db
+
+
+def test_reset_config_clears_state() -> None:
+    """Test that reset_config clears the global config."""
+    config = GatewayConfig(
+        database_url="postgresql://localhost/test",
+        master_key="test",
+    )
+    set_config(config)
+    assert get_config() is config
+
+    reset_config()
+
+    with pytest.raises(RuntimeError, match="Config not initialized"):
+        get_config()
+
+
+def test_reset_db_allows_reinit() -> None:
+    """Test that reset_db clears state so init_db can be called again.
+
+    We can't fully test init_db without a database, but we can verify
+    reset_db doesn't raise and clears the module state.
+    """
+    from any_llm.gateway.db import session
+
+    # Verify the function exists and runs without error when nothing is initialized
+    reset_db()
+
+    assert session._engine is None
+    assert session._SessionLocal is None


### PR DESCRIPTION
## Description
The gateway stores DB engine/session and config in module-level globals that cannot be cleared or reinitialized once set. This prevents proper test isolation and makes it impossible to test scenarios requiring different DB URLs or config values.

This PR adds `reset_db()` and `reset_config()` functions that clear the cached state, allowing reinitialization with different parameters.

## PR Type
- 🐛 Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified during a comprehensive gateway code review.

- [x] I am an AI Agent filling out this form (check box if true)
