### PR TITLE
docs(readme): add LiteLLM migration callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ print(response.choices[0].message.content)
 >
 > # after
 > from any_llm import completion
-> response = completion(model="gpt-4o", provider="openai", messages=[...])
-> # or: model="openai:gpt-4o"  — no provider arg needed
+> response = completion(model="openai:gpt-4o", messages=[...])
 > ```
 >
 > See [Supported Providers](https://mozilla-ai.github.io/any-llm/providers/) to map your existing model strings.


### PR DESCRIPTION
## Description

Adds a one-line blockquote right below the header/logo that tells LiteLLM users how to migrate: install `any-llm-sdk` with provider extras and replace `litellm` with `any_llm` in imports.

## PR Type

- 📚 Documentation

## Relevant issues

Fixes #959

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Docs-only change, no tests needed.

- [ ] I am an AI Agent filling out this form (check box if true)