### PR TITLE
docs(readme): add any-llm platform links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **Communicate with any LLM provider using a single, unified interface.**
 Switch between OpenAI, Anthropic, Mistral, Ollama, and more without changing your code.
 
-[Documentation](https://mozilla-ai.github.io/any-llm/) | [Try the Demos](#-try-it) | [Contributing](#-contributing)
+[Documentation](https://mozilla-ai.github.io/any-llm/) | [Platform (Beta)](https://any-llm.ai/) | [Try the Demos](#-try-it) | [Contributing](#-contributing)
 
 </div>
 
@@ -96,6 +96,10 @@ any-llm-gateway is an **optional** FastAPI-based proxy server that adds enterpri
 - **Multi-tenant Support** - Manage access and budgets across users and teams
 
 The gateway sits between your applications and LLM providers, exposing an OpenAI-compatible API that works with any supported provider.
+
+### Managed Platform (Beta)
+
+Prefer a hosted experience? The [any-llm platform](https://any-llm.ai/) provides a managed control plane for keys, usage tracking, and cost visibility across providers, while still building on the same `any-llm` interfaces.
 
 ### Quick Start
 ```bash
@@ -236,6 +240,7 @@ The landscape of LLM provider interfaces is fragmented. While OpenAI's API has b
 - **[Full Documentation](https://mozilla-ai.github.io/any-llm/)** - Complete guides and API reference
 - **[Supported Providers](https://mozilla-ai.github.io/any-llm/providers/)** - List of all supported LLM providers
 - **[Cookbook Examples](https://mozilla-ai.github.io/any-llm/cookbook/)** - In-depth usage examples
+- **[any-llm Platform (Beta)](https://any-llm.ai/)** - Hosted control plane for key management, usage tracking, and cost visibility
 
 
 ## Contributing


### PR DESCRIPTION
## Description
Add clear references to the hosted any-llm platform in the README so users can discover the managed option alongside the OSS library and gateway docs.

## PR Type
- 📚 Documentation

## Relevant issues
N/A

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: GPT-5.3 Codex
- AI Developer Tool used: OpenCode CLI
- Any other info you'd like to share: Docs-only changes to README content and link placement.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)