### PR TITLE
ci: allow maintainers to trigger integration tests on fork PRs via label

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -8,14 +8,38 @@ on:
       - 'tests/**'
       - '.github/workflows/**'
       - 'pyproject.toml'
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       filter:
         description: the arg you want to pass to pytest filter (-k)
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
+  remove-label:
+    if: github.event_name == 'pull_request_target' && github.event.label.name == 'run-integration-tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove run-integration-tests label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'run-integration-tests'
+            });
+
   expected-providers:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      github.event.label.name == 'run-integration-tests'
     runs-on: ubuntu-latest
     outputs:
       providers: ${{ steps.set_providers.outputs.expected_providers }}
@@ -37,6 +61,8 @@ jobs:
       should_run_local: ${{ steps.determine.outputs.should_run_local }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Determine which jobs should run based on filter
         id: determine
@@ -54,6 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -115,6 +143,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
## Description

When `response_format` or other features need integration testing on fork PRs, maintainers currently have no easy way to trigger the integration test workflow — they must push duplicate branches to the upstream repo.

This adds a `pull_request_target` trigger gated on the `run-integration-tests` label. Maintainers can now:
1. Review a fork PR
2. Add the `run-integration-tests` label
3. Integration tests run with access to repo secrets
4. The label is auto-removed so it can be re-applied to re-trigger

### Changes
- Added `pull_request_target: types: [labeled]` trigger
- Added `if` gate so only the `run-integration-tests` label triggers the workflow
- Added `remove-label` job to auto-remove the label after triggering (enables re-apply to re-run)
- Updated `actions/checkout` steps to use `github.event.pull_request.head.sha` so the PR code (not `main`) is tested
- Added explicit `permissions` block (`contents: read`, `pull-requests: write`)

### Security
This uses `pull_request_target` which runs in the base repo context with access to secrets. This is safe because only maintainers/collaborators can add labels, so they implicitly approve the PR code before it runs with secrets access.

## PR Type

- 🚦 Infrastructure

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Workflow design and implementation drafted with AI assistance, reviewed by human.
