### PR TITLE
fix(ci): validate release tag matches release name before publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,18 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release tag matches release name
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          TAG="${TAG#v}"
+          NAME="${{ github.event.release.name }}"
+          NAME="${NAME#v}"
+          if [ "$TAG" != "$NAME" ]; then
+            echo "::error::Release tag '$TAG' does not match release name '$NAME'. Delete this release, fix the tag, and try again."
+            exit 1
+          fi
+
       - name: Check out the repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

Adds an early validation step to the release workflow that compares the git tag with the GitHub release name (stripping optional `v` prefix from both). If they don't match, the workflow fails immediately with a clear error message before any code is checked out or published to PyPI.

This prevents the scenario described in #952 where a release titled "1.12.0" was accidentally tagged as "1.11.1", causing version 1.11.1 to be published to PyPI.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #952

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: N/A

- [x] I am an AI Agent filling out this form (check box if true)

> Note: No unit test added because this is a GitHub Actions workflow change — the validation is a simple shell string comparison that runs as a CI step. It cannot be meaningfully tested with pytest.