### PR TITLE
fix(platform): stop forwarding client_args to httpx.AsyncClient

### DIFF
--- a/src/any_llm/providers/platform/platform.py
+++ b/src/any_llm/providers/platform/platform.py
@@ -77,7 +77,7 @@ class PlatformProvider(AnyLLM):
 
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
-        self.client = AsyncClient(**kwargs)
+        self.client = AsyncClient()
         # Initialize the platform client for authentication and trace export
         from .utils import ANY_LLM_PLATFORM_API_URL
 

--- a/tests/unit/providers/test_platform_provider.py
+++ b/tests/unit/providers/test_platform_provider.py
@@ -2407,3 +2407,11 @@ async def test_acompletion_sets_error_status_and_deactivates_trace_on_exception(
     mock_span.set_status.assert_called_once()
     mock_span.end.assert_called_once()
     deactivate_mock.assert_called_once_with(456)
+
+
+def test_client_args_not_passed_to_httpx_client(any_llm_key: str) -> None:
+    """Test that provider-specific client_args don't leak into the platform's httpx client."""
+    with patch("any_llm.providers.platform.platform.AnyLLMPlatformClient"):
+        provider = PlatformProvider(api_key=any_llm_key, http_options={"timeout": 30000})
+    assert isinstance(provider.client, httpx.AsyncClient)
+    assert provider.kwargs == {"http_options": {"timeout": 30000}}


### PR DESCRIPTION
## Description

`PlatformProvider._init_client` passed all kwargs (including provider-specific `client_args` like `http_options`) to `httpx.AsyncClient()`, which rejected them. The httpx client is only used for platform usage-tracking API calls and has no need for provider-specific configuration.

The kwargs are already stored in `self.kwargs` and correctly forwarded to the wrapped provider during lazy initialization in `_ensure_provider_initialized`.

The fix removes `**kwargs` from the `AsyncClient()` constructor call.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #902

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: AI-assisted diagnosis and test drafting; fix reviewed by the author.

- [ ] I am an AI Agent filling out this form (check box if true)