### PR TITLE
fix(docs): show sidebar navigation on landing page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: any-llm
 description: A Python library providing a single interface to different LLM providers including OpenAI, Anthropic, Mistral, and more
-template: splash
+template: doc
 hero:
   title: One interface. Every LLM.
   image:


### PR DESCRIPTION
## Summary
- Switch the landing page Starlight template from `splash` to `doc` so the sidebar navigation is visible on the index page, consistent with the rest of the docs site.

## Test plan
- [ ] Run `npx astro dev` and verify the sidebar nav appears on the landing page
- [ ] Confirm the hero section still renders correctly
- [ ] Check that all sidebar links work from the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)