### PR TITLE
feat(docs): restore cookbooks with build-time notebook conversion

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,6 +10,7 @@ on:
       - 'scripts/generate_llms_txt.py'
       - 'scripts/generate_openapi.py'
       - 'scripts/generate_api_docs.py'
+      - 'scripts/generate_cookbooks.py'
       - '.github/workflows/**'
       - 'pyproject.toml'
   pull_request:
@@ -20,6 +21,7 @@ on:
       - 'scripts/generate_llms_txt.py'
       - 'scripts/generate_openapi.py'
       - 'scripts/generate_api_docs.py'
+      - 'scripts/generate_cookbooks.py'
       - '.github/workflows/**'
       - 'pyproject.toml'
   workflow_dispatch:
@@ -63,6 +65,9 @@ jobs:
 
       - name: Generate API docs
         run: uv run python scripts/generate_api_docs.py
+
+      - name: Generate cookbook pages
+        run: uv run python scripts/generate_cookbooks.py
 
       - name: Build docs
         working-directory: docs

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .astro/
 src/content/docs/api/
+src/content/docs/cookbooks/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,6 +35,12 @@ export default defineConfig({
         { label: "Quickstart", slug: "quickstart" },
         { label: "Providers", slug: "providers" },
         {
+          label: "Cookbooks",
+          items: [
+            { label: "Getting Started", slug: "cookbooks/any-llm-getting-started" },
+          ],
+        },
+        {
           label: "API Reference",
           items: [
             { label: "AnyLLM", slug: "api/any-llm" },

--- a/docs/cookbooks/any_llm_getting_started.ipynb
+++ b/docs/cookbooks/any_llm_getting_started.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Any-LLM\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mozilla-ai/any-llm/blob/main/docs/cookbooks/any_llm_getting_started.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Any-LLM is a unified interface that lets you work with language models from any provider using a consistent API. Whether you're using OpenAI, Anthropic, Google, local models, or open-source alternatives, any-llm makes it easy to switch between them without changing your code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Why Any-LLM?\n",
+    "- Provider Agnostic: One API for all LLM providers\n",
+    "- Easy Switching: Change models with a single line\n",
+    "- Cost Comparison: Compare costs across providers\n",
+    "- Streaming Support: Real-time responses from any model\n",
+    "- Type Safe: Full TypeScript/Python type support"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install any-llm-sdk[all] nest-asyncio -q\n",
+    "\n",
+    "# nest_asyncio allows us to use 'await' directly in Jupyter notebooks\n",
+    "# This is needed because any-llm uses async functions for API calls\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Setting Up API Keys\n",
+    "Different providers require different API keys. Let's set them up properly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "\n",
+    "def setup_api_key(key_name: str, provider: str) -> None:\n",
+    "    \"\"\"Set up API key for the specified provider.\"\"\"\n",
+    "    if key_name not in os.environ:\n",
+    "        print(f\"🔑 {key_name} not found in environment\")\n",
+    "        api_key = getpass(f\"Enter your {provider} API key (or press Enter to skip): \")\n",
+    "        if api_key:\n",
+    "            os.environ[key_name] = api_key\n",
+    "            print(f\"✅ {key_name} set for this session\")\n",
+    "        else:\n",
+    "            print(f\"⏭️  Skipping {provider}\")\n",
+    "    else:\n",
+    "        print(f\"✅ {key_name} found in environment\")\n",
+    "\n",
+    "\n",
+    "# Set up keys for different providers\n",
+    "print(\"Setting up API keys...\\n\")\n",
+    "setup_api_key(\"OPENAI_API_KEY\", \"OpenAI\")\n",
+    "setup_api_key(\"ANTHROPIC_API_KEY\", \"Anthropic\")\n",
+    "\n",
+    "#  You could add more using :\n",
+    "# setup_api_key(\"GOOGLE_API_KEY\", \"Google\")\n",
+    "# setup_api_key(\"MISTRAL_API_KEY\", \"Mistral\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## List Models Across Providers \n",
+    "`any_llm` can list all available models for an LLM provider - in this case, we are listing out models supported by OpenAI and Anthropic. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from any_llm import AnyLLM, LLMProvider\n",
+    "\n",
+    "for provider in [LLMProvider.OPENAI, LLMProvider.ANTHROPIC]:\n",
+    "    client = AnyLLM.create(provider=provider)\n",
+    "    models = client.list_models()\n",
+    "    print(f\"Provider: {provider}\")\n",
+    "    print(\", \".join([model.id for model in models]))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "### Expected output\n",
+    "Provider: openai\n",
+    "gpt-4o-mini, gpt-4-0613, gpt-4, gpt-3.5-turbo, gpt-5-search-api-2025-10-14, gpt-realtime-mini, gpt-realtime-mini-2025-10-06, sora-2, sora-2-pro, davinci-002, babbage-002, gpt-3.5-turbo-instruct, gpt-3.5-turbo-instruct-0914...\n",
+    "\n",
+    "Provider: anthropic\n",
+    "claude-haiku-4-5-20251001, claude-sonnet-4-5-20250929, claude-opus-4-1-20250805, claude-opus-4-20250514, claude-sonnet-4-20250514, claude-3-7-sonnet-20250219, claude-3-5-haiku-20241022, claude-3-haiku-20240307\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Generate Text\n",
+    "Let's use one model from each provider to generate text for the same prompt. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from any_llm import acompletion\n",
+    "from any_llm.types.completion import ChatCompletion\n",
+    "\n",
+    "prompt = \"Write a Haiku on the solar system.\"\n",
+    "\n",
+    "# OpenAI\n",
+    "model = \"openai:gpt-4o-mini\"\n",
+    "result = await acompletion(\n",
+    "    model=model,\n",
+    "    messages=[\n",
+    "        {\"role\": \"user\", \"content\": prompt},\n",
+    "    ],\n",
+    ")\n",
+    "assert isinstance(result, ChatCompletion)\n",
+    "\n",
+    "print(f\"Model: {result.model}\")\n",
+    "print(f\"Response:\\n{result.choices[0].message.content}\\n\")\n",
+    "\n",
+    "# Anthropic\n",
+    "model = \"anthropic:claude-haiku-4-5-20251001\"\n",
+    "result = await acompletion(\n",
+    "    model=model,\n",
+    "    messages=[\n",
+    "        {\"role\": \"user\", \"content\": prompt},\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "assert isinstance(result, ChatCompletion)\n",
+    "\n",
+    "print(f\"Model: {result.model}\")\n",
+    "print(f\"Response:\\n{result.choices[0].message.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Expected Output \n",
+    "\n",
+    "*Note: The haiku content will be different each time since it's generated by the LLM. This example shows the output format.*\n",
+    "\n",
+    "Model: gpt-4o-mini-2024-07-18\n",
+    "Response:\n",
+    "\n",
+    "Planets spin and dance,  \n",
+    "In the vast cosmic embrace,  \n",
+    "Stars whisper their tales.\n",
+    "\n",
+    "Model: claude-haiku-4-5-20251001\n",
+    "Response:\n",
+    "\n",
+    "Eight worlds circle round,  \n",
+    "Sun's gravity holds them close—  \n",
+    "Dance through endless void."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/generate_cookbooks.py
+++ b/scripts/generate_cookbooks.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Convert Jupyter notebooks in docs/cookbooks/ to Starlight-compatible .mdx pages.
+
+Reads each .ipynb file, converts cells to markdown/code blocks, and writes the
+result into docs/src/content/docs/cookbooks/. A Colab badge is injected at the
+top of each generated page.
+
+Usage:
+    python scripts/generate_cookbooks.py          # Generate .mdx files
+    python scripts/generate_cookbooks.py --check   # Verify .mdx files are up-to-date
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+COOKBOOKS_SRC = REPO_ROOT / "docs" / "cookbooks"
+COOKBOOKS_DEST = REPO_ROOT / "docs" / "src" / "content" / "docs" / "cookbooks"
+GITHUB_BASE = "https://colab.research.google.com/github/mozilla-ai/any-llm/blob/main/docs/cookbooks"
+
+
+def notebook_to_mdx(notebook_path: Path) -> str:
+    """Convert a single .ipynb file to an .mdx string."""
+    with open(notebook_path, encoding="utf-8") as f:
+        nb = json.load(f)
+
+    cells = nb.get("cells", [])
+    if not cells:
+        return ""
+
+    # Extract title from first cell if it's a markdown heading
+    title = notebook_path.stem.replace("_", " ").title()
+    first_cell_source = "".join(cells[0].get("source", []))
+    if first_cell_source.startswith("# "):
+        title = first_cell_source.lstrip("# ").strip()
+
+    colab_url = f"{GITHUB_BASE}/{notebook_path.name}"
+
+    lines: list[str] = []
+    lines.append("---")
+    lines.append(f"title: {title}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]({colab_url})")
+    lines.append("")
+
+    for cell in cells:
+        source = "".join(cell.get("source", []))
+        if not source.strip():
+            continue
+
+        cell_type = cell.get("cell_type", "code")
+
+        if cell_type == "markdown":
+            # Skip the title cell (already in frontmatter) and the Colab badge
+            # cell (already injected above).
+            stripped = source.strip()
+            if stripped.startswith("# ") and cell is cells[0]:
+                continue
+            if "colab-badge.svg" in stripped:
+                continue
+            lines.append(source)
+            lines.append("")
+        elif cell_type == "code":
+            lines.append("```python")
+            lines.append(source)
+            lines.append("```")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def slug_for(notebook_path: Path) -> str:
+    """Return the output .mdx filename for a notebook."""
+    return notebook_path.stem.replace("_", "-") + ".mdx"
+
+
+def generate_all() -> dict[Path, str]:
+    """Generate .mdx content for every notebook. Returns {dest_path: content}."""
+    results: dict[Path, str] = {}
+    if not COOKBOOKS_SRC.exists():
+        return results
+
+    for nb_path in sorted(COOKBOOKS_SRC.glob("*.ipynb")):
+        dest = COOKBOOKS_DEST / slug_for(nb_path)
+        results[dest] = notebook_to_mdx(nb_path)
+
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert cookbook notebooks to .mdx")
+    parser.add_argument("--check", action="store_true", help="Check if .mdx files are up-to-date")
+    args = parser.parse_args()
+
+    pages = generate_all()
+
+    if not pages:
+        print("No notebooks found in docs/cookbooks/", file=sys.stderr)
+        return 1
+
+    if args.check:
+        for dest, content in pages.items():
+            if not dest.exists():
+                print(f"Missing: {dest}", file=sys.stderr)
+                print("Run 'python scripts/generate_cookbooks.py' to generate cookbook pages.", file=sys.stderr)
+                return 1
+            if dest.read_text(encoding="utf-8") != content:
+                print(f"Out of date: {dest}", file=sys.stderr)
+                print("Run 'python scripts/generate_cookbooks.py' to regenerate cookbook pages.", file=sys.stderr)
+                return 1
+        print(f"✓ {len(pages)} cookbook page(s) up to date")
+        return 0
+
+    COOKBOOKS_DEST.mkdir(parents=True, exist_ok=True)
+    for dest, content in pages.items():
+        dest.write_text(content, encoding="utf-8")
+        print(f"✓ {dest.relative_to(REPO_ROOT)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

The MkDocs-to-Starlight migration (#900) accidentally dropped the `docs/cookbooks/` directory. This restores the getting-started notebook and adds a build-time conversion pipeline so notebooks are automatically rendered as Starlight pages.

**What's included:**
- Restored `docs/cookbooks/any_llm_getting_started.ipynb` (unchanged from before the migration)
- New `scripts/generate_cookbooks.py` — converts `.ipynb` files to `.mdx` with Starlight frontmatter and Colab badge (supports `--check` for CI validation)
- Cookbooks sidebar section in `docs/astro.config.mjs`
- CI workflow updated to run the generation script before build
- Generated `.mdx` files gitignored (same pattern as `api/` docs)

The `.ipynb` remains the single source of truth — the Colab "Open in Colab" link points to the same notebook path as before.

## PR Type

- 📚 Documentation
- 🚦 Infrastructure

## Relevant issues

Follow-up to #900 (cookbooks were unintentionally removed in that migration)

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Notebook restoration + build script creation + CI/sidebar wiring.

- [x] I am an AI Agent filling out this form (check box if true)