### PR TITLE
fix: resolve mypy indexing error in gemini test and document mypy guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,11 @@ This repo uses `uv` for local dev (Python 3.11+). For the full, up-to-date comma
 - Commits follow the project’s history: Conventional Commits such as `feat(scope): ...`, `fix: ...`, `chore(deps): ...`, `tests: ...`.
 - PRs should follow [.github/pull_request_template.md](.github/pull_request_template.md): clear description, linked issues (e.g., `Fixes #123`), completed checklist, and AI-usage disclosure when applicable.
 
+## Mypy and Provider SDKs
+
+- Provider SDKs are optional and may not be installed locally. When missing, mypy treats their types as `Any`, which makes `# type: ignore` comments appear "unused" even though they suppress real errors in CI.
+- Do not remove `# type: ignore` comments based on local mypy output. CI (`run-linter`) is the authoritative environment.
+
 ## Security & Configuration Tips
 
 - Never commit secrets. Use environment variables or a local `.env` (gitignored) for provider API keys.

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -298,18 +298,19 @@ async def test_completion_with_dict_json_schema_response_format() -> None:
     api_key = "test-api-key"
     model = "gemini-pro"
     messages = [{"role": "user", "content": "Hello"}]
-    response_format = {
+    expected_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "value": {"type": "integer"},
+        },
+        "required": ["name", "value"],
+    }
+    response_format: dict[str, Any] = {
         "type": "json_schema",
         "json_schema": {
             "name": "TestOutput",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "value": {"type": "integer"},
-                },
-                "required": ["name", "value"],
-            },
+            "schema": expected_schema,
         },
     }
 
@@ -323,7 +324,7 @@ async def test_completion_with_dict_json_schema_response_format() -> None:
         generation_config = call_kwargs["config"]
 
         assert generation_config.response_mime_type == "application/json"
-        assert generation_config.response_schema == response_format["json_schema"]["schema"]
+        assert generation_config.response_schema == expected_schema
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Fix the mypy `[index]` error on main in `test_gemini_provider.py:326` by extracting the nested schema dict with an explicit `dict[str, Any]` type annotation. Also adds a section to `AGENTS.md` documenting that `type: ignore` comments in provider code must not be removed based on local mypy output alone, since missing optional provider SDKs cause mypy to falsely report them as unused.

## PR Type
- 🐛 Bug Fix

## Changes
- `tests/unit/providers/test_gemini_provider.py`: Extract `expected_schema` variable with explicit type annotation to avoid mypy `Collection[str]` indexing error
- `AGENTS.md`: Add "Mypy and Provider SDKs" section documenting the relationship between optional SDK installs and `type: ignore` validity

## Checklist
- [x] I understand the code I am submitting.
- [x] New and existing tests pass locally
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## Test plan
- [x] Fixes the failing `run-linter` CI on main: https://github.com/mozilla-ai/any-llm/actions/runs/24041877245/job/70115386769
- [x] No behavioral changes to tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)