### PR TITLE
fix(providers): handle tools with None parameters

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -328,7 +328,7 @@ def _convert_tool_spec(openai_tools: list[dict[str, Any]]) -> list[dict[str, Any
         generic_tool = {
             "name": function["name"],
             "description": function.get("description", ""),
-            "parameters": function.get("parameters", {}),
+            "parameters": function.get("parameters") or {},
         }
         generic_tools.append(generic_tool)
 
@@ -339,7 +339,7 @@ def _convert_tool_spec(openai_tools: list[dict[str, Any]]) -> list[dict[str, Any
             "description": tool["description"],
             "input_schema": {
                 "type": "object",
-                "properties": tool["parameters"]["properties"],
+                "properties": tool["parameters"].get("properties") or {},
                 "required": tool["parameters"].get("required", []),
             },
         }

--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -87,7 +87,7 @@ def _convert_tool_spec(tools: list[dict[str, Any]], tool_choice: str | dict[str,
                 "toolSpec": {
                     "name": tool["function"]["name"],
                     "description": tool["function"].get("description", " "),
-                    "inputSchema": {"json": tool["function"]["parameters"]},
+                    "inputSchema": {"json": tool["function"].get("parameters") or {"type": "object", "properties": {}}},
                 }
             }
             for tool in tools

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -41,8 +41,9 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
             continue
 
         function = tool["function"]
+        params: dict[str, Any] = function.get("parameters") or {}
         properties: dict[str, dict[str, Any]] = {}
-        for param_name, param_info in function["parameters"]["properties"].items():
+        for param_name, param_info in (params.get("properties") or {}).items():
             prop: dict[str, Any] = {
                 "type": param_info.get("type", "string"),
                 "description": param_info.get("description", ""),
@@ -58,7 +59,7 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
         parameters_dict = {
             "type": "object",
             "properties": properties,
-            "required": function["parameters"].get("required", []),
+            "required": params.get("required", []),
         }
 
         function_declarations.append(

--- a/src/any_llm/providers/llama/utils.py
+++ b/src/any_llm/providers/llama/utils.py
@@ -6,7 +6,7 @@ def _patch_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     # Llama requires that the 'union_specified' has a parameter type specified
     # so we need to patch the schema to include the type of the parameter
     # if any of the function call parameter properties have 'oneOf' set, make sure the property has type set. If not, set it to string. This is a quirk with Llama API currently.
-    props = schema["function"]["parameters"]["properties"]
+    props = (schema["function"].get("parameters") or {}).get("properties") or {}
     for prop in props:
         if "oneOf" in props[prop] and "type" not in props[prop]:
             props[prop]["type"] = "string"

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -14,6 +14,7 @@ from any_llm.providers.anthropic.utils import (
     DEFAULT_MAX_TOKENS,
     REASONING_EFFORT_TO_ANTHROPIC_EFFORT,
     _convert_response_format,
+    _convert_tool_spec,
 )
 from any_llm.types.completion import ChatCompletionMessageFunctionToolCall, CompletionParams, ReasoningEffort
 
@@ -870,3 +871,19 @@ def test_non_streaming_response_preserves_multiple_tool_calls() -> None:
     assert isinstance(result.choices[0].message.tool_calls[1], ChatCompletionMessageFunctionToolCall)
     assert result.choices[0].message.tool_calls[1].function is not None
     assert result.choices[0].message.tool_calls[1].function.name == "get_time"
+
+
+def test_convert_tool_spec_none_parameters() -> None:
+    """Regression: parameters=None must not raise 'NoneType' object is not subscriptable."""
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": None}}])
+    assert len(tools) == 1
+    assert tools[0]["name"] == "ping"
+    assert tools[0]["input_schema"]["properties"] == {}
+    assert tools[0]["input_schema"]["required"] == []
+
+
+def test_convert_tool_spec_parameters_missing_properties() -> None:
+    """Regression: parameters without a 'properties' key must not raise KeyError."""
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}])
+    assert len(tools) == 1
+    assert tools[0]["input_schema"]["properties"] == {}

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -13,6 +13,7 @@ from any_llm.providers.bedrock.utils import (
     _convert_images_for_bedrock,
     _convert_messages,
     _convert_response,
+    _convert_tool_spec,
     _create_openai_chunk_from_aws_chunk,
 )
 from any_llm.types.completion import CompletionParams, ReasoningEffort
@@ -745,3 +746,25 @@ def test_streaming_metadata_chunk_without_cached_tokens() -> None:
     assert result.usage.prompt_tokens == 100
     assert result.usage.completion_tokens == 50
     assert result.usage.prompt_tokens_details is None
+
+
+def test_convert_tool_spec_none_parameters() -> None:
+    """Regression: parameters=None must not pass None to Bedrock's inputSchema."""
+    tool_config = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "ping", "parameters": None}}],
+        tool_choice=None,
+    )
+    spec = tool_config["tools"][0]["toolSpec"]
+    assert spec["name"] == "ping"
+    assert spec["inputSchema"]["json"] is not None
+    assert spec["inputSchema"]["json"]["properties"] == {}
+
+
+def test_convert_tool_spec_with_parameters() -> None:
+    """Parameters present must be forwarded as-is to inputSchema."""
+    params = {"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]}
+    tool_config = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "search", "parameters": params}}],
+        tool_choice=None,
+    )
+    assert tool_config["tools"][0]["toolSpec"]["inputSchema"]["json"] == params

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -642,6 +642,24 @@ def test_convert_tool_spec_basic_mapping() -> None:
     assert "additionalProperties" not in tools[0].function_declarations[0].parameters.properties["config"]  # type: ignore[union-attr, index]
 
 
+def test_convert_tool_spec_none_parameters() -> None:
+    """Regression: parameters=None must not raise 'NoneType' object is not subscriptable."""
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": None}}])
+    assert len(tools) == 1
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.name == "ping"
+    assert decl.parameters.properties == {}  # type: ignore[union-attr]
+    assert decl.parameters.required == []  # type: ignore[union-attr]
+
+
+def test_convert_tool_spec_parameters_missing_properties() -> None:
+    """Regression: parameters without a 'properties' key must not raise KeyError."""
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}])
+    assert len(tools) == 1
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.parameters.properties == {}  # type: ignore[union-attr]
+
+
 @pytest.mark.asyncio
 async def test_gemini_with_built_in_tools() -> None:
     """Test that built-in tools are added correctly when specified."""

--- a/tests/unit/providers/test_llama_provider.py
+++ b/tests/unit/providers/test_llama_provider.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from any_llm.providers.llama.utils import _patch_json_schema
+
+
+def test_patch_json_schema_none_parameters() -> None:
+    """Regression: parameters=None must not raise 'NoneType' object is not subscriptable."""
+    schema: dict[str, Any] = {"type": "function", "function": {"name": "ping", "parameters": None}}
+    result = _patch_json_schema(schema)
+    assert result is schema
+
+
+def test_patch_json_schema_parameters_missing_properties() -> None:
+    """Regression: parameters without 'properties' must not raise KeyError."""
+    schema: dict[str, Any] = {"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}
+    result = _patch_json_schema(schema)
+    assert result is schema
+
+
+def test_patch_json_schema_patches_union_without_type() -> None:
+    """Existing behaviour: oneOf props without type get type=string."""
+    schema: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": "fn",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"oneOf": [{"type": "string"}]}},
+            },
+        },
+    }
+    _patch_json_schema(schema)
+    assert schema["function"]["parameters"]["properties"]["x"]["type"] == "string"


### PR DESCRIPTION
## Description

Fix `'NoneType' object is not subscriptable` crash when a tool function has no parameters (`parameters=None`) in Anthropic, Bedrock, Gemini, and Llama providers. All four providers now treat `None` or missing `parameters` as an empty object schema, with regression tests for each.

Based on #1043 by @liukidar. Cleaned up to pass CI (mypy type annotations, ruff formatting) and squashed into a single commit with co-author credit.

Supersedes #1043

## PR Type

- 🐛 Bug Fix

## Relevant issues

Supersedes #1043

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Reimplementation of #1043 by @liukidar with CI fixes.

- [x] I am an AI Agent filling out this form (check box if true)