### PR TITLE
feat(gateway): rename auth header to AnyLLM-Key (RFC 6648)

### DIFF
--- a/docs/src/content/docs/gateway/authentication.md
+++ b/docs/src/content/docs/gateway/authentication.md
@@ -14,12 +14,13 @@ any-llm-gateway offers two authentication methods, each designed for different u
 
 ### Supported Headers
 
-The gateway accepts authentication via two headers:
+The gateway accepts authentication via the following headers, in order of precedence:
 
-- **`X-AnyLLM-Key`** (preferred): The gateway's native authentication header
-- **`Authorization`**: Standard HTTP authorization header for OpenAI client compatibility
+1. **`AnyLLM-Key`**: The gateway's native authentication header. Follows [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648), which deprecated the `X-` prefix convention in 2012.
+2. **`Authorization`**: Standard HTTP authorization header for OpenAI client compatibility.
+3. **`x-api-key`**: Raw key (no `Bearer` prefix) for Anthropic client compatibility.
 
-Both headers use the `Bearer <token>` format. When both headers are present, `X-AnyLLM-Key` takes precedence.
+Headers 1 and 2 use the `Bearer <token>` format. When multiple credential headers are present, the gateway uses the highest-precedence one.
 
 Using the `Authorization` header allows you to use the gateway with OpenAI-compatible clients without modification:
 
@@ -64,7 +65,7 @@ master_key: "Zx8Q_vKm3nR7wP2sT9yU5iO1eA6hD4fG0bN8cL3jM5k"
 
 ```bash
 curl -X POST http://localhost:8000/v1/users \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"user_id": "user-123", "alias": "Alice"}'
 ```
@@ -73,7 +74,7 @@ curl -X POST http://localhost:8000/v1/users \
 
 ```bash
 curl -X POST http://localhost:8000/v1/users \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d ' {
     "user_id": "user-123",
@@ -92,7 +93,7 @@ When using the master key, you **must** specify which user is making the request
 
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "openai:gpt-4o-mini",
@@ -111,7 +112,7 @@ Create a virtual key with a descriptive name:
 
 ```bash
 curl -X POST http://localhost:8000/v1/keys \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"key_name": "mobile-app"}'
 ```
@@ -139,7 +140,7 @@ Create a key that automatically expires on a specific date:
 
 ```bash
 curl -X POST http://localhost:8000/v1/keys \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "key_name": "trial-access",
@@ -152,7 +153,7 @@ Making requests with a virtual key is simpler than using the master key—no `us
 
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "X-AnyLLM-Key: Bearer gw-..." \
+  -H "AnyLLM-Key: Bearer gw-..." \
   -H "Content-Type: application/json" \
   -d '{"model": "openai:gpt-5-mini", "messages": [{"role": "user", "content": "Write a haiku on Saturn"}]}'
 ```
@@ -165,13 +166,13 @@ The gateway automatically tracks usage based on the virtual key used.
 **List all keys:**
 ```bash
 curl http://localhost:8000/v1/keys \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}"
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}"
 ```
 
 **Deactivate a key:**
 ```bash
 curl -X PATCH http://localhost:8000/v1/keys/<virtual_key_id>\
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"is_active": false}'
 ```
@@ -179,7 +180,7 @@ curl -X PATCH http://localhost:8000/v1/keys/<virtual_key_id>\
 **Delete a key:**
 ```bash
 curl -X DELETE http://localhost:8000/v1/keys/<virtual_key_id> \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}"
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}"
 ```
 
 > See [API Reference](/any-llm/gateway/api-reference/) for complete key management operations.

--- a/docs/src/content/docs/gateway/budget-management.md
+++ b/docs/src/content/docs/gateway/budget-management.md
@@ -10,7 +10,7 @@ Budgets provide shared spending limits that can be assigned to multiple users. T
 ```bash
 # Create a budget with a $10.00 spending limit and monthly resets (30 days = 2592000 seconds)
 curl -X POST http://localhost:8000/v1/budgets \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "max_budget": 10.0,
@@ -43,7 +43,7 @@ If you don't create and set a budget, budget is unlimited.
 ```bash
 # Create a user with a budget
 curl -X POST http://localhost:8000/v1/users \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "user_id": "user-456",
@@ -53,7 +53,7 @@ curl -X POST http://localhost:8000/v1/users \
 
 # Update an existing user's budget
 curl -X PATCH http://localhost:8000/v1/users/user-123 \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"budget_id": "abc-123"}'
 ```

--- a/docs/src/content/docs/gateway/configuration.md
+++ b/docs/src/content/docs/gateway/configuration.md
@@ -87,7 +87,7 @@ pricing:
 You can also set or update pricing dynamically using the API:
 ```bash
 curl -X POST http://localhost:8000/v1/pricing \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "openai:gpt-4",

--- a/docs/src/content/docs/gateway/overview.md
+++ b/docs/src/content/docs/gateway/overview.md
@@ -28,7 +28,7 @@ The gateway acts as a transparent proxy between your applications and LLM provid
 
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "X-AnyLLM-Key: Bearer your-secure-master-key" \
+  -H "AnyLLM-Key: Bearer your-secure-master-key" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "openai:gpt-5",

--- a/docs/src/content/docs/gateway/quickstart.md
+++ b/docs/src/content/docs/gateway/quickstart.md
@@ -154,7 +154,7 @@ To track usage, we must first create a user so that to associate our completion 
 
 ```bash
 curl -s -X POST http://localhost:8000/v1/users \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"user_id": "user-123", "alias": "Bob"}'
 ```
@@ -184,7 +184,7 @@ Make a completion request using the master key and specify that the completion s
 
 ```bash
 curl -s -X POST http://localhost:8000/v1/chat/completions \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "openai:gpt-4",
@@ -263,7 +263,7 @@ Now using the master key, we can access the usage information for the user.
 
 ```bash
 curl -s http://localhost:8000/v1/users/user-123 \
-  -H "X-AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "AnyLLM-Key: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json"
 ```
 

--- a/docs/src/content/docs/gateway/troubleshooting.md
+++ b/docs/src/content/docs/gateway/troubleshooting.md
@@ -16,7 +16,7 @@ python -c "from sqlalchemy import create_engine; engine = create_engine('postgre
 ### Authentication Errors
 
 - Ensure you're using the correct master key format: `Bearer your-secure-master-key`
-- Check that the `X-AnyLLM-Key` header is properly set
+- Check that the `AnyLLM-Key` header is properly set
 - Verify that virtual API keys are active and not expired
 
 ### Configuration Issues

--- a/src/any_llm/gateway/api/deps.py
+++ b/src/any_llm/gateway/api/deps.py
@@ -14,6 +14,16 @@ from any_llm.gateway.models.entities import APIKey
 
 _config: GatewayConfig | None = None
 
+# RFC 6750 Bearer scheme prefix, including the mandatory trailing space.
+_BEARER_PREFIX = "Bearer "
+
+# Headers we accept for bearer-format credentials, in order of precedence. Authentication
+# uses the first header present in the request; any later entries are ignored.
+_BEARER_HEADERS: tuple[str, ...] = (
+    API_KEY_HEADER,
+    "Authorization",
+)
+
 
 def set_config(config: GatewayConfig) -> None:
     """Set the global config instance."""
@@ -36,26 +46,25 @@ def reset_config() -> None:
 
 
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
-    """Extract and validate Bearer token from request header.
+    """Extract and validate the gateway credential from request headers.
 
-    Checks X-AnyLLM-Key first, then falls back to standard Authorization header
-    for OpenAI client compatibility, then falls back to x-api-key header
-    for Anthropic client compatibility.
+    Headers are consulted in the order defined by ``_BEARER_HEADERS`` (``AnyLLM-Key``
+    first, ``Authorization`` second), followed by ``x-api-key`` as an Anthropic-compatible
+    fallback that carries the raw key without a ``Bearer`` prefix.
     """
-    auth_header = request.headers.get(API_KEY_HEADER) or request.headers.get("Authorization")
-
-    if auth_header:
-        if not auth_header.startswith("Bearer "):
+    for header_name in _BEARER_HEADERS:
+        value = request.headers.get(header_name)
+        if not value:
+            continue
+        if not value.startswith(_BEARER_PREFIX):
             record_auth_failure("invalid_format")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid header format. Expected 'Bearer <token>'",
+                detail=f"Invalid header format. Expected '{_BEARER_PREFIX}<token>'",
             )
-        return auth_header[7:]
+        return value[len(_BEARER_PREFIX) :]
 
-    # Fallback: x-api-key header (Anthropic client compatibility, no Bearer prefix)
-    api_key = request.headers.get("x-api-key")
-    if api_key:
+    if api_key := request.headers.get("x-api-key"):
         return api_key
 
     record_auth_failure("missing_credentials")
@@ -118,7 +127,7 @@ async def verify_api_key(
     db: Annotated[Session, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> APIKey:
-    """Verify API key from X-AnyLLM-Key header.
+    """Verify API key from the gateway's authentication headers.
 
     Args:
         request: FastAPI request object
@@ -140,7 +149,7 @@ async def verify_master_key(
     request: Request,
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> None:
-    """Verify master key from X-AnyLLM-Key header.
+    """Verify master key from the gateway's authentication headers.
 
     Args:
         request: FastAPI request object
@@ -170,7 +179,7 @@ async def verify_api_key_or_master_key(
     db: Annotated[Session, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> tuple[APIKey | None, bool]:
-    """Verify either API key or master key from X-AnyLLM-Key header.
+    """Verify either API key or master key from the gateway's authentication headers.
 
     Args:
         request: FastAPI request object

--- a/src/any_llm/gateway/core/config.py
+++ b/src/any_llm/gateway/core/config.py
@@ -7,7 +7,9 @@ import yaml
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-API_KEY_HEADER = "X-AnyLLM-Key"
+# HTTP request header name for gateway Bearer authentication. Follows RFC 6648 (no `X-`
+# prefix).
+API_KEY_HEADER = "AnyLLM-Key"
 
 
 class PricingConfig(BaseModel):

--- a/src/any_llm/gateway/main.py
+++ b/src/any_llm/gateway/main.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from any_llm.gateway import __version__
 from any_llm.gateway.api.deps import set_config
 from any_llm.gateway.api.main import register_routers
-from any_llm.gateway.core.config import GatewayConfig
+from any_llm.gateway.core.config import API_KEY_HEADER, GatewayConfig
 from any_llm.gateway.core.database import get_db, init_db
 from any_llm.gateway.rate_limit import RateLimiter
 from any_llm.gateway.services.bootstrap_service import bootstrap_first_api_key
@@ -120,7 +120,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if not request.url.path.startswith(_PUBLIC_PREFIXES):
             response.headers["Cache-Control"] = "private, no-store, no-cache"
-            response.headers["Vary"] = "Authorization"
+            response.headers["Vary"] = f"Authorization, {API_KEY_HEADER}"
         return response
 
 
@@ -163,7 +163,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             allow_origins=config.cors_allow_origins,
             allow_credentials=allow_credentials,
             allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-            allow_headers=["Content-Type", "Authorization", "X-AnyLLM-Key", "x-api-key"],
+            allow_headers=["Content-Type", "Authorization", API_KEY_HEADER, "x-api-key"],
         )
 
     if config.enable_metrics:

--- a/src/any_llm/providers/gateway/gateway.py
+++ b/src/any_llm/providers/gateway/gateway.py
@@ -6,7 +6,7 @@ from typing_extensions import override
 from any_llm.logging import logger
 from any_llm.providers.openai.base import BaseOpenAIProvider
 
-GATEWAY_HEADER_NAME = "X-AnyLLM-Key"
+GATEWAY_HEADER_NAME = "AnyLLM-Key"
 
 
 class GatewayProvider(BaseOpenAIProvider):

--- a/tests/gateway/test_auth_header_precedence.py
+++ b/tests/gateway/test_auth_header_precedence.py
@@ -1,0 +1,74 @@
+"""End-to-end tests for the canonical ``AnyLLM-Key`` authentication header.
+
+Precedence and malformed-input branches are unit-tested in
+``tests/unit/test_extract_bearer_token.py``; this module focuses on behaviour that
+only emerges through the full middleware stack: CORS allow-listing, the ``Vary``
+caching hint, and the virtual-API-key auth path.
+"""
+
+from fastapi.testclient import TestClient
+
+from any_llm.gateway.core.config import API_KEY_HEADER, GatewayConfig
+
+
+def test_canonical_header_constant_is_rfc6648_compliant() -> None:
+    """The auth header constant must be the RFC 6648-compliant name (no ``X-`` prefix)."""
+    assert API_KEY_HEADER == "AnyLLM-Key"
+
+
+def test_canonical_header_accepted(client: TestClient, test_config: GatewayConfig) -> None:
+    """Requests using the canonical header authenticate against the master-key path."""
+    response = client.post(
+        "/v1/keys",
+        json={"key_name": "canonical-header-test"},
+        headers={API_KEY_HEADER: f"Bearer {test_config.master_key}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["key_name"] == "canonical-header-test"
+
+
+def test_virtual_api_key_with_canonical_header(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """A virtual API key authenticates on the canonical header for the models endpoint."""
+    response = client.get("/v1/models", headers=api_key_header)
+
+    assert response.status_code == 200
+
+
+def test_authenticated_response_vary_includes_canonical_header(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Authenticated responses advertise Vary on both ``Authorization`` and ``AnyLLM-Key``."""
+    response = client.get("/v1/keys", headers=master_key_header)
+
+    assert response.status_code == 200
+    vary = response.headers.get("Vary", "")
+    assert "Authorization" in vary
+    assert API_KEY_HEADER in vary
+
+
+def test_canonical_header_added_to_cors_allowlist(postgres_url: str) -> None:
+    """The canonical ``AnyLLM-Key`` header must be included in the CORS allow-list."""
+    from any_llm.gateway.main import create_app
+
+    config = GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        cors_allow_origins=["https://trusted.com"],
+    )
+    app = create_app(config)
+
+    with TestClient(app) as test_client:
+        response = test_client.options(
+            "/v1/keys",
+            headers={
+                "Origin": "https://trusted.com",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": API_KEY_HEADER,
+            },
+        )
+        assert response.status_code == 200
+        allowed = response.headers.get("access-control-allow-headers", "").lower()
+        assert API_KEY_HEADER.lower() in allowed

--- a/tests/gateway/test_client_args.py
+++ b/tests/gateway/test_client_args.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from any_llm.gateway.core.config import GatewayConfig
+from any_llm.gateway.core.config import API_KEY_HEADER, GatewayConfig
 from any_llm.gateway.db import get_db
 from any_llm.gateway.main import create_app
 from tests.gateway.conftest import _run_alembic_migrations
@@ -81,7 +81,7 @@ async def test_client_args_passed_to_acompletion(
         captured_kwargs.update(kwargs)
         raise MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     response = client_with_client_args.post(
         "/v1/users",

--- a/tests/gateway/test_key_management.py
+++ b/tests/gateway/test_key_management.py
@@ -248,7 +248,7 @@ def test_inactive_api_key_rejected(
 
 def test_authorization_header_accepted(client: TestClient, test_config: GatewayConfig) -> None:
     """Test that Authorization header works as fallback for OpenAI client compatibility."""
-    # Use Authorization header instead of X-AnyLLM-Key
+    # Use Authorization header instead of AnyLLM-Key.
     auth_header = {"Authorization": f"Bearer {test_config.master_key}"}
 
     response = client.post(

--- a/tests/gateway/test_provider_kwargs_override.py
+++ b/tests/gateway/test_provider_kwargs_override.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from any_llm import LLMProvider
 from any_llm.gateway.api.routes.chat import get_provider_kwargs
-from any_llm.gateway.core.config import GatewayConfig
+from any_llm.gateway.core.config import API_KEY_HEADER, GatewayConfig
 from any_llm.gateway.db import Base, get_db
 from any_llm.gateway.main import create_app
 from tests.gateway.conftest import _run_alembic_migrations
@@ -96,7 +96,7 @@ async def test_user_model_not_overridden_by_provider_config(
         captured_kwargs.update(kwargs)
         raise _MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     response = client_with_model_in_provider.post(
         "/v1/users",
@@ -132,7 +132,7 @@ async def test_unset_optional_fields_do_not_override_provider_defaults(
         captured_kwargs.update(kwargs)
         raise _MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     with patch("any_llm.gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client_with_model_in_provider.post(

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -1,0 +1,138 @@
+"""Unit tests for the gateway's Bearer-token extraction.
+
+These tests exercise ``_extract_bearer_token`` directly — a pure function over
+``Request.headers`` — so they cover all precedence and malformed-input branches
+without needing the full FastAPI stack or a database.
+"""
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from any_llm.gateway.api.deps import _extract_bearer_token
+from any_llm.gateway.core.config import API_KEY_HEADER, GatewayConfig
+
+
+def _make_request(headers: dict[str, str]) -> Request:
+    """Build a minimal ASGI ``Request`` with the provided headers."""
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [(name.lower().encode("latin-1"), value.encode("latin-1")) for name, value in headers.items()],
+        "state": {},
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def config() -> GatewayConfig:
+    """A minimal config object; ``_extract_bearer_token`` does not read fields from it."""
+    return GatewayConfig(master_key="test-master-key", auto_migrate=False)
+
+
+def test_canonical_header_returns_token(config: GatewayConfig) -> None:
+    request = _make_request({API_KEY_HEADER: "Bearer token-canonical"})
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "token-canonical"
+
+
+def test_authorization_header_returns_token(config: GatewayConfig) -> None:
+    request = _make_request({"Authorization": "Bearer token-auth"})
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "token-auth"
+
+
+def test_x_api_key_returns_raw_key(config: GatewayConfig) -> None:
+    request = _make_request({"x-api-key": "raw-anthropic-key"})
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "raw-anthropic-key"
+
+
+def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            API_KEY_HEADER: "Bearer canonical-wins",
+            "Authorization": "Bearer authorization-loses",
+        }
+    )
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "canonical-wins"
+
+
+def test_authorization_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            "Authorization": "Bearer authorization-wins",
+            "x-api-key": "x-api-key-loses",
+        }
+    )
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "authorization-wins"
+
+
+def test_canonical_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            API_KEY_HEADER: "Bearer canonical-wins",
+            "x-api-key": "x-api-key-loses",
+        }
+    )
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "canonical-wins"
+
+
+def test_malformed_canonical_header_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({API_KEY_HEADER: "NotBearer token-bad"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+    assert "Bearer" in exc_info.value.detail
+
+
+def test_malformed_authorization_header_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({"Authorization": "Basic abc123"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_missing_credentials_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+    assert API_KEY_HEADER in exc_info.value.detail
+
+
+def test_empty_canonical_header_falls_through_to_authorization(config: GatewayConfig) -> None:
+    """An empty string in the canonical header is treated as absent."""
+    request = _make_request(
+        {
+            API_KEY_HEADER: "",
+            "Authorization": "Bearer authorization-used",
+        }
+    )
+
+    extracted = _extract_bearer_token(request, config)
+
+    assert extracted == "authorization-used"


### PR DESCRIPTION
## Description

Rename the gateway's Bearer-authentication header from `X-AnyLLM-Key` to `AnyLLM-Key`, so the name follows [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648) (no `X-` prefix). The gateway has no live deployments yet, so there is no backward-compatibility path — this is a simple rename.

This mirrors the same rename landing in [mozilla-ai/gateway#45](https://github.com/mozilla-ai/gateway/pull/45); both repos need to flip in step so the SDK's gateway client and the gateway itself agree on the header name.

### What changes

- `src/any_llm/gateway/core/config.py`: `API_KEY_HEADER = "AnyLLM-Key"`, comment cites RFC 6648.
- `src/any_llm/gateway/api/deps.py`: `_extract_bearer_token` walks a precedence tuple (`AnyLLM-Key` > `Authorization`, then `x-api-key` as the Anthropic-compatible fallback).
- `src/any_llm/gateway/main.py`: `Vary` hint and CORS `allow_headers` list use the new name via `API_KEY_HEADER`.
- `src/any_llm/providers/gateway/gateway.py`: `GATEWAY_HEADER_NAME` is now `"AnyLLM-Key"`, so the SDK's gateway client sends the canonical header by default.
- `docs/`: every curl example, quickstart snippet, and authentication reference now teaches the canonical header.
- `tests/gateway/test_client_args.py`, `test_key_management.py`, `test_provider_kwargs_override.py`: hard-coded header literals replaced with `API_KEY_HEADER` so the tests track the rename.
- `tests/unit/test_extract_bearer_token.py` (new): direct unit tests of `_extract_bearer_token` covering every precedence pair among `AnyLLM-Key`, `Authorization`, and `x-api-key`, malformed `Bearer` prefix on each bearer-format header, missing credentials, and empty-string fall-through.
- `tests/gateway/test_auth_header_precedence.py` (new): end-to-end integration tests that exercise the middleware stack: virtual-API-key auth on `/v1/models`, the `Vary` caching hint, and the CORS allow-list.

### Commits

1. `feat(gateway): rename auth header from X-AnyLLM-Key to AnyLLM-Key`
2. `test(gateway): cover AnyLLM-Key precedence and bearer-token extraction`

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #1023

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude Opus 4.6 (1M context)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)