### PR TITLE
chore: add supply chain attack guards for uv and npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ Documentation = "https://mozilla-ai.github.io/any-llm/"
 Issues = "https://github.com/mozilla-ai/any-llm/issues"
 Source = "https://github.com/mozilla-ai/any-llm"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 "any_llm.gateway" = ["alembic.ini", "alembic/**/*"]


### PR DESCRIPTION
## Description

Add supply chain attack protection by requiring packages to be at least 7 days old before installation. Most malicious packages are detected and removed within hours of publication, so this delay significantly reduces exposure to compromised dependencies.

- **uv (Python):** `exclude-newer = "7 days"` in `pyproject.toml` under `[tool.uv]`
- **npm (docs site):** `min-release-age=7` in `.npmrc` (requires npm 11.10.0+; harmless warning on older versions)

## PR Type

- 🚦 Infrastructure

## Relevant issues

Fixes #982

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: N/A

- [x] I am an AI Agent filling out this form (check box if true)