### PR TITLE
fix(gemini): support OpenAI dict response_format for structured output

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -147,6 +147,14 @@ class GoogleProvider(AnyLLM):
         if is_structured_output_type(response_format):
             kwargs["response_mime_type"] = "application/json"
             kwargs["response_schema"] = get_json_schema(response_format)
+        elif isinstance(response_format, dict):
+            if response_format.get("type") == "json_schema":
+                json_schema = response_format.get("json_schema", {})
+                schema = json_schema.get("schema", {})
+                kwargs["response_mime_type"] = "application/json"
+                kwargs["response_schema"] = schema
+            elif response_format.get("type") == "json_object":
+                kwargs["response_mime_type"] = "application/json"
 
         formatted_messages, system_instruction = _convert_messages(params.messages, provider_name=provider_name)
         if system_instruction:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -294,6 +294,43 @@ async def test_completion_with_dataclass_response_format() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completion_with_dict_json_schema_response_format() -> None:
+    """Test that OpenAI dict response_format is converted to JSON schema for Gemini."""
+    openai_json_schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "TestOutput",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "value": {"type": "integer"}},
+                "required": ["name", "value"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+
+    api_key = "test-api-key"
+    model = "gemini-pro"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key=api_key)
+        await provider._acompletion(
+            CompletionParams(model_id=model, messages=messages, response_format=openai_json_schema)
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        generation_config = call_kwargs["config"]
+
+        assert generation_config.response_mime_type == "application/json"
+        assert isinstance(generation_config.response_schema, dict)
+        assert "properties" in generation_config.response_schema
+        assert "name" in generation_config.response_schema["properties"]
+        assert "value" in generation_config.response_schema["properties"]
+
+
+@pytest.mark.asyncio
 async def test_completion_with_stream_and_response_format_raises() -> None:
     api_key = "test-api-key"
     model = "gemini-pro"


### PR DESCRIPTION
## Description
The Gemini provider now handles OpenAI-format `response_format` dicts (e.g. `{"type": "json_schema", "json_schema": {...}}`). Previously, only Pydantic models and dataclasses were converted. Passing a dict was silently ignored, so structured output was never enforced.

The fix extracts the schema from the dict and passes it as `response_schema` with `application/json` mime type. Both `json_schema` and `json_object` format types are handled.

## PR Type
- 🐛 Bug Fix

## Relevant issues
Fixes #541

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.4 (implementation), Claude Opus 4.6 (planning/review)
- AI Developer Tool used: Claude Code + Codex CLI
- Any other info you'd like to share: Same pattern as #542 (XAI), extended to Gemini. Extracted schema from the OpenAI dict and passed it through the existing `response_schema` / `response_mime_type` kwargs.

- [ ] I am an AI Agent filling out this form (check box if true)

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)