### PR TITLE
fix(mistral): handle Optional choice.message from v2 SDK

### DIFF
--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -170,6 +170,12 @@ def _create_mistral_completion_from_response(
 
     for i, choice_data in enumerate(response_data.choices):
         message_data = choice_data.message
+        # mistralai v2 types choice.message as Optional, but every chat-completion choice
+        # carries a message in practice. Fail loudly if the SDK ever hands us None so we
+        # do not silently emit a truncated ChatCompletion.
+        if message_data is None:
+            msg = "Mistral chat completion returned a choice without a message"
+            raise ValueError(msg)
 
         if message_data.content:
             content, reasoning_content = _extract_mistral_content_and_reasoning(message_data.content)

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -978,3 +978,68 @@ async def test_create_batch_model_mismatch_raises_error() -> None:
             import os
 
             os.unlink(tmp_path)
+
+
+def test_create_mistral_completion_raises_when_choice_message_is_none() -> None:
+    """Guard against the mistralai v2 `choice.message: AssistantMessage | None` type.
+
+    A real chat completion always carries a message, but the SDK types permit None.
+    The converter should fail loudly rather than silently emit a truncated ChatCompletion.
+    """
+    pytest.importorskip("mistralai")
+    from any_llm.providers.mistral.utils import _create_mistral_completion_from_response
+
+    choice = Mock()
+    choice.message = None
+    response = Mock()
+    response.choices = [choice]
+
+    with pytest.raises(ValueError, match="without a message"):
+        _create_mistral_completion_from_response(response, model="mistral-small-latest")
+
+
+def test_create_mistral_completion_builds_chatcompletion_from_well_formed_response() -> None:
+    """Happy path for `_create_mistral_completion_from_response`.
+
+    Covers the `message_data is not None` branch the guard introduced and exercises the
+    rest of the converter against a well-formed response so the function has baseline
+    unit coverage beyond the error path.
+    """
+    pytest.importorskip("mistralai")
+    from any_llm.providers.mistral.utils import _create_mistral_completion_from_response
+
+    message = Mock()
+    message.content = "Hello from Mistral!"
+    message.tool_calls = None
+
+    choice = Mock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    usage = Mock()
+    usage.prompt_tokens = 12
+    usage.completion_tokens = 7
+    usage.total_tokens = 19
+
+    response = Mock()
+    response.id = "chatcmpl-abc"
+    response.created = 1_700_000_000
+    response.choices = [choice]
+    response.usage = usage
+
+    completion = _create_mistral_completion_from_response(response, model="mistral-small-latest")
+
+    assert completion.id == "chatcmpl-abc"
+    assert completion.model == "mistral-small-latest"
+    assert completion.created == 1_700_000_000
+    assert completion.object == "chat.completion"
+    assert len(completion.choices) == 1
+    assert completion.choices[0].index == 0
+    assert completion.choices[0].finish_reason == "stop"
+    assert completion.choices[0].message.role == "assistant"
+    assert completion.choices[0].message.content == "Hello from Mistral!"
+    assert completion.choices[0].message.tool_calls is None
+    assert completion.usage is not None
+    assert completion.usage.prompt_tokens == 12
+    assert completion.usage.completion_tokens == 7
+    assert completion.usage.total_tokens == 19


### PR DESCRIPTION
## Description

The mistralai v2 SDK (adopted in #1020) types `choice.message` as `AssistantMessage | None`, but `_create_mistral_completion_from_response` dereferenced `message_data.content` and `message_data.tool_calls` without a None guard. This produced five `union-attr` errors under mypy strict mode:

```
src/any_llm/providers/mistral/utils.py:174: error: Item "None" of "AssistantMessage | None" has no attribute "content"  [union-attr]
src/any_llm/providers/mistral/utils.py:175: error: ... [union-attr]
src/any_llm/providers/mistral/utils.py:181: error: ... [union-attr]
src/any_llm/providers/mistral/utils.py:183: error: ... [union-attr]
src/any_llm/providers/mistral/utils.py:201: error: ... [union-attr]
```

The lint job on `main` has been intermittently failing since #1020 merged — whichever CI run hit the resolver state where mistralai's tightened typing was visible would fail. The most recent failure is on PR #1028.

### Fix

Add an explicit `ValueError` guard at the top of the loop so the converter fails loudly rather than silently emitting a truncated `ChatCompletion`. A real chat-completion choice always carries a message; if the SDK ever hands us `None`, we want to know rather than drop the choice silently.

Includes a unit test that covers the new guard path.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Regression introduced by #1020 (`fix(mistral): update imports for mistralai v2 SDK`).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude Opus 4.6 (1M context)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)