### PR TITLE
fix(ci): mock completion call for docs test so that forks can pass the docs test

### DIFF
--- a/tests/docs/test_all.py
+++ b/tests/docs/test_all.py
@@ -13,7 +13,18 @@ from any_llm.constants import LLMProvider
     ids=str,
 )
 def test_all_docs(doc_file: pathlib.Path) -> None:
-    if doc_file.name == "quickstart.md":
+    if doc_file.name == "index.md":
+        mock_response = Mock(choices=[Mock(message=Mock(content="Hello!"))])
+        with patch("any_llm.completion", return_value=mock_response):
+            check_md_file(fpath=doc_file, memory=True)  # type: ignore[no-untyped-call]
+    elif doc_file.name == "quickstart.md" and "gateway" in doc_file.parts:
+        mock_response = Mock(choices=[Mock(message=Mock(content="Hello!"))])
+        with (
+            patch("any_llm.completion", return_value=mock_response),
+            patch.dict("os.environ", {"GATEWAY_MASTER_KEY": "fake-gateway-key"}),
+        ):
+            check_md_file(fpath=doc_file, memory=True)  # type: ignore[no-untyped-call]
+    elif doc_file.name == "quickstart.md":
         mock_provider = Mock()
         mock_provider.completion.return_value = Mock(choices=[Mock(message=Mock(content="Hello!"))])
         mock_provider.get_provider_metadata.return_value = Mock(streaming=True, completion=True)


### PR DESCRIPTION
## Description

Mock `completion()` calls in `docs/index.md` and `docs/gateway/quickstart.md`, matching the pattern already used for `docs/quickstart.md`. This removes the need for real API keys in docs tests, allowing them to pass on fork and Dependabot PRs where secrets are unavailable.

The workflow is kept as the simple `pull_request` trigger — no label gating needed.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #889

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Mocks API calls in doc code examples so docs tests don't require real API keys.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)