### PR TITLE
fix(openai): remap max_tokens from kwargs and warn on conflict

### DIFF
--- a/docs/gateway/openapi.json
+++ b/docs/gateway/openapi.json
@@ -890,13 +890,6 @@
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [

--- a/docs/gateway/openapi.json
+++ b/docs/gateway/openapi.json
@@ -890,6 +890,13 @@
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -59,6 +59,26 @@ class BaseOpenAIProvider(AnyLLM):
         """Convert CompletionParams to kwargs for OpenAI API."""
         converted_params = params.model_dump(exclude_none=True, exclude={"model_id", "messages"})
         converted_params.update(kwargs)
+
+        max_tokens_key = "max_tokens"
+        max_completion_tokens_key = "max_completion_tokens"
+
+        # Attempt to map max_tokens to max_completion_tokens for OpenAI API compatibility.
+        max_tokens = converted_params.pop(max_tokens_key, None)
+
+        # We can return early if there's no max tokens to deal with.
+        if max_tokens is None:
+            return converted_params
+
+        if max_completion_tokens_key in converted_params:
+            logger.warning(
+                "Ignoring %s (%s) in favor of %s (%s).",
+                max_tokens_key, max_tokens,
+                max_completion_tokens_key, converted_params[max_completion_tokens_key],
+            )
+        else:
+            converted_params[max_completion_tokens_key] = max_tokens
+
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -73,8 +73,10 @@ class BaseOpenAIProvider(AnyLLM):
         if max_completion_tokens_key in converted_params:
             logger.warning(
                 "Ignoring %s (%s) in favor of %s (%s).",
-                max_tokens_key, max_tokens,
-                max_completion_tokens_key, converted_params[max_completion_tokens_key],
+                max_tokens_key,
+                max_tokens,
+                max_completion_tokens_key,
+                converted_params[max_completion_tokens_key],
             )
         else:
             converted_params[max_completion_tokens_key] = max_tokens

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -1,6 +1,10 @@
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.types.completion import CompletionParams
 from any_llm.types.model import Model
 
 
@@ -70,3 +74,138 @@ def test_list_models_passes_kwargs_to_client(mock_openai_class: MagicMock) -> No
     provider.list_models(limit=10, after="model-123")
 
     mock_client.models.list.assert_called_once_with(limit=10, after="model-123")
+
+
+def test_convert_completion_params_maps_max_tokens_to_max_completion_tokens() -> None:
+    """Test that max_tokens is mapped to max_completion_tokens for the OpenAI API."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=8192,
+    )
+
+    result = BaseOpenAIProvider._convert_completion_params(params)
+
+    assert "max_completion_tokens" in result
+    assert result["max_completion_tokens"] == 8192
+    assert "max_tokens" not in result
+
+
+def test_convert_completion_params_preserves_explicit_max_completion_tokens(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that explicit max_completion_tokens is not overwritten by max_tokens."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=4096,
+        max_completion_tokens=8192,
+    )
+
+    any_llm_logger = logging.getLogger("any_llm")
+    any_llm_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            result = BaseOpenAIProvider._convert_completion_params(params)
+    finally:
+        any_llm_logger.propagate = False
+
+    assert result["max_completion_tokens"] == 8192
+    assert "max_tokens" not in result
+    assert "Ignoring max_tokens (4096) in favor of max_completion_tokens (8192)" in caplog.text
+
+
+def test_convert_completion_params_without_max_tokens() -> None:
+    """Test that params without max_tokens pass through unchanged."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        temperature=0.7,
+    )
+
+    result = BaseOpenAIProvider._convert_completion_params(params)
+
+    assert "max_tokens" not in result
+    assert "max_completion_tokens" not in result
+    assert result["temperature"] == 0.7
+
+
+def test_convert_completion_params_max_completion_tokens_only() -> None:
+    """Test that max_completion_tokens alone passes through correctly."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_completion_tokens=1024,
+    )
+
+    result = BaseOpenAIProvider._convert_completion_params(params)
+
+    assert result["max_completion_tokens"] == 1024
+    assert "max_tokens" not in result
+
+
+def test_convert_completion_params_kwargs_max_tokens_remapped() -> None:
+    """Test that max_tokens passed via kwargs is remapped to max_completion_tokens."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    result = BaseOpenAIProvider._convert_completion_params(params, max_tokens=2048)
+
+    assert result["max_completion_tokens"] == 2048
+    assert "max_tokens" not in result
+
+
+def test_convert_completion_params_kwargs_override_other_params() -> None:
+    """Test that kwargs override params values for non-max_tokens fields."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        temperature=0.7,
+    )
+
+    result = BaseOpenAIProvider._convert_completion_params(params, temperature=0.2)
+
+    assert result["temperature"] == 0.2
+
+
+def test_convert_completion_params_conflict_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that providing both max_tokens and max_completion_tokens via kwargs logs a warning."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    any_llm_logger = logging.getLogger("any_llm")
+    any_llm_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            result = BaseOpenAIProvider._convert_completion_params(params, max_tokens=4096, max_completion_tokens=8192)
+    finally:
+        any_llm_logger.propagate = False
+
+    assert result["max_completion_tokens"] == 8192
+    assert "max_tokens" not in result
+    assert "Ignoring max_tokens (4096) in favor of max_completion_tokens (8192)" in caplog.text
+
+
+def test_convert_completion_params_kwargs_max_completion_tokens_wins_over_params_max_tokens(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that max_completion_tokens via kwargs wins over max_tokens in params."""
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=4096,
+    )
+
+    any_llm_logger = logging.getLogger("any_llm")
+    any_llm_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            result = BaseOpenAIProvider._convert_completion_params(params, max_completion_tokens=8192)
+    finally:
+        any_llm_logger.propagate = False
+
+    assert result["max_completion_tokens"] == 8192
+    assert "max_tokens" not in result
+    assert "Ignoring max_tokens (4096) in favor of max_completion_tokens (8192)" in caplog.text


### PR DESCRIPTION
## Description

`BaseOpenAIProvider._convert_completion_params()` applied `kwargs` after the `max_tokens` → `max_completion_tokens` remapping, so `max_tokens` or `max_completion_tokens` passed via `**kwargs` bypassed the mapping entirely.

This fix moves `converted_params.update(kwargs)` before the remapping logic so all sources of these parameters are handled consistently. When both `max_tokens` and `max_completion_tokens` are present (from any combination of params and kwargs), a warning is logged and `max_completion_tokens` takes precedence.

## PR Type

- 🐛 Bug Fix

## Relevant issues


## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)

Fixes: #862
