### PR TITLE
fix(gateway): add structural validation for chat completion messages

### DIFF
--- a/docs/gateway/openapi.json
+++ b/docs/gateway/openapi.json
@@ -49,39 +49,6 @@
         "title": "BudgetResponse",
         "type": "object"
       },
-      "ChatCompletionMessage": {
-        "additionalProperties": true,
-        "description": "A single message in a chat completion request.",
-        "properties": {
-          "content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string"
-          }
-        },
-        "required": [
-          "role"
-        ],
-        "title": "ChatCompletionMessage",
-        "type": "object"
-      },
       "ChatCompletionRequest": {
         "description": "OpenAI-compatible chat completion request.",
         "properties": {
@@ -109,7 +76,8 @@
           },
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/ChatCompletionMessage"
+              "additionalProperties": true,
+              "type": "object"
             },
             "minItems": 1,
             "title": "Messages",

--- a/tests/gateway/test_message_validation.py
+++ b/tests/gateway/test_message_validation.py
@@ -31,10 +31,8 @@ def test_empty_messages_rejected(client: TestClient, master_key_header: dict[str
     assert response.status_code == 422
 
 
-def test_valid_message_with_extra_fields_accepted(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that messages with extra provider-specific fields are accepted."""
-    # This should pass validation (though may fail at the provider level)
-    # The point is the request model accepts it
+def test_valid_message_accepted(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that valid messages with extra provider-specific fields are accepted."""
     response = client.post(
         "/v1/chat/completions",
         json={
@@ -44,7 +42,6 @@ def test_valid_message_with_extra_fields_accepted(client: TestClient, master_key
         },
         headers=master_key_header,
     )
-    # Will be 404 (user not found) or 500 (provider error), not 422
     assert response.status_code != 422
 
 
@@ -59,5 +56,4 @@ def test_message_with_null_content_accepted(client: TestClient, master_key_heade
         },
         headers=master_key_header,
     )
-    # Should not be a validation error
     assert response.status_code != 422


### PR DESCRIPTION
## Description
ChatCompletionRequest.messages is typed as list[dict[str, Any]], accepting any dictionary including empty dicts or dicts without a role field. Invalid messages pass through to providers, returning confusing
  provider-specific errors.

 This PR adds a Pydantic field_validator on messages that rejects messages missing a role key, and enforces min_length=1 on the messages list to reject empty arrays. The messages type remains list[dict[str, Any]]
   to preserve compatibility with provider-specific fields like name, tool_calls, and function_call.

## PR Type
- 🐛 Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified during a comprehensive gateway code review.

- [x] I am an AI Agent filling out this form (check box if true)
