### PR TITLE
feat(gateway): add GET /v1/models endpoint for OpenAI compatibility

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -614,6 +614,57 @@
         "title": "MessagesRequest",
         "type": "object"
       },
+      "ModelListResponse": {
+        "description": "OpenAI-compatible model list response.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ModelObject"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "object": {
+            "default": "list",
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ModelListResponse",
+        "type": "object"
+      },
+      "ModelObject": {
+        "description": "OpenAI-compatible model object.",
+        "properties": {
+          "created": {
+            "title": "Created",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "object": {
+            "default": "model",
+            "title": "Object",
+            "type": "string"
+          },
+          "owned_by": {
+            "title": "Owned By",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created",
+          "owned_by"
+        ],
+        "title": "ModelObject",
+        "type": "object"
+      },
       "PricingResponse": {
         "description": "Response model for model pricing.",
         "properties": {
@@ -1688,6 +1739,71 @@
         "summary": "Create Message",
         "tags": [
           "messages"
+        ]
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "description": "List all available models.\n\nReturns models derived from the model_pricing table in an\nOpenAI-compatible format.",
+        "operationId": "list_models_v1_models_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Models",
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/v1/models/{model_id}": {
+      "get": {
+        "description": "Get details for a specific model.",
+        "operationId": "get_model_v1_models__model_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_id",
+            "required": true,
+            "schema": {
+              "title": "Model Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Model",
+        "tags": [
+          "models"
         ]
       }
     },

--- a/src/any_llm/gateway/routes/models.py
+++ b/src/any_llm/gateway/routes/models.py
@@ -1,0 +1,71 @@
+"""OpenAI-compatible models listing endpoint."""
+
+import calendar
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from any_llm.gateway.auth import verify_api_key_or_master_key
+from any_llm.gateway.db import ModelPricing, get_db
+
+router = APIRouter(prefix="/v1", tags=["models"])
+
+
+class ModelObject(BaseModel):
+    """OpenAI-compatible model object."""
+
+    id: str
+    object: str = "model"
+    created: int
+    owned_by: str
+
+
+class ModelListResponse(BaseModel):
+    """OpenAI-compatible model list response."""
+
+    object: str = "list"
+    data: list[ModelObject]
+
+
+def _model_from_pricing(pricing: ModelPricing) -> ModelObject:
+    """Convert a ModelPricing row to an OpenAI-compatible ModelObject."""
+    parts = pricing.model_key.split(":", 1)
+    owned_by = parts[0] if len(parts) > 1 else "unknown"
+    created = int(calendar.timegm(pricing.created_at.utctimetuple()))
+    return ModelObject(
+        id=pricing.model_key,
+        created=created,
+        owned_by=owned_by,
+    )
+
+
+@router.get("/models", dependencies=[Depends(verify_api_key_or_master_key)])
+async def list_models(
+    db: Annotated[Session, Depends(get_db)],
+) -> ModelListResponse:
+    """List all available models.
+
+    Returns models derived from the model_pricing table in an
+    OpenAI-compatible format.
+    """
+    pricings = db.query(ModelPricing).order_by(ModelPricing.model_key).all()
+    return ModelListResponse(data=[_model_from_pricing(p) for p in pricings])
+
+
+@router.get("/models/{model_id:path}", dependencies=[Depends(verify_api_key_or_master_key)])
+async def get_model(
+    model_id: str,
+    db: Annotated[Session, Depends(get_db)],
+) -> ModelObject:
+    """Get details for a specific model."""
+    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_id).first()
+
+    if not pricing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model '{model_id}' not found",
+        )
+
+    return _model_from_pricing(pricing)

--- a/src/any_llm/gateway/server.py
+++ b/src/any_llm/gateway/server.py
@@ -7,7 +7,7 @@ from any_llm.gateway.config import GatewayConfig
 from any_llm.gateway.db import get_db, init_db
 from any_llm.gateway.pricing_init import initialize_pricing_from_config
 from any_llm.gateway.rate_limit import RateLimiter
-from any_llm.gateway.routes import budgets, chat, health, keys, messages, pricing, users
+from any_llm.gateway.routes import budgets, chat, health, keys, messages, models, pricing, users
 
 
 def create_app(config: GatewayConfig) -> FastAPI:
@@ -52,6 +52,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
 
     app.include_router(chat.router)
     app.include_router(messages.router)
+    app.include_router(models.router)
     app.include_router(keys.router)
     app.include_router(users.router)
     app.include_router(budgets.router)

--- a/tests/gateway/test_models_endpoint.py
+++ b/tests/gateway/test_models_endpoint.py
@@ -1,0 +1,128 @@
+"""Tests for the GET /v1/models endpoint."""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+def test_list_models_empty(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """GET /v1/models returns empty list when no pricing is configured."""
+    resp = client.get("/v1/models", headers=master_key_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    assert data["data"] == []
+
+
+def test_list_models_returns_configured_models(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    model_pricing: dict[str, Any],
+) -> None:
+    """GET /v1/models returns models from the pricing table."""
+    resp = client.get("/v1/models", headers=master_key_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    assert len(data["data"]) >= 1
+
+    model = data["data"][0]
+    assert model["object"] == "model"
+    assert "id" in model
+    assert "created" in model
+    assert isinstance(model["created"], int)
+    assert "owned_by" in model
+
+
+def test_list_models_owned_by_from_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Models owned_by field is derived from the provider prefix."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o",
+            "input_price_per_million": 2.5,
+            "output_price_per_million": 10.0,
+        },
+        headers=master_key_header,
+    )
+
+    resp = client.get("/v1/models", headers=master_key_header)
+    assert resp.status_code == 200
+    models = resp.json()["data"]
+    gpt4 = next(m for m in models if m["id"] == "openai:gpt-4o")
+    assert gpt4["owned_by"] == "openai"
+
+
+def test_get_model_found(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    model_pricing: dict[str, Any],
+) -> None:
+    """GET /v1/models/{model_id} returns the model when it exists."""
+    model_key = model_pricing["model_key"]
+    resp = client.get(f"/v1/models/{model_key}", headers=master_key_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == model_key
+    assert data["object"] == "model"
+    assert isinstance(data["created"], int)
+    assert data["owned_by"] == model_key.split(":")[0]
+
+
+def test_get_model_not_found(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """GET /v1/models/{model_id} returns 404 for unknown models."""
+    resp = client.get("/v1/models/nonexistent:model", headers=master_key_header)
+    assert resp.status_code == 404
+
+
+def test_list_models_requires_auth(client: TestClient) -> None:
+    """GET /v1/models requires authentication."""
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+
+
+def test_get_model_requires_auth(client: TestClient) -> None:
+    """GET /v1/models/{model_id} requires authentication."""
+    resp = client.get("/v1/models/openai:gpt-4o")
+    assert resp.status_code == 401
+
+
+def test_list_models_with_api_key(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """GET /v1/models works with API key authentication (not just master key)."""
+    resp = client.get("/v1/models", headers=api_key_header)
+    assert resp.status_code == 200
+    assert resp.json()["object"] == "list"
+
+
+def test_list_models_sorted_by_key(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """GET /v1/models returns models sorted by model_key."""
+    for model_key in ["openai:gpt-4o", "anthropic:claude-3-haiku"]:
+        client.post(
+            "/v1/pricing",
+            json={
+                "model_key": model_key,
+                "input_price_per_million": 1.0,
+                "output_price_per_million": 1.0,
+            },
+            headers=master_key_header,
+        )
+
+    resp = client.get("/v1/models", headers=master_key_header)
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    assert ids == sorted(ids)


### PR DESCRIPTION
## Description

Every OpenAI client calls `GET /v1/models` on startup to discover available models. Without this endpoint, the gateway can't serve as a drop-in OpenAI-compatible proxy.

Adds two new endpoints:
- **`GET /v1/models`** — list all available models (sorted by key), sourced from the `model_pricing` table
- **`GET /v1/models/{model_id}`** — get details for a specific model

Response format matches the [OpenAI Models API](https://platform.openai.com/docs/api-reference/models):
```json
{
  "object": "list",
  "data": [
    {
      "id": "openai:gpt-4o",
      "object": "model",
      "created": 1686935002,
      "owned_by": "openai"
    }
  ]
}
```

Both endpoints require authentication (API key or master key).

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #935

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code

- [x] I am an AI Agent filling out this form (check box if true)