### PR TITLE
feat(gateway): add platform mode for user-token authentication

### DIFF
--- a/src/any_llm/exceptions.py
+++ b/src/any_llm/exceptions.py
@@ -44,9 +44,25 @@ class AnyLLMError(Exception):
 
 
 class RateLimitError(AnyLLMError):
-    """Raised when the API rate limit is exceeded."""
+    """Raised when the API rate limit is exceeded.
+
+    Attributes:
+        retry_after: Value of the ``Retry-After`` header, when the server
+            provides one.  May be a number of seconds or an HTTP-date string.
+
+    """
 
     default_message = "Rate limit exceeded"
+
+    def __init__(
+        self,
+        message: str | None = None,
+        original_exception: Exception | None = None,
+        provider_name: str | None = None,
+        retry_after: str | None = None,
+    ) -> None:
+        super().__init__(message, original_exception, provider_name)
+        self.retry_after = retry_after
 
 
 class AuthenticationError(AnyLLMError):
@@ -122,6 +138,24 @@ class UnsupportedParameterError(AnyLLMError):
             message = f"{message}.\n{additional_message}"
 
         super().__init__(message, provider_name=provider_name)
+
+
+class InsufficientFundsError(AnyLLMError):
+    """Raised when the user's budget or credits are exhausted (HTTP 402)."""
+
+    default_message = "Insufficient funds or budget exceeded"
+
+
+class UpstreamProviderError(AnyLLMError):
+    """Raised when the upstream provider is unreachable or returns an error (HTTP 502)."""
+
+    default_message = "Upstream provider error"
+
+
+class GatewayTimeoutError(AnyLLMError):
+    """Raised when the gateway times out waiting for the upstream provider (HTTP 504)."""
+
+    default_message = "Gateway timeout waiting for upstream provider"
 
 
 class _FinishReasonError(AnyLLMError):

--- a/src/any_llm/providers/gateway/gateway.py
+++ b/src/any_llm/providers/gateway/gateway.py
@@ -1,12 +1,43 @@
+from __future__ import annotations
+
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
+from any_llm.exceptions import (
+    AuthenticationError,
+    GatewayTimeoutError,
+    InsufficientFundsError,
+    ModelNotFoundError,
+    RateLimitError,
+    UpstreamProviderError,
+)
 from any_llm.logging import logger
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from openresponses_types import ResponseResource
+
+    from any_llm.types.completion import (
+        ChatCompletion,
+        ChatCompletionChunk,
+        CompletionParams,
+        CreateEmbeddingResponse,
+    )
+    from any_llm.types.model import Model
+    from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
+
 GATEWAY_HEADER_NAME = "X-AnyLLM-Key"
+GATEWAY_PLATFORM_TOKEN_ENV = "GATEWAY_PLATFORM_TOKEN"  # noqa: S105
+
+_STATUS_TO_EXCEPTION: dict[int, type[AuthenticationError | ModelNotFoundError]] = {
+    401: AuthenticationError,
+    403: AuthenticationError,
+    404: ModelNotFoundError,
+}
 
 
 class GatewayProvider(BaseOpenAIProvider):
@@ -15,7 +46,8 @@ class GatewayProvider(BaseOpenAIProvider):
     PROVIDER_NAME = "gateway"
     PROVIDER_DOCUMENTATION_URL = "https://github.com/mozilla-ai/any-llm"
 
-    # All features are marked as supported, but depending on which provider you call inside the gateway, they may not all work.
+    # All features are marked as supported, but depending on which provider
+    # you call inside the gateway, they may not all work.
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True
     SUPPORTS_RESPONSES = True
@@ -26,11 +58,37 @@ class GatewayProvider(BaseOpenAIProvider):
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = True
 
-    def __init__(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        *,
+        platform_mode: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         resolved_api_base = api_base or os.getenv(self.ENV_API_BASE_NAME)
         if not resolved_api_base:
             msg = f"For any-llm-gateway, api_base is required (set via parameter or {self.ENV_API_BASE_NAME} env var)"
             raise ValueError(msg)
+
+        platform_token = os.getenv(GATEWAY_PLATFORM_TOKEN_ENV)
+
+        if platform_mode is True:
+            resolved_token = api_key or platform_token
+            if not resolved_token:
+                msg = f"Platform mode requires a user token (pass api_key or set the {GATEWAY_PLATFORM_TOKEN_ENV} env var)"
+                raise ValueError(msg)
+            self.platform_mode = True
+            super().__init__(api_key=resolved_token, api_base=resolved_api_base, **kwargs)
+            return
+
+        if platform_mode is None and platform_token and not api_key:
+            self.platform_mode = True
+            super().__init__(api_key=platform_token, api_base=resolved_api_base, **kwargs)
+            return
+
+        # Non-platform mode (existing behavior)
+        self.platform_mode = False
         api_key = self._verify_and_set_api_key(api_key)
         if api_key:
             if "default_headers" not in kwargs:
@@ -43,5 +101,117 @@ class GatewayProvider(BaseOpenAIProvider):
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        """Unlike other providers, the gateway provider does not require an API key"""
+        """Unlike other providers, the gateway provider does not require an API key."""
         return api_key or os.getenv(self.ENV_API_KEY_NAME, "")
+
+    # -- Platform-mode error handling -----------------------------------------
+
+    def _handle_platform_error(self, exc: Exception) -> None:
+        """Convert ``openai.APIStatusError`` to typed any-llm exceptions.
+
+        Extracts the ``Retry-After`` and ``X-Correlation-ID`` response headers
+        when available and includes them in the raised exception so callers can
+        act on rate-limit back-off or trace gateway requests.
+        """
+        import openai  # inline import to keep module-level deps minimal
+
+        if not isinstance(exc, openai.APIStatusError):
+            raise exc
+
+        status = exc.status_code
+        headers = exc.response.headers
+        correlation_id = headers.get("x-correlation-id")
+        retry_after = headers.get("retry-after")
+
+        detail = str(exc.message) if hasattr(exc, "message") else str(exc)
+        if correlation_id:
+            detail = f"{detail} (correlation_id={correlation_id})"
+
+        if (exc_cls := _STATUS_TO_EXCEPTION.get(status)) is not None:
+            raise exc_cls(
+                message=detail,
+                original_exception=exc,
+                provider_name=self.PROVIDER_NAME,
+            ) from exc
+
+        if status == 402:
+            raise InsufficientFundsError(
+                message=detail,
+                original_exception=exc,
+                provider_name=self.PROVIDER_NAME,
+            ) from exc
+
+        if status == 429:
+            raise RateLimitError(
+                message=detail,
+                original_exception=exc,
+                provider_name=self.PROVIDER_NAME,
+                retry_after=retry_after,
+            ) from exc
+
+        if status == 502:
+            raise UpstreamProviderError(
+                message=detail,
+                original_exception=exc,
+                provider_name=self.PROVIDER_NAME,
+            ) from exc
+
+        if status == 504:
+            raise GatewayTimeoutError(
+                message=detail,
+                original_exception=exc,
+                provider_name=self.PROVIDER_NAME,
+            ) from exc
+
+        raise exc
+
+    # -- Overridden async methods with platform error wrapping ----------------
+
+    @override
+    async def _acompletion(
+        self, params: CompletionParams, **kwargs: Any
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if not self.platform_mode:
+            return await super()._acompletion(params, **kwargs)
+        try:
+            return await super()._acompletion(params, **kwargs)
+        except Exception as exc:
+            self._handle_platform_error(exc)
+            raise  # unreachable when _handle_platform_error raises, satisfies type checker
+
+    @override
+    async def _aresponses(
+        self, params: ResponsesParams, **kwargs: Any
+    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+        if not self.platform_mode:
+            return await super()._aresponses(params, **kwargs)
+        try:
+            return await super()._aresponses(params, **kwargs)
+        except Exception as exc:
+            self._handle_platform_error(exc)
+            raise
+
+    @override
+    async def _aembedding(
+        self,
+        model: str,
+        inputs: str | list[str],
+        **kwargs: Any,
+    ) -> CreateEmbeddingResponse:
+        if not self.platform_mode:
+            return await super()._aembedding(model, inputs, **kwargs)
+        try:
+            return await super()._aembedding(model, inputs, **kwargs)
+        except Exception as exc:
+            self._handle_platform_error(exc)
+            raise
+
+    @override
+    async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
+        if not self.platform_mode:
+            return await super()._alist_models(**kwargs)
+        try:
+            return await super()._alist_models(**kwargs)
+        except Exception as exc:
+            self._handle_platform_error(exc)
+            raise

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -13,10 +13,13 @@ from any_llm.exceptions import (
     AuthenticationError,
     ContentFilterError,
     ContextLengthExceededError,
+    GatewayTimeoutError,
+    InsufficientFundsError,
     InvalidRequestError,
     ModelNotFoundError,
     ProviderError,
     RateLimitError,
+    UpstreamProviderError,
 )
 
 if TYPE_CHECKING:
@@ -103,6 +106,27 @@ def convert_exception(
 
     if re.search(r"invalid|badrequest|validation", exc_text):
         return InvalidRequestError(
+            message=original_message,
+            original_exception=exception,
+            provider_name=provider_name,
+        )
+
+    if re.search(r"insufficient.*funds|payment.*required|budget.*exceeded", exc_text):
+        return InsufficientFundsError(
+            message=original_message,
+            original_exception=exception,
+            provider_name=provider_name,
+        )
+
+    if re.search(r"bad.*gateway|upstream.*error|upstream.*provider", exc_text):
+        return UpstreamProviderError(
+            message=original_message,
+            original_exception=exception,
+            provider_name=provider_name,
+        )
+
+    if re.search(r"gateway.*timeout", exc_text):
+        return GatewayTimeoutError(
             message=original_message,
             original_exception=exception,
             provider_name=provider_name,

--- a/tests/unit/providers/test_cohere_exceptions.py
+++ b/tests/unit/providers/test_cohere_exceptions.py
@@ -23,6 +23,9 @@ from any_llm.exceptions import (
     ProviderError,
     RateLimitError,
 )
+from any_llm.exceptions import (
+    GatewayTimeoutError as AnyLLMGatewayTimeoutError,
+)
 from any_llm.utils.exception_handler import convert_exception
 
 
@@ -101,6 +104,6 @@ def test_gateway_timeout_error_conversion() -> None:
 
     result = convert_exception(original, "cohere")
 
-    assert isinstance(result, ProviderError)
+    assert isinstance(result, AnyLLMGatewayTimeoutError)
     assert result.provider_name == "cohere"
     assert result.original_exception is original

--- a/tests/unit/providers/test_gateway_provider.py
+++ b/tests/unit/providers/test_gateway_provider.py
@@ -1,9 +1,25 @@
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import openai
 import pytest
 
-from any_llm.providers.gateway.gateway import GATEWAY_HEADER_NAME, GatewayProvider
+from any_llm.exceptions import (
+    AuthenticationError,
+    GatewayTimeoutError,
+    InsufficientFundsError,
+    ModelNotFoundError,
+    RateLimitError,
+    UpstreamProviderError,
+)
+from any_llm.providers.gateway.gateway import (
+    GATEWAY_HEADER_NAME,
+    GATEWAY_PLATFORM_TOKEN_ENV,
+    GatewayProvider,
+)
+
+# -- Non-platform mode (existing behaviour) -----------------------------------
 
 
 def test_gateway_init_requires_api_base() -> None:
@@ -135,3 +151,269 @@ def test_gateway_passes_kwargs_to_parent(mock_openai_class: MagicMock) -> None:
     assert call_kwargs["timeout"] == 30
     assert call_kwargs["max_retries"] == 5
     assert call_kwargs["default_headers"][GATEWAY_HEADER_NAME] == "Bearer test-key"
+
+
+# -- Platform mode: initialisation -------------------------------------------
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+def test_gateway_platform_mode_explicit(mock_openai_class: MagicMock) -> None:
+    """Explicit platform_mode=True sends only Authorization header, not X-AnyLLM-Key."""
+    mock_openai_class.return_value = AsyncMock()
+
+    provider = GatewayProvider(
+        api_key="user-token",
+        api_base="https://gateway.example.com",
+        platform_mode=True,
+    )
+
+    assert provider.platform_mode is True
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["api_key"] == "user-token"
+    assert call_kwargs["base_url"] == "https://gateway.example.com"
+    assert GATEWAY_HEADER_NAME not in call_kwargs.get("default_headers", {})
+
+
+def test_gateway_platform_mode_requires_token() -> None:
+    """platform_mode=True without a token raises ValueError."""
+    with pytest.raises(ValueError, match="Platform mode requires a user token"):
+        GatewayProvider(api_base="https://gateway.example.com", platform_mode=True)
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@patch.dict(os.environ, {GATEWAY_PLATFORM_TOKEN_ENV: "env-platform-token"}, clear=False)
+def test_gateway_platform_mode_explicit_with_env_token(mock_openai_class: MagicMock) -> None:
+    """platform_mode=True falls back to GATEWAY_PLATFORM_TOKEN env var."""
+    mock_openai_class.return_value = AsyncMock()
+
+    provider = GatewayProvider(api_base="https://gateway.example.com", platform_mode=True)
+
+    assert provider.platform_mode is True
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["api_key"] == "env-platform-token"
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@patch.dict(os.environ, {GATEWAY_PLATFORM_TOKEN_ENV: "env-platform-token"}, clear=False)
+def test_gateway_platform_mode_auto_detect_via_env(mock_openai_class: MagicMock) -> None:
+    """When GATEWAY_PLATFORM_TOKEN is set and no api_key, auto-enter platform mode."""
+    mock_openai_class.return_value = AsyncMock()
+
+    provider = GatewayProvider(api_base="https://gateway.example.com")
+
+    assert provider.platform_mode is True
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["api_key"] == "env-platform-token"
+    assert GATEWAY_HEADER_NAME not in call_kwargs.get("default_headers", {})
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@patch.dict(os.environ, {GATEWAY_PLATFORM_TOKEN_ENV: "env-platform-token"}, clear=False)
+def test_gateway_platform_mode_env_ignored_when_api_key_provided(mock_openai_class: MagicMock) -> None:
+    """When an explicit api_key is provided, GATEWAY_PLATFORM_TOKEN does not trigger platform mode."""
+    mock_openai_class.return_value = AsyncMock()
+
+    provider = GatewayProvider(api_key="gateway-key", api_base="https://gateway.example.com")
+
+    assert provider.platform_mode is False
+    call_kwargs = mock_openai_class.call_args[1]
+    assert call_kwargs["api_key"] == "gateway-key"
+    assert call_kwargs["default_headers"][GATEWAY_HEADER_NAME] == "Bearer gateway-key"
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+def test_gateway_default_mode_sets_platform_mode_false(mock_openai_class: MagicMock) -> None:
+    """Non-platform init sets platform_mode to False."""
+    mock_openai_class.return_value = AsyncMock()
+
+    provider = GatewayProvider(api_key="test-key", api_base="https://gateway.example.com")
+    assert provider.platform_mode is False
+
+
+# -- Platform mode: error handling --------------------------------------------
+
+
+def _make_api_status_error(
+    status_code: int,
+    message: str = "error",
+    headers: dict[str, str] | None = None,
+) -> openai.APIStatusError:
+    """Build an ``openai.APIStatusError`` with a fake httpx response."""
+    resp_headers = {"content-type": "application/json"}
+    if headers:
+        resp_headers.update(headers)
+    response = httpx.Response(
+        status_code=status_code,
+        headers=resp_headers,
+        json={"error": {"message": message}},
+        request=httpx.Request("POST", "https://gateway.example.com/v1/chat/completions"),
+    )
+    return openai.APIStatusError(
+        message=message,
+        response=response,
+        body={"error": {"message": message}},
+    )
+
+
+def _make_platform_provider() -> GatewayProvider:
+    with patch("any_llm.providers.openai.base.AsyncOpenAI"):
+        return GatewayProvider(
+            api_key="user-token",
+            api_base="https://gateway.example.com",
+            platform_mode=True,
+        )
+
+
+def test_gateway_platform_error_401() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(401, "Invalid token")
+
+    with pytest.raises(AuthenticationError, match="Invalid token"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_402() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(402, "Budget exceeded")
+
+    with pytest.raises(InsufficientFundsError, match="Budget exceeded"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_403() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(403, "Forbidden")
+
+    with pytest.raises(AuthenticationError, match="Forbidden"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_404() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(404, "Model not found")
+
+    with pytest.raises(ModelNotFoundError, match="Model not found"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_429_with_retry_after() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(429, "Too many requests", headers={"retry-after": "30"})
+
+    with pytest.raises(RateLimitError) as exc_info:
+        provider._handle_platform_error(exc)
+
+    assert exc_info.value.retry_after == "30"
+    assert "Too many requests" in str(exc_info.value)
+
+
+def test_gateway_platform_error_429_without_retry_after() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(429, "Rate limited")
+
+    with pytest.raises(RateLimitError) as exc_info:
+        provider._handle_platform_error(exc)
+
+    assert exc_info.value.retry_after is None
+
+
+def test_gateway_platform_error_502() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(502, "Bad gateway")
+
+    with pytest.raises(UpstreamProviderError, match="Bad gateway"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_504() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(504, "Gateway timeout")
+
+    with pytest.raises(GatewayTimeoutError, match="Gateway timeout"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_correlation_id() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(
+        500,
+        "Internal error",
+        headers={"x-correlation-id": "abc-123"},
+    )
+
+    with pytest.raises(openai.APIStatusError):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_correlation_id_in_mapped_error() -> None:
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(
+        401,
+        "Unauthorized",
+        headers={"x-correlation-id": "trace-xyz"},
+    )
+
+    with pytest.raises(AuthenticationError, match="correlation_id=trace-xyz"):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_unknown_status_reraises() -> None:
+    """Unrecognised status codes pass through unchanged."""
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(500, "Internal server error")
+
+    with pytest.raises(openai.APIStatusError):
+        provider._handle_platform_error(exc)
+
+
+def test_gateway_platform_error_non_api_error_reraises() -> None:
+    """Non-APIStatusError exceptions pass through unchanged."""
+    provider = _make_platform_provider()
+
+    with pytest.raises(RuntimeError, match="something else"):
+        provider._handle_platform_error(RuntimeError("something else"))
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_acompletion_wraps_errors() -> None:
+    """_acompletion wraps APIStatusError in platform mode."""
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(429, "Rate limited", headers={"retry-after": "5"})
+    provider.client = AsyncMock()
+    provider.client.chat.completions.create = AsyncMock(side_effect=exc)
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await provider._acompletion(
+            MagicMock(
+                model_id="openai:gpt-4",
+                messages=[],
+                reasoning_effort=None,
+                stream=False,
+                response_format=None,
+            ),
+        )
+
+    assert exc_info.value.retry_after == "5"
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_platform_acompletion_no_wrapping() -> None:
+    """In non-platform mode, errors are not wrapped by _handle_platform_error."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI"):
+        provider = GatewayProvider(api_key="key", api_base="https://gateway.example.com")
+
+    assert provider.platform_mode is False
+    exc = _make_api_status_error(429, "Rate limited")
+    provider.client = AsyncMock()
+    provider.client.chat.completions.create = AsyncMock(side_effect=exc)
+
+    with pytest.raises(openai.APIStatusError):
+        await provider._acompletion(
+            MagicMock(
+                model_id="openai:gpt-4",
+                messages=[],
+                reasoning_effort=None,
+                stream=False,
+                response_format=None,
+            ),
+        )

--- a/tests/unit/providers/test_gateway_provider.py
+++ b/tests/unit/providers/test_gateway_provider.py
@@ -417,3 +417,148 @@ async def test_gateway_non_platform_acompletion_no_wrapping() -> None:
                 response_format=None,
             ),
         )
+
+
+# -- Platform mode: success paths and other method overrides ------------------
+
+
+def _completion_params_mock() -> MagicMock:
+    return MagicMock(
+        model_id="openai:gpt-4",
+        messages=[],
+        reasoning_effort=None,
+        stream=False,
+        response_format=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_acompletion_success() -> None:
+    """Platform-mode _acompletion returns the result on success (no error wrapping interferes)."""
+    provider = _make_platform_provider()
+    sentinel = MagicMock(name="completion-result")
+
+    with patch.object(
+        type(provider).__bases__[0], "_acompletion", new_callable=AsyncMock, return_value=sentinel
+    ) as mock_super:
+        result = await provider._acompletion(_completion_params_mock())
+
+    mock_super.assert_awaited_once()
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_aresponses_wraps_errors() -> None:
+    """_aresponses wraps APIStatusError in platform mode."""
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(502, "Bad gateway")
+
+    with patch.object(type(provider).__bases__[0], "_aresponses", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(UpstreamProviderError, match="Bad gateway"):
+            await provider._aresponses(MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_aresponses_success() -> None:
+    """Platform-mode _aresponses returns the result on success."""
+    provider = _make_platform_provider()
+    sentinel = MagicMock(name="responses-result")
+
+    with patch.object(
+        type(provider).__bases__[0], "_aresponses", new_callable=AsyncMock, return_value=sentinel
+    ) as mock_super:
+        result = await provider._aresponses(MagicMock())
+
+    mock_super.assert_awaited_once()
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_aembedding_wraps_errors() -> None:
+    """_aembedding wraps APIStatusError in platform mode."""
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(401, "Unauthorized")
+
+    with patch.object(type(provider).__bases__[0], "_aembedding", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(AuthenticationError, match="Unauthorized"):
+            await provider._aembedding("text-embedding-3-small", "hello")
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_aembedding_success() -> None:
+    """Platform-mode _aembedding returns the result on success."""
+    provider = _make_platform_provider()
+    sentinel = MagicMock(name="embedding-result")
+
+    with patch.object(
+        type(provider).__bases__[0], "_aembedding", new_callable=AsyncMock, return_value=sentinel
+    ) as mock_super:
+        result = await provider._aembedding("text-embedding-3-small", "hello")
+
+    mock_super.assert_awaited_once()
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_alist_models_wraps_errors() -> None:
+    """_alist_models wraps APIStatusError in platform mode."""
+    provider = _make_platform_provider()
+    exc = _make_api_status_error(504, "Timed out")
+
+    with patch.object(type(provider).__bases__[0], "_alist_models", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(GatewayTimeoutError, match="Timed out"):
+            await provider._alist_models()
+
+
+@pytest.mark.asyncio
+async def test_gateway_platform_alist_models_success() -> None:
+    """Platform-mode _alist_models returns the result on success."""
+    provider = _make_platform_provider()
+    sentinel = MagicMock(name="models-result")
+
+    with patch.object(
+        type(provider).__bases__[0], "_alist_models", new_callable=AsyncMock, return_value=sentinel
+    ) as mock_super:
+        result = await provider._alist_models()
+
+    mock_super.assert_awaited_once()
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_platform_aresponses_no_wrapping() -> None:
+    """In non-platform mode, _aresponses errors pass through unchanged."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI"):
+        provider = GatewayProvider(api_key="key", api_base="https://gateway.example.com")
+
+    exc = _make_api_status_error(502, "Bad gateway")
+
+    with patch.object(type(provider).__bases__[0], "_aresponses", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(openai.APIStatusError):
+            await provider._aresponses(MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_platform_aembedding_no_wrapping() -> None:
+    """In non-platform mode, _aembedding errors pass through unchanged."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI"):
+        provider = GatewayProvider(api_key="key", api_base="https://gateway.example.com")
+
+    exc = _make_api_status_error(401, "Unauthorized")
+
+    with patch.object(type(provider).__bases__[0], "_aembedding", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(openai.APIStatusError):
+            await provider._aembedding("text-embedding-3-small", "hello")
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_platform_alist_models_no_wrapping() -> None:
+    """In non-platform mode, _alist_models errors pass through unchanged."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI"):
+        provider = GatewayProvider(api_key="key", api_base="https://gateway.example.com")
+
+    exc = _make_api_status_error(504, "Timed out")
+
+    with patch.object(type(provider).__bases__[0], "_alist_models", new_callable=AsyncMock, side_effect=exc):
+        with pytest.raises(openai.APIStatusError):
+            await provider._alist_models()

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,7 +1,8 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from any_llm.utils.exception_handler import _handle_exception
+from any_llm.exceptions import GatewayTimeoutError, InsufficientFundsError, UpstreamProviderError
+from any_llm.utils.exception_handler import _handle_exception, convert_exception
 
 
 def test_validation_error_bubbles_up_unchanged() -> None:
@@ -25,3 +26,45 @@ def test_validation_error_bubbles_up_unchanged() -> None:
         _handle_exception(original, "openai")
 
     assert raised.value is original
+
+
+def test_convert_exception_insufficient_funds() -> None:
+    original = Exception("Insufficient funds for this request")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, InsufficientFundsError)
+    assert result.provider_name == "gateway"
+    assert result.original_exception is original
+
+
+def test_convert_exception_payment_required() -> None:
+    original = Exception("Payment required")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, InsufficientFundsError)
+
+
+def test_convert_exception_budget_exceeded() -> None:
+    original = Exception("Budget exceeded for project")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, InsufficientFundsError)
+
+
+def test_convert_exception_bad_gateway() -> None:
+    original = Exception("Bad gateway")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, UpstreamProviderError)
+    assert result.provider_name == "gateway"
+    assert result.original_exception is original
+
+
+def test_convert_exception_upstream_provider_error() -> None:
+    original = Exception("Upstream provider error")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, UpstreamProviderError)
+
+
+def test_convert_exception_gateway_timeout() -> None:
+    original = Exception("Gateway timeout")
+    result = convert_exception(original, "gateway")
+    assert isinstance(result, GatewayTimeoutError)
+    assert result.provider_name == "gateway"
+    assert result.original_exception is original


### PR DESCRIPTION
## Description

Add platform mode to `GatewayProvider` that allows users to authenticate with the gateway using a simple user token and URL, without needing a gateway API key.

**Platform mode** sends user auth as `Authorization: Bearer <platform_user_token>` (standard OpenAI client behavior) instead of the `X-AnyLLM-Key` custom header. It keeps using OpenAI-style `/v1/chat/completions` payloads and supports both `provider:model` and bare model formats.

### How platform mode activates

| Trigger | Behavior |
|---------|----------|
| `platform_mode=True` with `api_key` param | Explicit platform mode using the provided token |
| `platform_mode=True` without `api_key` | Falls back to `GATEWAY_PLATFORM_TOKEN` env var |
| `GATEWAY_PLATFORM_TOKEN` env var set, no `api_key` passed | Auto-detects platform mode |
| Explicit `api_key` passed (no `platform_mode=True`) | Standard gateway mode (unchanged) |

### Error handling in platform mode

Maps gateway HTTP responses to typed any-llm exceptions:

| HTTP Status | Exception |
|-------------|-----------|
| 401, 403 | `AuthenticationError` |
| 402 | `InsufficientFundsError` (new) |
| 404 | `ModelNotFoundError` |
| 429 | `RateLimitError` (with `retry_after` attribute) |
| 502 | `UpstreamProviderError` (new) |
| 504 | `GatewayTimeoutError` (new) |

`X-Correlation-ID` from gateway responses is surfaced in error messages for tracing.

### Files changed

- `src/any_llm/exceptions.py` - New exception types + `retry_after` on `RateLimitError`
- `src/any_llm/providers/gateway/gateway.py` - Platform mode init, error handling, method overrides
- `src/any_llm/utils/exception_handler.py` - Recognize new exception patterns in `convert_exception`
- `tests/unit/providers/test_gateway_provider.py` - 20 new tests for platform mode (31 total)
- `tests/unit/providers/test_cohere_exceptions.py` - Updated to expect `GatewayTimeoutError`

## PR Type

- 🆕 New Feature

## Relevant issues


## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4 (claude-opus-4-6)
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Full implementation including exception design, platform mode detection logic, error mapping, and comprehensive test coverage.

- [x] I am an AI Agent filling out this form (check box if true)