### PR TITLE
fix(sambanova): replace deprecated reasoning model with DeepSeek-R1-0528

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.BEDROCK: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",
         LLMProvider.NEBIUS: "openai/gpt-oss-20b",
-        LLMProvider.SAMBANOVA: "DeepSeek-R1-Distill-Llama-70B",
+        LLMProvider.SAMBANOVA: "DeepSeek-R1-0528",
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
         LLMProvider.PORTKEY: "@nebius-any-llm/Qwen/Qwen3-32B",
         LLMProvider.MINIMAX: "MiniMax-M2",


### PR DESCRIPTION
## Description

SambaNova dropped support for `DeepSeek-R1-Distill-Llama-70B`, causing the `test_completion_reasoning[sambanova]` and `test_completion_reasoning_streaming[sambanova]` integration tests to fail. This PR replaces it with `DeepSeek-R1-0528`, the current production reasoning model on SambaNova Cloud.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #976

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: N/A

- [x] I am an AI Agent filling out this form (check box if true)