### PR TITLE
fix(gateway): add upper bounds to pagination parameters

### DIFF
--- a/docs/gateway/openapi.json
+++ b/docs/gateway/openapi.json
@@ -1014,6 +1014,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Skip",
               "type": "integer"
             }
@@ -1024,6 +1025,8 @@
             "required": false,
             "schema": {
               "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -1280,6 +1283,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Skip",
               "type": "integer"
             }
@@ -1290,6 +1294,8 @@
             "required": false,
             "schema": {
               "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -1506,6 +1512,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Skip",
               "type": "integer"
             }
@@ -1516,6 +1523,8 @@
             "required": false,
             "schema": {
               "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -1681,6 +1690,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Skip",
               "type": "integer"
             }
@@ -1691,6 +1701,8 @@
             "required": false,
             "schema": {
               "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -1916,6 +1928,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Skip",
               "type": "integer"
             }
@@ -1926,6 +1939,8 @@
             "required": false,
             "schema": {
               "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }

--- a/src/any_llm/gateway/routes/budgets.py
+++ b/src/any_llm/gateway/routes/budgets.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -63,8 +63,8 @@ async def create_budget(
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_budgets(
     db: Annotated[Session, Depends(get_db)],
-    skip: int = 0,
-    limit: int = 100,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[BudgetResponse]:
     """List all budgets with pagination."""
     budgets = db.query(Budget).offset(skip).limit(limit).all()

--- a/src/any_llm/gateway/routes/keys.py
+++ b/src/any_llm/gateway/routes/keys.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -117,8 +117,8 @@ async def create_key(
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_keys(
     db: Annotated[Session, Depends(get_db)],
-    skip: int = 0,
-    limit: int = 100,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[KeyInfo]:
     """List all API keys.
 

--- a/src/any_llm/gateway/routes/pricing.py
+++ b/src/any_llm/gateway/routes/pricing.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -65,8 +65,8 @@ async def set_pricing(
 @router.get("")
 async def list_pricing(
     db: Annotated[Session, Depends(get_db)],
-    skip: int = 0,
-    limit: int = 100,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[PricingResponse]:
     """List all model pricing."""
     pricings = db.query(ModelPricing).offset(skip).limit(limit).all()

--- a/src/any_llm/gateway/routes/users.py
+++ b/src/any_llm/gateway/routes/users.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -119,8 +119,8 @@ async def create_user(
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_users(
     db: Annotated[Session, Depends(get_db)],
-    skip: int = 0,
-    limit: int = 100,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[UserResponse]:
     """List all users with pagination."""
     users = db.query(User).offset(skip).limit(limit).all()
@@ -246,8 +246,8 @@ async def delete_user(
 async def get_user_usage(
     user_id: str,
     db: Annotated[Session, Depends(get_db)],
-    skip: int = 0,
-    limit: int = 100,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[UsageLogResponse]:
     """Get usage history for a specific user."""
     user = db.query(User).filter(User.user_id == user_id).first()

--- a/tests/gateway/test_pagination_bounds.py
+++ b/tests/gateway/test_pagination_bounds.py
@@ -1,0 +1,48 @@
+"""Tests for pagination parameter bounds on list endpoints."""
+
+from fastapi.testclient import TestClient
+
+
+def test_users_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that /v1/users rejects limit > 1000."""
+    response = client.get("/v1/users?limit=10000", headers=master_key_header)
+    assert response.status_code == 422
+
+
+def test_users_list_rejects_negative_skip(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that /v1/users rejects negative skip."""
+    response = client.get("/v1/users?skip=-1", headers=master_key_header)
+    assert response.status_code == 422
+
+
+def test_users_list_rejects_zero_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that /v1/users rejects limit=0."""
+    response = client.get("/v1/users?limit=0", headers=master_key_header)
+    assert response.status_code == 422
+
+
+def test_keys_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that /v1/keys rejects limit > 1000."""
+    response = client.get("/v1/keys?limit=10000", headers=master_key_header)
+    assert response.status_code == 422
+
+
+def test_budgets_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that /v1/budgets rejects limit > 1000."""
+    response = client.get("/v1/budgets?limit=10000", headers=master_key_header)
+    assert response.status_code == 422
+
+
+def test_pricing_list_rejects_excessive_limit(client: TestClient) -> None:
+    """Test that /v1/pricing rejects limit > 1000."""
+    response = client.get("/v1/pricing?limit=10000")
+    assert response.status_code == 422
+
+
+def test_users_list_accepts_valid_bounds(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Test that valid pagination parameters are accepted."""
+    response = client.get("/v1/users?skip=0&limit=100", headers=master_key_header)
+    assert response.status_code == 200
+
+    response = client.get("/v1/users?skip=0&limit=1000", headers=master_key_header)
+    assert response.status_code == 200


### PR DESCRIPTION
## Description
All list endpoints accept `skip` and `limit` as plain ints with no constraints. A client can request `limit=999999999` to force an enormous result set (memory exhaustion / DoS). Negative `skip` causes undefined DB behavior.

This PR adds `Annotated` Query validation: `skip >= 0`, `1 <= limit <= 1000` across all list endpoints. Invalid values return 422.

## PR Type
- 🐛 Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified during a comprehensive gateway code review.

- [x] I am an AI Agent filling out this form (check box if true)
