### PR TITLE
fix(ci): remove llama from expected integration test providers

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Set expected providers for integration tests
         id: set_providers
-        run: echo "expected_providers=anthropic,azureopenai,bedrock,cerebras,cohere,deepseek,fireworks,gemini,groq,huggingface,inception,llama,mistral,moonshot,nebius,openai,openrouter,perplexity,portkey,together,sambanova,voyage,xai,zai,minimax" >> $GITHUB_OUTPUT
+        run: echo "expected_providers=anthropic,azureopenai,bedrock,cerebras,cohere,deepseek,fireworks,gemini,groq,huggingface,inception,mistral,moonshot,nebius,openai,openrouter,perplexity,portkey,together,sambanova,voyage,xai,zai,minimax" >> $GITHUB_OUTPUT
 
       - name: Set expected providers for local integration tests
         id: set_local_providers
@@ -106,7 +106,6 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           INCEPTION_API_KEY: ${{ secrets.INCEPTION_API_KEY }}
-          LLAMA_API_KEY: ${{ secrets.LLAMA_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           NEBIUS_API_KEY: ${{ secrets.NEBIUS_API_KEY }}


### PR DESCRIPTION
## Summary
- Removes `llama` from `EXPECTED_PROVIDERS` in the integration test workflow
- Removes the `LLAMA_API_KEY` secret reference from the workflow env

The `LLAMA_API_KEY` secret was removed but `llama` was still listed in `EXPECTED_PROVIDERS`. The integration test skip logic re-raises `MissingApiKeyError` for expected providers instead of skipping, which caused all llama tests to fail rather than skip.

## Test plan
- [ ] Verify integration tests pass (llama tests should now skip instead of fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)