### PR TITLE
fix(llama): use accessible model for integration tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ Documentation = "https://mozilla-ai.github.io/any-llm/"
 Issues = "https://github.com/mozilla-ai/any-llm/issues"
 Source = "https://github.com/mozilla-ai/any-llm"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 "any_llm.gateway" = ["alembic.ini", "alembic/**/*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-20b",
         LLMProvider.GROQ: "openai/gpt-oss-20b",
         LLMProvider.PORTKEY: "@any-llm-test/gpt-4.1-mini",
-        LLMProvider.LLAMA: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        LLMProvider.LLAMA: "Llama-3.3-8B-Instruct",
         LLMProvider.AZURE: "openai/gpt-4.1-nano",
         LLMProvider.AZUREOPENAI: "gpt-4.1-nano",
         LLMProvider.PERPLEXITY: "sonar",


### PR DESCRIPTION
## Summary
- Switch Llama integration test model from `Llama-4-Maverick-17B-128E-Instruct-FP8` to `Llama-3.3-8B-Instruct`
- The Llama API returns 403 `permission_denied` ("The requested model is not available for your application") for the Maverick model
- `Llama-3.3-8B-Instruct` is a lightweight text-only model available on the current API plan

## Test plan
- [ ] Integration tests pass for the `llama` provider (all 10 previously failing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>