### PR TITLE
chore: add deprecation notices for bundled gateway (removal on May 18, 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Alternatively, pass API keys directly in your code (see [Usage](#usage) examples
 
 ## any-llm-gateway
 
+> **Deprecation Notice:** The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+> Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+
 any-llm-gateway is an **optional** FastAPI-based proxy server that adds enterprise-grade features on top of the core library:
 
 - **Budget Management** - Enforce spending limits with automatic daily, weekly, or monthly resets

--- a/docs/gateway/api-reference.md
+++ b/docs/gateway/api-reference.md
@@ -1,7 +1,12 @@
 ---
-title: API Reference
+title: API Reference (Deprecated)
 description: Complete OpenAPI specification for the any-llm gateway
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 The gateway API follows the OpenAI-compatible format. You can view and download the full OpenAPI specification below.
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -1,7 +1,12 @@
 ---
-title: Authentication
+title: Authentication (Deprecated)
 description: Master key and virtual API key authentication for the gateway
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 any-llm-gateway offers two authentication methods, each designed for different use cases. Understanding when to use each approach will help you secure your gateway effectively.
 

--- a/docs/gateway/budget-management.md
+++ b/docs/gateway/budget-management.md
@@ -1,7 +1,12 @@
 ---
-title: Budget Management
+title: Budget Management (Deprecated)
 description: Configure spending limits, budget tiers, and automatic resets
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 Budgets provide shared spending limits that can be assigned to multiple users. This allows you to create budget tiers (like "Free", "Pro", "Enterprise") and enforce spending limits across groups of users.
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1,7 +1,12 @@
 ---
-title: Configuration
+title: Configuration (Deprecated)
 description: Configure the gateway using YAML files or environment variables
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 The any-llm-gateway requires configuration to connect to your database, authenticate requests, and route to LLM providers. This guide covers the two main configuration approaches and how to set up model pricing for cost tracking.
 

--- a/docs/gateway/docker-deployment.md
+++ b/docs/gateway/docker-deployment.md
@@ -1,7 +1,12 @@
 ---
-title: Docker Deployment Guide
+title: Docker Deployment Guide (Deprecated)
 description: Deploy any-llm-gateway using Docker and Docker Compose
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 This guide walks you through deploying `any-llm-gateway` using Docker and Docker Compose. Whether you're setting up a local development environment or deploying to production, this guide covers the essential steps and best practices for a secure, reliable deployment.
 

--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -1,7 +1,12 @@
 ---
-title: Gateway Overview
+title: Gateway Overview (Deprecated)
 description: FastAPI-based proxy server for budget enforcement, API key management, and usage analytics
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 ## What is any-llm-gateway?
 

--- a/docs/gateway/quickstart.md
+++ b/docs/gateway/quickstart.md
@@ -1,7 +1,12 @@
 ---
-title: Quick Start
+title: Quick Start (Deprecated)
 description: Set up any-llm-gateway and make your first LLM completion request
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 This guide will help you set up any-llm-gateway and make your first LLM completion request. The gateway acts as a proxy between your applications and LLM providers, providing cost control, usage tracking, and API key management.
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -1,7 +1,12 @@
 ---
-title: Troubleshooting
+title: Troubleshooting (Deprecated)
 description: Common issues and solutions for the any-llm gateway
 ---
+
+:::caution[Deprecation Notice]
+The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
+Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
+:::
 
 ## Database connection errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,8 @@ sambanova = []
 minimax = []
 mzai = []
 vllm = []
+# Deprecated: the gateway is moving to a standalone package.
+# See https://github.com/mozilla-ai/gateway
 gateway = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "anthropic>=0.83.0",
   "rich",
   "httpx",
-  "typing_extensions>=4.4.0",
+  "typing_extensions>=4.5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/any_llm/gateway/__init__.py
+++ b/src/any_llm/gateway/__init__.py
@@ -1,3 +1,12 @@
+import warnings
+
+warnings.warn(
+    "any_llm.gateway is deprecated and will be removed on May 18, 2026. "
+    "Migrate to the standalone package at https://github.com/mozilla-ai/gateway",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from any_llm import __version__
 
 __all__ = ["__version__"]

--- a/src/any_llm/gateway/__init__.py
+++ b/src/any_llm/gateway/__init__.py
@@ -1,12 +1,12 @@
 import warnings
 
+from any_llm import __version__
+
 warnings.warn(
     "any_llm.gateway is deprecated and will be removed on May 18, 2026. "
     "Migrate to the standalone package at https://github.com/mozilla-ai/gateway",
     DeprecationWarning,
     stacklevel=2,
 )
-
-from any_llm import __version__
 
 __all__ = ["__version__"]

--- a/src/any_llm/gateway/cli.py
+++ b/src/any_llm/gateway/cli.py
@@ -152,9 +152,11 @@ def migrate(config: str | None, database_url: str | None, revision: str) -> None
 
 def main() -> None:
     """Entry point for the CLI."""
-    invoked_as = os.path.basename(sys.argv[0])
-    if invoked_as == "any-llm-gateway":
-        click.echo("'any-llm-gateway' is deprecated. Use 'gateway' instead.", err=True)
+    click.echo(
+        "WARNING: The gateway bundled in any-llm is deprecated and will be removed "
+        "on May 18, 2026. Migrate to https://github.com/mozilla-ai/gateway",
+        err=True,
+    )
     cli()
 
 

--- a/src/any_llm/gateway/core/config.py
+++ b/src/any_llm/gateway/core/config.py
@@ -6,6 +6,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import deprecated
 
 API_KEY_HEADER = "X-AnyLLM-Key"
 
@@ -17,6 +18,9 @@ class PricingConfig(BaseModel):
     output_price_per_million: float = Field(ge=0)
 
 
+@deprecated(
+    "any_llm.gateway is deprecated and will be removed on May 18, 2026. Migrate to https://github.com/mozilla-ai/gateway"
+)
 class GatewayConfig(BaseSettings):
     """Gateway configuration with support for YAML files and environment variables."""
 
@@ -61,6 +65,9 @@ class GatewayConfig(BaseSettings):
     )
 
 
+@deprecated(
+    "any_llm.gateway is deprecated and will be removed on May 18, 2026. Migrate to https://github.com/mozilla-ai/gateway"
+)
 def load_config(config_path: str | None = None) -> GatewayConfig:
     """Load configuration from file and environment variables.
 

--- a/src/any_llm/gateway/main.py
+++ b/src/any_llm/gateway/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from typing_extensions import override
+from typing_extensions import deprecated, override
 
 from any_llm.gateway import __version__
 from any_llm.gateway.api.deps import set_config
@@ -124,6 +124,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         return response
 
 
+@deprecated(
+    "any_llm.gateway is deprecated and will be removed on May 18, 2026. Migrate to https://github.com/mozilla-ai/gateway"
+)
 def create_app(config: GatewayConfig) -> FastAPI:
     """Create and configure FastAPI application.
 

--- a/tests/unit/test_gateway_cli.py
+++ b/tests/unit/test_gateway_cli.py
@@ -6,9 +6,7 @@ import any_llm.gateway.cli as gateway_cli
 from any_llm.gateway.core.config import GatewayConfig
 
 
-def test_main_warns_for_deprecated_binary_name(
-    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_emits_deprecation_warning(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     called = False
 
     def fake_cli() -> None:
@@ -21,26 +19,9 @@ def test_main_warns_for_deprecated_binary_name(
     gateway_cli.main()
 
     captured = capsys.readouterr()
-    assert "'any-llm-gateway' is deprecated. Use 'gateway' instead." in captured.err
-    assert called
-
-
-def test_main_does_not_warn_for_gateway_binary_name(
-    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    called = False
-
-    def fake_cli() -> None:
-        nonlocal called
-        called = True
-
-    monkeypatch.setattr(gateway_cli, "cli", fake_cli)
-    monkeypatch.setattr(sys, "argv", ["gateway", "serve"])
-
-    gateway_cli.main()
-
-    captured = capsys.readouterr()
-    assert captured.err == ""
+    assert "deprecated" in captured.err
+    assert "May 18, 2026" in captured.err
+    assert "https://github.com/mozilla-ai/gateway" in captured.err
     assert called
 
 


### PR DESCRIPTION
## Description

Adds deprecation notices across all gateway touchpoints to give users a one-month warning before the gateway is removed from this repository. The gateway is moving to a standalone package at https://github.com/mozilla-ai/gateway.

Changes:
- **Runtime warning**: `DeprecationWarning` emitted on any `import any_llm.gateway`
- **CLI warning**: Every `any-llm-gateway` CLI invocation prints a deprecation notice to stderr
- **README**: Deprecation banner added to the `## any-llm-gateway` section
- **Documentation**: All 8 gateway doc pages get a `:::caution[Deprecation Notice]` banner and `(Deprecated)` in their titles
- **Sidebar**: Gateway section labeled as `"Gateway (Deprecated)"` in `astro.config.mjs`
- **pyproject.toml**: Comment above the `gateway` extra noting the deprecation
- **Tests**: CLI tests updated to match the new always-warn behavior

All messages consistently reference the removal date (May 18, 2026) and the new repository URL.

## PR Type

- 📚 Documentation
- 🚦 Infrastructure

## Relevant issues

N/A - Preparing for gateway extraction to https://github.com/mozilla-ai/gateway

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4 (claude-opus-4-6)
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Used to research the gateway surface area and implement deprecation notices across all touchpoints.

- [ ] I am an AI Agent filling out this form (check box if true)