### PR TITLE
fix(gateway): handle dict user_id in Anthropic messages metadata

### DIFF
--- a/src/any_llm/gateway/api/routes/messages.py
+++ b/src/any_llm/gateway/api/routes/messages.py
@@ -1,3 +1,4 @@
+import json
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -45,6 +46,22 @@ class MessagesRequest(BaseModel):
     cache_control: dict[str, Any] | None = None
 
 
+def _normalize_user_id(value: Any) -> str | None:
+    """Extract a user_id string from metadata, handling dict and string types.
+
+    The Anthropic API spec defines metadata.user_id as a string, but some clients
+    may send a dict. This function handles both cases gracefully.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("user_id", "id", "account_uuid", "device_id"):
+            if key in value and isinstance(value[key], str) and value[key]:
+                return value[key]
+        return json.dumps(value, sort_keys=True)
+    return str(value) if value is not None else None
+
+
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
     """Create an HTTPException with Anthropic-style error body."""
     return HTTPException(
@@ -74,7 +91,7 @@ async def create_message(
     api_key, is_master_key = auth_result
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
     user_id = resolve_user_id(
-        user_id_from_request=str(user_from_metadata) if user_from_metadata else None,
+        user_id_from_request=_normalize_user_id(user_from_metadata),
         api_key=api_key,
         is_master_key=is_master_key,
         master_key_error=_anthropic_error(

--- a/tests/gateway/test_messages_endpoint.py
+++ b/tests/gateway/test_messages_endpoint.py
@@ -194,6 +194,52 @@ def test_messages_endpoint_provider_error_format(
     assert detail["error"]["type"] == "api_error"
 
 
+def test_messages_endpoint_dict_user_id_in_metadata(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+    messages_request_body: dict[str, Any],
+) -> None:
+    """Test that dict-typed user_id in metadata is handled gracefully."""
+    mock_response = _make_message_response()
+    messages_request_body["metadata"] = {
+        "user_id": {
+            "device_id": "c7a9f910a6b876ceca80e42de13bb085f05a81bfa4d77ede4104459e7776a3de",
+            "account_uuid": "",
+            "session_id": "2f614ef6-0f8d-413d-ba56-3dfe4b02fa88",
+        }
+    }
+
+    with patch("any_llm.gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+        response = client.post(
+            "/v1/messages",
+            json=messages_request_body,
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 200
+
+
+def test_messages_endpoint_dict_user_id_extracts_known_field(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+    messages_request_body: dict[str, Any],
+) -> None:
+    """Test that dict user_id with a 'user_id' key extracts that value."""
+    mock_response = _make_message_response()
+    messages_request_body["metadata"] = {"user_id": {"user_id": "test-user", "extra": "data"}}
+
+    with patch("any_llm.gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+        response = client.post(
+            "/v1/messages",
+            json=messages_request_body,
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 200
+
+
 def test_messages_endpoint_bearer_auth(
     client: TestClient,
     api_key_obj: dict[str, Any],


### PR DESCRIPTION
## Problem

When a client sends `metadata.user_id` as a dict (e.g. `{"device_id": "...", "session_id": "..."}`), `str(dict)` produces a Python repr string like `"{'device_id': '...', 'session_id': '...'}"`. This string never matches any user in the DB, causing a silent HTTP 404.

Reported in #1027.

## Root Cause

In `messages.py:75`:
```python
user_id_from_request=str(user_from_metadata) if user_from_metadata else None
```

When `user_from_metadata` is a dict, `str()` produces a Python repr, not a valid user ID.

## Fix

Added `_normalize_user_id()` helper that:
1. Returns strings as-is (happy path)
2. For dicts, tries to extract a known identifier field (`user_id`, `id`, `account_uuid`, `device_id`)
3. Falls back to deterministic JSON serialization if no known field found
4. Handles None gracefully

Added 2 tests:
- `test_messages_endpoint_dict_user_id_in_metadata` — dict with no known fields (extracts device_id)
- `test_messages_endpoint_dict_user_id_extracts_known_field` — dict with a `user_id` key

## AI Disclosure

This PR was authored with AI assistance (Hermes Agent).
