### PR TITLE
fix(gateway): support inline env var substitution in YAML config

### DIFF
--- a/src/any_llm/gateway/config.py
+++ b/src/any_llm/gateway/config.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -86,11 +87,15 @@ def _resolve_env_vars(config: dict[str, Any]) -> dict[str, Any]:
         return {key: _resolve_env_vars(value) for key, value in config.items()}
     if isinstance(config, list):
         return [_resolve_env_vars(item) for item in config]
-    if isinstance(config, str) and config.startswith("${") and config.endswith("}"):
-        env_var = config[2:-1]
-        value = os.getenv(env_var)
-        if value is None:
-            msg = f"Environment variable '{env_var}' is not set (referenced in config as '${{{env_var}}}')"
-            raise ValueError(msg)
-        return value
+    if isinstance(config, str) and "${" in config:
+
+        def _replace(match: re.Match[str]) -> str:
+            env_var = match.group(1)
+            value = os.getenv(env_var)
+            if value is None:
+                msg = f"Environment variable '{env_var}' is not set (referenced in config as '${{{env_var}}}')"
+                raise ValueError(msg)
+            return value
+
+        return re.sub(r"\$\{([^}]+)}", _replace, config)
     return config

--- a/tests/gateway/test_env_var_resolution.py
+++ b/tests/gateway/test_env_var_resolution.py
@@ -55,3 +55,38 @@ def test_partial_env_var_syntax_passes_through() -> None:
     """Test that partial env var syntax (not matching ${...}) passes through."""
     result = _resolve_env_vars({"key": "${PARTIAL"})
     assert result["key"] == "${PARTIAL"
+
+
+def test_inline_substitution() -> None:
+    """Test that env vars embedded in a larger string are substituted."""
+    os.environ["TEST_DB_USER"] = "admin"
+    os.environ["TEST_DB_ROLE"] = "readwrite"
+    os.environ["TEST_DB_HOST"] = "db.example.com"
+    try:
+        result = _resolve_env_vars({"url": "postgresql://${TEST_DB_USER}:${TEST_DB_ROLE}@${TEST_DB_HOST}/mydb"})
+        assert result["url"] == "postgresql://admin:readwrite@db.example.com/mydb"
+    finally:
+        del os.environ["TEST_DB_USER"]
+        del os.environ["TEST_DB_ROLE"]
+        del os.environ["TEST_DB_HOST"]
+
+
+def test_inline_substitution_missing_var_raises() -> None:
+    """Test that a missing var in an inline string raises ValueError."""
+    os.environ["TEST_INLINE_OK"] = "present"
+    os.environ.pop("TEST_INLINE_MISSING", None)
+    try:
+        with pytest.raises(ValueError, match="TEST_INLINE_MISSING"):
+            _resolve_env_vars({"url": "prefix-${TEST_INLINE_OK}-${TEST_INLINE_MISSING}-suffix"})
+    finally:
+        del os.environ["TEST_INLINE_OK"]
+
+
+def test_single_inline_var_with_surrounding_text() -> None:
+    """Test a single var reference with surrounding text."""
+    os.environ["TEST_PORT"] = "5432"
+    try:
+        result = _resolve_env_vars({"host": "localhost:${TEST_PORT}"})
+        assert result["host"] == "localhost:5432"
+    finally:
+        del os.environ["TEST_PORT"]


### PR DESCRIPTION
## Description
Previously `_resolve_env_vars` only resolved environment variables when the entire string value was a single `${VAR}` reference. Strings with multiple embedded references (e.g. connection URLs like `postgresql://${DB_USER}:${DB_ROLE}@${DB_HOST}/mydb`) were not substituted.

This switches to `re.sub` with a replacer function so all `${...}` patterns within a string are resolved inline, enabling real-world config patterns like database URLs with multiple env var references.

## PR Type
- 🐛 Bug Fix

## Relevant issues
Fixes #921

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: N/A

- [x] I am an AI Agent filling out this form (check box if true)