### PR TITLE
fix(cohere): allow parallel tool messages in message validation

### DIFF
--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -29,7 +29,11 @@ def _patch_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for i, message in enumerate(messages):
         patched_message = message.copy()
         if patched_message.get("role") == "tool":
-            if i > 0 and messages[i - 1].get("role") != "assistant":
+            # Walk backwards past sibling tool messages to find the assistant message
+            j = i - 1
+            while j >= 0 and messages[j].get("role") == "tool":
+                j -= 1
+            if j < 0 or messages[j].get("role") != "assistant":
                 msg = "A tool message must be preceded by an assistant message with tool_calls."
                 raise ValueError(msg)
             patched_message.pop("name", None)

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -144,6 +144,41 @@ def test_patch_messages_with_invalid_tool_sequence_raises_error() -> None:
         _patch_messages(messages)
 
 
+def test_patch_messages_with_parallel_tool_messages() -> None:
+    """Test that multiple consecutive tool messages after an assistant message are valid."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Get weather for Paris and London."},
+        {
+            "role": "assistant",
+            "content": "I'll check both cities.",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "get_weather", "arguments": '{"location":"Paris"}'}},
+                {"id": "call_2", "function": {"name": "get_weather", "arguments": '{"location":"London"}'}},
+            ],
+        },
+        {"role": "tool", "name": "get_weather", "content": "Sunny in Paris", "tool_call_id": "call_1"},
+        {"role": "tool", "name": "get_weather", "content": "Rainy in London", "tool_call_id": "call_2"},
+    ]
+
+    result = _patch_messages(messages)
+
+    tool_messages = [msg for msg in result if msg["role"] == "tool"]
+    assert len(tool_messages) == 2
+    for msg in tool_messages:
+        assert "name" not in msg
+
+
+def test_patch_messages_tool_after_tool_without_assistant_raises() -> None:
+    """Test that a tool message group not preceded by an assistant message raises."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Hello"},
+        {"role": "tool", "content": "result1", "tool_call_id": "call_1"},
+        {"role": "tool", "content": "result2", "tool_call_id": "call_2"},
+    ]
+    with pytest.raises(ValueError, match=r"A tool message must be preceded by an assistant message with tool_calls."):
+        _patch_messages(messages)
+
+
 def test_preprocess_response_format_dataclass() -> None:
     from dataclasses import dataclass
 


### PR DESCRIPTION
## Summary
- The `_patch_messages()` validation in the Cohere provider only checked if the *immediately preceding* message was an assistant, but with parallel tool calls multiple tool result messages follow a single assistant message. The second tool message's predecessor is another tool message, not the assistant, causing a `ValueError`.
- Fixed by walking backwards past sibling tool messages to find the originating assistant message.
- Added unit tests for parallel tool message sequences (both valid and invalid).

Fixes failing integration tests:
- `test_agent_loop_parallel_tool_calls[cohere]`
- `test_agent_loop_sequential_tool_calls[cohere]`

Regression introduced in #1013.

## Test plan
- [x] Existing unit tests pass (18/18)
- [x] Pre-commit checks pass
- [ ] Integration tests pass for cohere provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>