### PR TITLE
fix(gateway): cache and clean up Vertex AI temp credential files

### DIFF
--- a/tests/gateway/test_vertex_credential_cleanup.py
+++ b/tests/gateway/test_vertex_credential_cleanup.py
@@ -1,0 +1,62 @@
+"""Tests for Vertex AI credential file caching and cleanup."""
+
+import json
+import os
+
+from any_llm.gateway.auth import vertex_auth
+from any_llm.gateway.auth.vertex_auth import setup_vertex_environment
+
+
+def test_temp_credential_file_reused_across_calls() -> None:
+    """Test that repeated calls reuse the same temp credential file."""
+    # Reset cached file
+    original = vertex_auth._temp_credential_file
+    vertex_auth._temp_credential_file = None
+
+    creds = {"type": "service_account", "project_id": "test-project"}
+
+    try:
+        setup_vertex_environment(credentials=creds, project="test-project")
+        first_file = vertex_auth._temp_credential_file
+        assert first_file is not None
+        assert os.path.exists(first_file)
+
+        setup_vertex_environment(credentials=creds, project="test-project")
+        second_file = vertex_auth._temp_credential_file
+
+        assert first_file == second_file, "Should reuse the same temp file"
+    finally:
+        # Clean up
+        if vertex_auth._temp_credential_file and os.path.exists(vertex_auth._temp_credential_file):
+            os.remove(vertex_auth._temp_credential_file)
+        vertex_auth._temp_credential_file = original
+        # Clean up env vars we set
+        for var in ["GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"]:
+            os.environ.pop(var, None)
+
+
+def test_temp_credential_file_contains_valid_json() -> None:
+    """Test that the temp credential file contains valid JSON."""
+    original = vertex_auth._temp_credential_file
+    vertex_auth._temp_credential_file = None
+
+    creds = {
+        "type": "service_account",
+        "project_id": "test-project",
+        "client_email": "test@test.iam.gserviceaccount.com",
+    }
+
+    try:
+        setup_vertex_environment(credentials=creds, project="test-project")
+        temp_file = vertex_auth._temp_credential_file
+        assert temp_file is not None
+
+        with open(temp_file, encoding="utf-8") as f:
+            loaded = json.load(f)
+        assert loaded["project_id"] == "test-project"
+    finally:
+        if vertex_auth._temp_credential_file and os.path.exists(vertex_auth._temp_credential_file):
+            os.remove(vertex_auth._temp_credential_file)
+        vertex_auth._temp_credential_file = original
+        for var in ["GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"]:
+            os.environ.pop(var, None)


### PR DESCRIPTION
## Description
`setup_vertex_environment()` creates a new `NamedTemporaryFile(delete=False)` on every call, writing credentials to a new temp file per request. These files are never cleaned up, causing unbounded disk usage and leaving sensitive service account keys on disk.

This PR caches the temp file path and reuses it across requests. An `atexit` handler ensures cleanup on process exit.

## PR Type
- 🐛 Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified during a comprehensive gateway code review.

- [x] I am an AI Agent filling out this form (check box if true)
