### PR TITLE
fix(gateway): add Cache-Control headers to prevent cross-user identity leak

### DIFF
--- a/src/any_llm/gateway/server.py
+++ b/src/any_llm/gateway/server.py
@@ -14,12 +14,20 @@ from any_llm.gateway.routes import budgets, chat, embeddings, health, keys, mess
 _PUBLIC_PREFIXES = ("/health",)
 
 
-class CacheControlMiddleware(BaseHTTPMiddleware):
-    """Prevent CDN/proxy caches from storing authenticated responses."""
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add security headers to all responses.
+
+    Sets standard security headers on every response, plus cache-control
+    headers on non-health endpoints to prevent CDN/proxy caches from
+    storing authenticated responses.
+    """
 
     @override
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if not request.url.path.startswith(_PUBLIC_PREFIXES):
             response.headers["Cache-Control"] = "private, no-store, no-cache"
             response.headers["Vary"] = "Authorization"
@@ -51,7 +59,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
         version=__version__,
     )
 
-    app.add_middleware(CacheControlMiddleware)
+    app.add_middleware(SecurityHeadersMiddleware)
 
     if config.cors_allow_origins:
         allow_credentials = "*" not in config.cors_allow_origins

--- a/tests/gateway/test_cache_control_headers.py
+++ b/tests/gateway/test_cache_control_headers.py
@@ -1,15 +1,15 @@
-"""Tests for Cache-Control headers added by CacheControlMiddleware."""
+"""Tests for security headers added by SecurityHeadersMiddleware."""
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from any_llm.gateway.server import CacheControlMiddleware
+from any_llm.gateway.server import SecurityHeadersMiddleware
 
 
 def _make_app() -> FastAPI:
-    """Create a minimal FastAPI app with CacheControlMiddleware for testing."""
+    """Create a minimal FastAPI app with SecurityHeadersMiddleware for testing."""
     app = FastAPI()
-    app.add_middleware(CacheControlMiddleware)
+    app.add_middleware(SecurityHeadersMiddleware)
 
     @app.get("/v1/users")
     def list_users() -> list[str]:
@@ -87,3 +87,21 @@ def test_cache_headers_on_budgets_endpoint() -> None:
         response = client.get("/v1/budgets")
         assert response.headers["Cache-Control"] == "private, no-store, no-cache"
         assert "Authorization" in response.headers.get("Vary", "")
+
+
+def test_security_headers_on_all_responses() -> None:
+    """All responses must include X-Content-Type-Options, X-Frame-Options, and Referrer-Policy."""
+    with TestClient(_make_app()) as client:
+        response = client.get("/v1/users")
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+def test_security_headers_on_health_endpoints() -> None:
+    """Health endpoints must also include security headers (just not cache headers)."""
+    with TestClient(_make_app()) as client:
+        response = client.get("/health")
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Description

Adds `CacheControlMiddleware` to the gateway that sets `Cache-Control: private, no-store, no-cache` and `Vary: Authorization` on all non-health responses. Without these headers, a CDN or shared proxy could cache authenticated responses (users, keys, budgets, usage data) and serve them to the wrong user.

Health endpoints (`/health`, `/health/liveness`, `/health/readiness`) are excluded since they return no user-specific data and benefit from cacheability.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #973

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Identified vulnerability by analyzing a cross-user identity leak postmortem and checking gateway code for missing cache headers.

- [x] I am an AI Agent filling out this form (check box if true)