### PR TITLE
refactor(gateway): extract shared pricing lookup helper

### DIFF
--- a/src/any_llm/gateway/budget.py
+++ b/src/any_llm/gateway/budget.py
@@ -4,8 +4,9 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from any_llm.any_llm import AnyLLM
-from any_llm.gateway.db import Budget, BudgetResetLog, ModelPricing, User
+from any_llm.gateway.db import Budget, BudgetResetLog, User
 from any_llm.gateway.log_config import logger
+from any_llm.gateway.pricing import find_model_pricing
 
 
 def calculate_next_reset(start: datetime, duration_sec: int) -> datetime:
@@ -114,17 +115,11 @@ def _is_model_free(db: Session, model: str) -> bool:
     """
     try:
         provider, model_name = AnyLLM.split_model_provider(model)
-        model_key = f"{provider.value}:{model_name}" if provider else model_name
-        model_key_legacy = f"{provider.value}/{model_name}" if provider else None
-
-        pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
-        if not pricing and model_key_legacy:
-            pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key_legacy).first()
-
+        provider_str = provider.value if provider else None
+        pricing = find_model_pricing(db, provider_str, model_name)
         if pricing:
             return pricing.input_price_per_million == 0 and pricing.output_price_per_million == 0
     except Exception as e:
-        # If we can't determine the provider or pricing, treat as not free
         logger.warning("Failed to determine provider pricing: %s", e)
 
     return False

--- a/src/any_llm/gateway/pricing.py
+++ b/src/any_llm/gateway/pricing.py
@@ -1,0 +1,25 @@
+"""Shared pricing lookup utilities."""
+
+from sqlalchemy.orm import Session
+
+from any_llm.gateway.db import ModelPricing
+
+
+def find_model_pricing(db: Session, provider: str | None, model: str) -> ModelPricing | None:
+    """Look up model pricing, falling back to legacy slash-separated key format.
+
+    Args:
+        db: Database session
+        provider: Provider name (e.g., "openai") or None
+        model: Model name (e.g., "gpt-4")
+
+    Returns:
+        ModelPricing object if found, None otherwise
+
+    """
+    model_key = f"{provider}:{model}" if provider else model
+    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
+    if not pricing and provider:
+        legacy_key = f"{provider}/{model}"
+        pricing = db.query(ModelPricing).filter(ModelPricing.model_key == legacy_key).first()
+    return pricing

--- a/src/any_llm/gateway/routes/chat.py
+++ b/src/any_llm/gateway/routes/chat.py
@@ -14,8 +14,9 @@ from any_llm.gateway.auth.dependencies import get_config
 from any_llm.gateway.auth.vertex_auth import setup_vertex_environment
 from any_llm.gateway.budget import validate_user_budget
 from any_llm.gateway.config import GatewayConfig
-from any_llm.gateway.db import APIKey, ModelPricing, UsageLog, User, get_db
+from any_llm.gateway.db import APIKey, UsageLog, User, get_db
 from any_llm.gateway.log_config import logger
+from any_llm.gateway.pricing import find_model_pricing
 from any_llm.gateway.rate_limit import RateLimitInfo, check_rate_limit
 from any_llm.gateway.streaming import OPENAI_STREAM_FORMAT, streaming_generator
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionUsage
@@ -141,12 +142,7 @@ async def log_usage(
         usage_log.completion_tokens = usage_data.completion_tokens
         usage_log.total_tokens = usage_data.total_tokens
 
-        model_key = f"{provider}:{model}" if provider else model
-        model_key_legacy = f"{provider}/{model}" if provider else None
-        pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
-        if not pricing and model_key_legacy:
-            pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key_legacy).first()
-
+        pricing = find_model_pricing(db, provider, model)
         if pricing:
             cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
                 usage_data.completion_tokens / 1_000_000
@@ -158,8 +154,8 @@ async def log_usage(
                     {User.spend: User.spend + cost}
                 )
         else:
-            attempted = f"'{model_key}'" + (f" or '{model_key_legacy}'" if model_key_legacy else "")
-            logger.warning(f"No pricing configured for {attempted}. Usage will be tracked without cost.")
+            model_ref = f"{provider}:{model}" if provider else model
+            logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
     try:
         nested = db.begin_nested()

--- a/tests/gateway/test_find_model_pricing.py
+++ b/tests/gateway/test_find_model_pricing.py
@@ -1,0 +1,54 @@
+"""Tests for the shared find_model_pricing helper."""
+
+from sqlalchemy.orm import Session
+
+from any_llm.gateway.db import ModelPricing
+from any_llm.gateway.pricing import find_model_pricing
+
+
+def test_find_pricing_colon_format(test_db: Session) -> None:
+    """Test lookup with canonical colon-separated key."""
+    test_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    test_db.commit()
+
+    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    assert pricing is not None
+    assert pricing.input_price_per_million == 30.0
+
+
+def test_find_pricing_legacy_slash_fallback(test_db: Session) -> None:
+    """Test fallback to legacy slash-separated key when colon key is missing."""
+    test_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    test_db.commit()
+
+    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    assert pricing is not None
+    assert pricing.model_key == "openai/gpt-4"
+
+
+def test_find_pricing_no_provider(test_db: Session) -> None:
+    """Test lookup without a provider uses model name directly."""
+    test_db.add(ModelPricing(model_key="gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    test_db.commit()
+
+    pricing = find_model_pricing(test_db, None, "gpt-4")
+    assert pricing is not None
+    assert pricing.model_key == "gpt-4"
+
+
+def test_find_pricing_not_found(test_db: Session) -> None:
+    """Test that None is returned when no pricing exists."""
+    pricing = find_model_pricing(test_db, "openai", "nonexistent-model")
+    assert pricing is None
+
+
+def test_find_pricing_colon_preferred_over_slash(test_db: Session) -> None:
+    """Test that colon format is returned when both formats exist."""
+    test_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    test_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=10.0, output_price_per_million=20.0))
+    test_db.commit()
+
+    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    assert pricing is not None
+    assert pricing.model_key == "openai:gpt-4"
+    assert pricing.input_price_per_million == 30.0


### PR DESCRIPTION
## Description

Extracts the duplicated "try colon key, then legacy slash key" pricing lookup pattern into a shared `find_model_pricing()` helper in `gateway/pricing.py`.

The same 5-line lookup pattern was duplicated in `log_usage()` (chat.py) and `_is_model_free()` (budget.py). Both now call the shared helper, ensuring consistent fallback behavior.

## PR Type

- 💅 Refactor

## Relevant issues

Fixes #920

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Part of a gateway codebase improvement sweep.

- [x] I am an AI Agent filling out this form (check box if true)