### PR TITLE
fix(xai): support OpenAI dict response_format for structured output

### DIFF
--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -153,6 +153,21 @@ class XaiProvider(AnyLLM):
                 format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
                 schema=json.dumps(get_json_schema(params.response_format)),
             )
+        elif params.response_format is not None and isinstance(params.response_format, dict):
+            from xai_sdk.proto import chat_pb2
+
+            rf = params.response_format
+            if rf.get("type") == "json_schema":
+                json_schema = rf.get("json_schema", {})
+                schema = json_schema.get("schema", {})
+                response_format_pb = chat_pb2.ResponseFormat(
+                    format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
+                    schema=json.dumps(schema),
+                )
+            elif rf.get("type") == "json_object":
+                response_format_pb = chat_pb2.ResponseFormat(
+                    format_type=chat_pb2.FORMAT_TYPE_JSON_OBJECT,
+                )
 
         chat = self.client.chat.create(
             model=params.model_id,

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -90,6 +90,46 @@ async def test_dataclass_response_format_uses_sample_not_parse() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dict_json_schema_response_format_uses_sample_not_parse() -> None:
+    """Test that OpenAI dict response_format is converted to protobuf and uses sample()."""
+    from any_llm.providers.xai.xai import XaiProvider
+
+    openai_json_schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "TestOutput",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+
+    with mock_xai_provider() as (mock_xai, _):
+        create_return = mock_xai.return_value.chat.create.return_value
+
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="model",
+                messages=[{"role": "user", "content": "Hello"}],
+                response_format=openai_json_schema,
+            )
+        )
+
+        # Should call sample(), not parse()
+        create_return.sample.assert_called_once()
+        create_return.parse.assert_not_called()
+
+        # Should pass response_format protobuf to create()
+        _, call_kwargs = mock_xai.return_value.chat.create.call_args
+        assert call_kwargs["response_format"] is not None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("reasoning_effort", ["auto", "none"])
 async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
     """Test that reasoning_effort 'auto' and 'none' are filtered from xAI API calls."""


### PR DESCRIPTION
## Description
The XAI provider now handles OpenAI-format `response_format` dicts (e.g. `{"type": "json_schema", "json_schema": {...}}`). Previously, passing a dict would fall through to `chat.parse()`, which expects a Pydantic model and fails. The fix extracts the schema from the dict and builds the XAI protobuf `ResponseFormat` directly, the same path already used for dataclasses.

Both `json_schema` and `json_object` format types are supported.

## PR Type
- 🐛 Bug Fix

## Relevant issues
Fixes #542

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.4 (implementation), Claude Opus 4.6 (planning/review)
- AI Developer Tool used: Claude Code + Codex CLI
- Any other info you'd like to share: Investigated the existing dataclass/Pydantic handling in `_acompletion()` and extended the same protobuf pattern to dict inputs. The downstream `create()`/`sample()` logic already worked correctly when `response_format_pb` is set.

- [ ] I am an AI Agent filling out this form (check box if true)

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)