### PR TITLE
tests: add unit tests for moonshot provider

### DIFF
--- a/tests/unit/providers/test_moonshot_provider.py
+++ b/tests/unit/providers/test_moonshot_provider.py
@@ -1,0 +1,51 @@
+import pytest
+
+from any_llm import AnyLLM
+from any_llm.providers.moonshot.moonshot import MoonshotProvider
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOONSHOT_API_KEY", "sk-moonshot-test-123")
+
+
+def test_provider_basics() -> None:
+    """Test provider instantiation and basic attributes."""
+    p = MoonshotProvider(api_key="sk-test")
+    assert p.PROVIDER_NAME == "moonshot"
+    assert p.API_BASE == "https://api.moonshot.ai/v1"
+    assert p.SUPPORTS_COMPLETION is True
+    assert p.SUPPORTS_COMPLETION_STREAMING is True
+    assert p.SUPPORTS_EMBEDDING is False
+    assert p.SUPPORTS_COMPLETION_IMAGE is False
+    assert p.SUPPORTS_COMPLETION_PDF is False
+    assert p.SUPPORTS_COMPLETION_REASONING is True
+
+
+def test_factory_integration() -> None:
+    """Test that the provider factory can create and discover the provider."""
+    p = AnyLLM.create("moonshot", api_key="sk-1")
+    assert isinstance(p, MoonshotProvider)
+    assert p.PROVIDER_NAME == "moonshot"
+
+    supported = AnyLLM.get_supported_providers()
+    assert "moonshot" in supported
+
+
+def test_model_provider_split() -> None:
+    """Test that model string parsing works correctly."""
+    provider_enum, model_name = AnyLLM.split_model_provider("moonshot:moonshot-v1-8k")
+    assert provider_enum.value == "moonshot"
+    assert model_name == "moonshot-v1-8k"
+
+
+def test_provider_metadata() -> None:
+    """Test provider metadata is correctly configured."""
+    metadata = MoonshotProvider.get_provider_metadata()
+    assert metadata.name == "moonshot"
+    assert metadata.env_key == "MOONSHOT_API_KEY"
+    assert metadata.doc_url == "https://platform.moonshot.ai/"
+    assert metadata.completion is True
+    assert metadata.streaming is True
+    assert metadata.embedding is False
+    assert metadata.image is False


### PR DESCRIPTION
## Description
The Moonshot provider had no unit test coverage. This adds basic unit tests following the same pattern used by other provider tests (e.g., `test_perplexity_provider.py`).

Tests cover:
- Provider instantiation and attribute validation (API base, feature flags)
- Factory integration via `AnyLLM.create()`
- Model string parsing (`moonshot:moonshot-v1-8k`)
- Provider metadata correctness

## PR Type
- 🚦 Infrastructure

## Relevant issues
N/A

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code

- [ ] I am an AI Agent filling out this form (check box if true)