### PR TITLE
feat(gateway): Config to disable FastAPI docs endpoints (on by default)

### DIFF
--- a/src/any_llm/gateway/core/config.py
+++ b/src/any_llm/gateway/core/config.py
@@ -55,6 +55,10 @@ class GatewayConfig(BaseSettings):
         default=False,
         description="Enable Prometheus metrics endpoint at /metrics",
     )
+    enable_docs: bool = Field(
+        default=True,
+        description="Enable FastAPI docs endpoints (/docs, /redoc, /openapi.json). Enabled by default.",
+    )
     bootstrap_api_key: bool = Field(
         default=True,
         description="Create a first-use API key on startup when no API keys exist",

--- a/src/any_llm/gateway/main.py
+++ b/src/any_llm/gateway/main.py
@@ -148,6 +148,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         title="any-llm-gateway",
         description="A clean FastAPI gateway for any-llm with API key management",
         version=__version__,
+        docs_url="/docs" if config.enable_docs else None,
+        redoc_url="/redoc" if config.enable_docs else None,
+        openapi_url="/openapi.json" if config.enable_docs else None,
     )
 
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)


### PR DESCRIPTION
## Description

Adds an `enable_docs` config flag that controls whether the gateway exposes FastAPI's `/docs`, `/redoc`, and `/openapi.json` endpoints.

Today these endpoints are always live because `FastAPI()` is constructed without overriding the defaults. They're unauthenticated and enumerate the full API surface (including admin routes), which is extra attack surface for public-facing deployments. Operators have no way to turn them off.

This change:

- Adds `enable_docs: bool = True` to `GatewayConfig`, using the existing `GATEWAY_` env prefix so operators can flip it via `GATEWAY_ENABLE_DOCS=false`.
- Wires the flag into `create_app` so `docs_url`/`redoc_url`/`openapi_url` become `None` when the flag is off.
- **Default is `true`** to preserve existing behavior — no action needed to keep docs working.


## PR Type

- 🆕 New Feature


## Relevant issues

Closes the manually-filed issue for making docs endpoints configurable.


## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: AI was used to draft the config flag wiring and PR copy. The change is intentionally small — one field on `GatewayConfig` and three `FastAPI()` kwargs.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
