### PR TITLE
tests: add unit tests for lmstudio provider

### DIFF
--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -1,0 +1,47 @@
+from any_llm import AnyLLM
+from any_llm.providers.lmstudio.lmstudio import LmstudioProvider
+
+
+def test_provider_basics() -> None:
+    """Test provider instantiation and basic attributes."""
+    p = LmstudioProvider(api_key="sk-test")
+    assert p.PROVIDER_NAME == "lmstudio"
+    assert p.API_BASE == "http://localhost:1234/v1"
+    assert p.SUPPORTS_COMPLETION is True
+    assert p.SUPPORTS_COMPLETION_STREAMING is True
+    assert p.SUPPORTS_COMPLETION_REASONING is True
+    assert p.SUPPORTS_RESPONSES is True
+
+
+def test_api_key_not_required() -> None:
+    """Test that LM Studio does not require an API key."""
+    p = LmstudioProvider()
+    assert p.PROVIDER_NAME == "lmstudio"
+
+
+def test_factory_integration() -> None:
+    """Test that the provider factory can create and discover the provider."""
+    p = AnyLLM.create("lmstudio")
+    assert isinstance(p, LmstudioProvider)
+    assert p.PROVIDER_NAME == "lmstudio"
+
+    supported = AnyLLM.get_supported_providers()
+    assert "lmstudio" in supported
+
+
+def test_model_provider_split() -> None:
+    """Test that model string parsing works correctly."""
+    provider_enum, model_name = AnyLLM.split_model_provider("lmstudio:google/gemma-3-4b")
+    assert provider_enum.value == "lmstudio"
+    assert model_name == "google/gemma-3-4b"
+
+
+def test_provider_metadata() -> None:
+    """Test provider metadata is correctly configured."""
+    metadata = LmstudioProvider.get_provider_metadata()
+    assert metadata.name == "lmstudio"
+    assert metadata.env_key == "LM_STUDIO_API_KEY"
+    assert metadata.doc_url == "https://lmstudio.ai/"
+    assert metadata.completion is True
+    assert metadata.streaming is True
+    assert metadata.responses is True


### PR DESCRIPTION
## Description
The LM Studio provider had no unit test coverage. This adds unit tests following the same pattern used by other provider tests.

Tests cover:
- Provider instantiation and attribute validation
- API key not required (LM Studio runs locally and overrides `_verify_and_set_api_key`)
- Factory integration via `AnyLLM.create()` without providing an API key
- Model string parsing with nested paths (`lmstudio:google/gemma-3-4b`)
- Provider metadata correctness

## PR Type
- 🚦 Infrastructure

## Relevant issues
N/A

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code

- [ ] I am an AI Agent filling out this form (check box if true)