### PR TITLE
fix(openai): map max_tokens to max_completion_tokens

### DIFF
--- a/src/any_llm/providers/openai/openai.py
+++ b/src/any_llm/providers/openai/openai.py
@@ -1,3 +1,10 @@
+from typing import Any
+
+from typing_extensions import override
+
+from any_llm.logging import logger
+from any_llm.types.completion import CompletionParams
+
 from .base import BaseOpenAIProvider
 
 
@@ -11,3 +18,19 @@ class OpenaiProvider(BaseOpenAIProvider):
     SUPPORTS_RESPONSES = True
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = True
+
+    @staticmethod
+    @override
+    def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
+        converted_params = BaseOpenAIProvider._convert_completion_params(params, **kwargs)
+        if "max_tokens" in converted_params:
+            max_tokens = converted_params.pop("max_tokens")
+            if "max_completion_tokens" in converted_params:
+                logger.warning(
+                    "Ignoring max_tokens (%s) in favor of max_completion_tokens (%s).",
+                    max_tokens,
+                    converted_params["max_completion_tokens"],
+                )
+            else:
+                converted_params["max_completion_tokens"] = max_tokens
+        return converted_params

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -1,6 +1,11 @@
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.providers.openai.openai import OpenaiProvider
+from any_llm.types.completion import CompletionParams
 from any_llm.types.model import Model
 
 
@@ -70,3 +75,59 @@ def test_list_models_passes_kwargs_to_client(mock_openai_class: MagicMock) -> No
     provider.list_models(limit=10, after="model-123")
 
     mock_client.models.list.assert_called_once_with(limit=10, after="model-123")
+
+
+def test_openai_provider_maps_max_tokens_to_max_completion_tokens() -> None:
+    params = CompletionParams(model_id="gpt-5.2", messages=[{"role": "user", "content": "hi"}], max_tokens=8192)
+    result = OpenaiProvider._convert_completion_params(params)
+    assert "max_tokens" not in result
+    assert result["max_completion_tokens"] == 8192
+
+
+def test_openai_provider_preserves_explicit_max_completion_tokens() -> None:
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "hi"}],
+        max_completion_tokens=4096,
+    )
+    result = OpenaiProvider._convert_completion_params(params)
+    assert "max_tokens" not in result
+    assert result["max_completion_tokens"] == 4096
+
+
+def test_openai_provider_max_completion_tokens_takes_precedence_over_max_tokens(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    params = CompletionParams(
+        model_id="gpt-5.2",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=8192,
+        max_completion_tokens=4096,
+    )
+
+    any_llm_logger = logging.getLogger("any_llm")
+    any_llm_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            result = OpenaiProvider._convert_completion_params(params)
+    finally:
+        any_llm_logger.propagate = False
+
+    assert "max_tokens" not in result
+    assert result["max_completion_tokens"] == 4096
+    assert "Ignoring max_tokens (8192) in favor of max_completion_tokens (4096)" in caplog.text
+
+
+def test_openai_provider_no_max_tokens_passes_through_unchanged() -> None:
+    params = CompletionParams(model_id="gpt-5.2", messages=[{"role": "user", "content": "hi"}], temperature=0.5)
+    result = OpenaiProvider._convert_completion_params(params)
+    assert "max_tokens" not in result
+    assert "max_completion_tokens" not in result
+    assert result["temperature"] == 0.5
+
+
+def test_base_openai_provider_does_not_map_max_tokens() -> None:
+    params = CompletionParams(model_id="model", messages=[{"role": "user", "content": "hi"}], max_tokens=8192)
+    result = BaseOpenAIProvider._convert_completion_params(params)
+    assert result["max_tokens"] == 8192
+    assert "max_completion_tokens" not in result


### PR DESCRIPTION
## Description

OpenAI deprecated `max_tokens` in favour of `max_completion_tokens` for newer models (gpt-5.x, o-series). Callers using `acompletion(max_tokens=...)` with the OpenAI provider get a 400 error because the parameter is passed through unchanged.

This PR overrides `_convert_completion_params` in `OpenaiProvider` to remap `max_tokens` → `max_completion_tokens`. When both are provided, `max_completion_tokens` takes precedence and a warning is logged.

### Difference from #864

PR #864 puts the remapping in `BaseOpenAIProvider`, which affects **all** OpenAI-compatible providers (vLLM, LM Studio, OpenRouter, Perplexity, Fireworks, etc.). Some of those providers may not yet support `max_completion_tokens`, so that change has a wider blast radius. This PR scopes the mapping to `OpenaiProvider` only, keeping `BaseOpenAIProvider` unchanged for other providers. A dedicated test (`test_base_openai_provider_does_not_map_max_tokens`) verifies this boundary.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #862

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [x] I am an AI Agent filling out this form (check box if true)