### PR TITLE
feat(vertexai): add credential parameter passing support

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+from google.oauth2.service_account import Credentials
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
@@ -19,6 +20,9 @@ from any_llm.types.completion import (
     Function,
     Reasoning,
 )
+import json
+import os
+
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
@@ -306,3 +310,47 @@ class GoogleProvider(AnyLLM):
     async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
         models_list = await self.client.aio.models.list(**kwargs)
         return self._convert_list_models_response(models_list)
+
+    def _build_credentials(self, credentials: str | dict) -> Credentials:
+        """
+        Build and return Google Cloud Credentials from the credentials parameter.
+
+        The 'credentials' parameter can be a path to a JSON key file,
+        a JSON string containing the key file contents, or a dictionary
+        representing the service account key.
+
+        Args:
+            credentials: Service account JSON string, file path, or dictionary
+
+        Returns:
+            Credentials: A Google OAuth2 Service Account Credentials object with the required scopes.
+
+        Raises:
+            ValueError: If 'credentials' is not provided or is in an invalid format.
+        """
+        if not credentials:
+            raise ValueError("Missing 'credentials' file or string")
+
+        scopes = [
+            "https://www.googleapis.com/auth/generative-language",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/aiplatform",
+        ]
+
+        # Check if it is a file path
+        if isinstance(credentials, str) and os.path.isfile(credentials):
+            return Credentials.from_service_account_file(credentials, scopes=scopes)
+
+        # Otherwise, attempt to parse as JSON string or dict
+        service_account_info = None
+        if isinstance(credentials, dict):
+            service_account_info = credentials
+        elif isinstance(credentials, str):
+            try:
+                service_account_info = json.loads(credentials)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON format for credentials: {e}")
+        else:
+            raise ValueError("credentials must be a file path, JSON string, or dictionary")
+
+        return Credentials.from_service_account_info(service_account_info, scopes=scopes)

--- a/src/any_llm/providers/vertexai/vertexai.py
+++ b/src/any_llm/providers/vertexai/vertexai.py
@@ -27,13 +27,33 @@ class VertexaiProvider(GoogleProvider):
         if (timeout := kwargs.pop("timeout", None)) is not None:
             GoogleProvider._merge_timeout_into_http_options(timeout, kwargs)
 
-        self.client = genai.Client(
-            vertexai=True,
-            **kwargs,
-        )
+        if ('credentials' in kwargs
+                and 'project' in kwargs
+                and 'location' in kwargs):
+
+            credentials = self._build_credentials(kwargs['credentials'])
+            project = kwargs['project']
+            location = kwargs['location']
+
+            exclude = {"credentials", "project", "location"}
+            kwargs_copy = {k: v for k, v in kwargs.items() if k not in exclude}
+
+            self.client = genai.client.Client(
+                vertexai=True,
+                credentials=credentials,
+                project=project,
+                location=location,
+                **kwargs_copy,
+            )
+        else:
+            self.client = genai.client.Client(
+                vertexai=True,
+                **kwargs,
+            )
+
         if self.client._api_client.project is None:
             msg = "vertexai"
-            raise MissingApiKeyError(msg, "GOOGLE_CLOUD_PROJECT")
+            raise MissingApiKeyError(msg, "env:GOOGLE_CLOUD_PROJECT or provider:config:client_args:project")
         if self.client._api_client.location is None:
             msg = "vertexai"
-            raise MissingApiKeyError(msg, "GOOGLE_CLOUD_LOCATION")
+            raise MissingApiKeyError(msg, "env:GOOGLE_CLOUD_LOCATION or provider:config:client_args:location")


### PR DESCRIPTION
 ## Description
  This PR implements Phase 1 of the VertexAI credential loading enhancement as described in issue #1038. It modifies the VertexAI provider to support direct credential parameter passing instead of relying solely on environment variables.

  ### Key Changes:
  1. **Added `_build_credentials()` method to `GoogleProvider` base class** (`src/any_llm/providers/gemini/base.py`):
     - Supports JSON file paths, JSON strings, and dictionary objects
     - Includes proper scopes for VertexAI access
     - Provides detailed error messages for invalid credential formats

  2. **Enhanced `_init_client()` method in `VertexaiProvider`** (`src/any_llm/providers/vertexai/vertexai.py`):
     - Checks for `credentials`, `project`, and `location` parameters in `kwargs`
     - Uses `_build_credentials()` to construct credential objects when parameters are provided
     - Maintains backward compatibility with environment variable fallback
     - Updated error messages to indicate both environment variable and parameter options

  3. **Parameter priority**: The provider now prioritizes:
     - 1. Direct parameters (`credentials`, `project`, `location` in `kwargs`)
     - 2. Environment variables (`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`)

  ### Usage Examples:
  ```python
  # Using file path
  llm = AnyLLM(
      provider="vertexai",
      credentials="/path/to/service_account.json",
      project="my-project",
      location="us-central1",
  )

  # Using JSON string
  llm = AnyLLM(
      provider="vertexai",
      credentials='{"type": "service_account", "project_id": "...", ...}',
      project="my-project",
      location="us-central1",
  )

  # Using dictionary
  llm = AnyLLM(
      provider="vertexai",
      credentials={"type": "service_account", "project_id": "...", ...},
      project="my-project",
      location="us-central1",
  )
```

##  PR Type

  - 🆕 New Feature
  - 💅 Refactor

 ## Relevant issues

  Fixes #1038

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

## Notes for Reviewers

  1. This is Phase 1 of the enhancement (SDK modifications only)
  2. Phase 2 (Gateway modifications) will be implemented after this SDK change is released
  3. The Gateway currently still uses setup_vertex_environment() - this will be updated in Phase 2
  4. Backward compatibility is maintained - existing deployments using environment variables will continue to work
  5. Error messages now clearly indicate both configuration options for better developer experience

##  Next Steps

  After this PR is merged and a new SDK version is released:
  1. Update gateway to pass credentials directly instead of using environment variables
  2. Mark setup_vertex_environment() as deprecated
  3. Remove temporary file creation logic from gateway
