### PR TITLE
feat(anthropic): expose cache_creation_input_tokens in usage response

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -225,11 +225,17 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
             cache_read = anthropic_usage.cache_read_input_tokens or 0
             cache_creation = anthropic_usage.cache_creation_input_tokens or 0
             total_prompt_tokens = anthropic_usage.input_tokens + cache_read + cache_creation
+            prompt_tokens_details = None
+            if cache_read or cache_creation:
+                prompt_tokens_details = PromptTokensDetails(
+                    cached_tokens=cache_read or None,
+                    cache_creation_input_tokens=cache_creation or None,
+                )
             chunk_dict["usage"] = {
                 "prompt_tokens": total_prompt_tokens,
                 "completion_tokens": anthropic_usage.output_tokens,
                 "total_tokens": total_prompt_tokens + anthropic_usage.output_tokens,
-                "prompt_tokens_details": PromptTokensDetails(cached_tokens=cache_read) if cache_read else None,
+                "prompt_tokens_details": prompt_tokens_details,
             }
 
     choice = {
@@ -287,11 +293,18 @@ def _convert_response(response: Message) -> ChatCompletion:
     cache_creation = response.usage.cache_creation_input_tokens or 0
     total_prompt_tokens = response.usage.input_tokens + cache_read + cache_creation
 
+    prompt_tokens_details = None
+    if cache_read or cache_creation:
+        prompt_tokens_details = PromptTokensDetails(
+            cached_tokens=cache_read or None,
+            cache_creation_input_tokens=cache_creation or None,
+        )
+
     usage = CompletionUsage(
         completion_tokens=response.usage.output_tokens,
         prompt_tokens=total_prompt_tokens,
         total_tokens=total_prompt_tokens + response.usage.output_tokens,
-        prompt_tokens_details=PromptTokensDetails(cached_tokens=cache_read) if cache_read else None,
+        prompt_tokens_details=prompt_tokens_details,
     )
 
     from typing import Literal

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -32,6 +32,14 @@ class Reasoning(BaseModel):
     content: str
 
 
+class PromptTokensDetails(OpenAIPromptTokensDetails):
+    cache_creation_input_tokens: int | None = None
+
+
+class CompletionUsage(OpenAICompletionUsage):
+    prompt_tokens_details: PromptTokensDetails | None = None
+
+
 class ChatCompletionMessage(OpenAIChatCompletionMessage):
     reasoning: Reasoning | None = None
     annotations: list[dict[str, Any]] | None = None  # type: ignore[assignment]
@@ -43,6 +51,7 @@ class Choice(OpenAIChoice):
 
 class ChatCompletion(OpenAIChatCompletion):
     choices: list[Choice]  # type: ignore[assignment]
+    usage: CompletionUsage | None = None
 
 
 ContentType = TypeVar("ContentType")
@@ -70,6 +79,7 @@ class ChunkChoice(OpenAIChunkChoice):
 
 class ChatCompletionChunk(OpenAIChatCompletionChunk):
     choices: list[ChunkChoice]  # type: ignore[assignment]
+    usage: CompletionUsage | None = None
 
 
 class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionToolCall):
@@ -88,8 +98,6 @@ class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionT
 
 ChatCompletionMessageToolCall = ChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
 Function = OpenAIFunction
-CompletionUsage = OpenAICompletionUsage
-PromptTokensDetails = OpenAIPromptTokensDetails
 CreateEmbeddingResponse = OpenAICreateEmbeddingResponse
 Embedding = OpenAIEmbedding
 Usage = OpenAIUsage

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -645,10 +645,11 @@ def test_convert_response_includes_cache_tokens_in_usage() -> None:
     assert result.usage.total_tokens == expected_total_tokens
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 13332
+    assert result.usage.prompt_tokens_details.cache_creation_input_tokens is None
 
 
 def test_convert_response_includes_cache_creation_tokens() -> None:
-    """Test that cache_creation_input_tokens are included in usage when writing to cache."""
+    """Test that cache_creation_input_tokens are exposed in prompt_tokens_details when writing to cache."""
     from datetime import datetime
     from unittest.mock import MagicMock
 
@@ -674,7 +675,9 @@ def test_convert_response_includes_cache_creation_tokens() -> None:
     assert result.usage is not None
     assert result.usage.prompt_tokens == expected_prompt_tokens
     assert result.usage.total_tokens == expected_total_tokens
-    assert result.usage.prompt_tokens_details is None
+    assert result.usage.prompt_tokens_details is not None
+    assert result.usage.prompt_tokens_details.cache_creation_input_tokens == 13332
+    assert result.usage.prompt_tokens_details.cached_tokens is None
 
 
 def test_convert_response_without_cache_tokens() -> None:
@@ -737,6 +740,74 @@ def test_streaming_chunk_includes_cache_tokens_in_usage() -> None:
     assert result.usage.total_tokens == expected_total_tokens
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 13332
+    assert result.usage.prompt_tokens_details.cache_creation_input_tokens is None
+
+
+def test_streaming_chunk_includes_cache_creation_tokens_in_usage() -> None:
+    """Test that streaming chunks expose cache_creation_input_tokens in prompt_tokens_details."""
+    from unittest.mock import MagicMock
+
+    from anthropic.types import MessageStopEvent, Usage
+
+    from any_llm.providers.anthropic.utils import _create_openai_chunk_from_anthropic_chunk
+
+    usage = Usage(
+        input_tokens=3,
+        output_tokens=122,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=13332,
+    )
+
+    mock_message = MagicMock()
+    mock_message.usage = usage
+
+    chunk = MessageStopEvent(type="message_stop")
+    chunk.message = mock_message  # type: ignore[attr-defined]
+
+    result = _create_openai_chunk_from_anthropic_chunk(chunk, "claude-3-haiku")
+
+    expected_prompt_tokens = 3 + 0 + 13332
+    expected_total_tokens = expected_prompt_tokens + 122
+
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == expected_prompt_tokens
+    assert result.usage.completion_tokens == 122
+    assert result.usage.total_tokens == expected_total_tokens
+    assert result.usage.prompt_tokens_details is not None
+    assert result.usage.prompt_tokens_details.cache_creation_input_tokens == 13332
+    assert result.usage.prompt_tokens_details.cached_tokens is None
+
+
+def test_convert_response_includes_both_cache_fields() -> None:
+    """Test that both cache_read and cache_creation tokens are exposed in prompt_tokens_details."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    mock_response = MagicMock()
+    mock_response.id = "msg_123"
+    mock_response.model = "claude-3-haiku"
+    mock_response.stop_reason = "end_turn"
+    mock_response.content = [MagicMock(type="text", text="Hello!")]
+    mock_response.created_at = datetime.now(UTC)
+
+    mock_response.usage.input_tokens = 5
+    mock_response.usage.output_tokens = 100
+    mock_response.usage.cache_read_input_tokens = 8000
+    mock_response.usage.cache_creation_input_tokens = 4000
+
+    result = _convert_response(mock_response)
+
+    expected_prompt_tokens = 5 + 8000 + 4000
+    expected_total_tokens = expected_prompt_tokens + 100
+
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == expected_prompt_tokens
+    assert result.usage.total_tokens == expected_total_tokens
+    assert result.usage.prompt_tokens_details is not None
+    assert result.usage.prompt_tokens_details.cached_tokens == 8000
+    assert result.usage.prompt_tokens_details.cache_creation_input_tokens == 4000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Anthropic's `cache_creation_input_tokens` was used in the `prompt_tokens` calculation but never surfaced to users. This PR extends `PromptTokensDetails` with a `cache_creation_input_tokens` field so users can track cache write costs separately from cache read costs.

Previously, only `cached_tokens` (mapping to Anthropic's `cache_read_input_tokens`) was exposed via `prompt_tokens_details`. Now both cache read and cache creation tokens are available:

```python
response = await acompletion(model="claude-haiku-4-5", provider="anthropic", ...)
usage = response.usage
if usage and usage.prompt_tokens_details:
    print(usage.prompt_tokens_details.cached_tokens)                # cache read tokens
    print(usage.prompt_tokens_details.cache_creation_input_tokens)  # cache creation tokens
```

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #759

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: N/A

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)