### PR TITLE
fix(docs): use GitBook hint syntax for gateway deprecation warnings

### DIFF
--- a/docs/gateway/api-reference.md
+++ b/docs/gateway/api-reference.md
@@ -3,10 +3,10 @@ title: API Reference (Deprecated)
 description: Complete OpenAPI specification for the any-llm gateway
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 The gateway API follows the OpenAI-compatible format. You can view and download the full OpenAPI specification below.
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -3,10 +3,10 @@ title: Authentication (Deprecated)
 description: Master key and virtual API key authentication for the gateway
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 any-llm-gateway offers two authentication methods, each designed for different use cases. Understanding when to use each approach will help you secure your gateway effectively.
 

--- a/docs/gateway/budget-management.md
+++ b/docs/gateway/budget-management.md
@@ -3,10 +3,10 @@ title: Budget Management (Deprecated)
 description: Configure spending limits, budget tiers, and automatic resets
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 Budgets provide shared spending limits that can be assigned to multiple users. This allows you to create budget tiers (like "Free", "Pro", "Enterprise") and enforce spending limits across groups of users.
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3,10 +3,10 @@ title: Configuration (Deprecated)
 description: Configure the gateway using YAML files or environment variables
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 The any-llm-gateway requires configuration to connect to your database, authenticate requests, and route to LLM providers. This guide covers the two main configuration approaches and how to set up model pricing for cost tracking.
 

--- a/docs/gateway/docker-deployment.md
+++ b/docs/gateway/docker-deployment.md
@@ -3,10 +3,10 @@ title: Docker Deployment Guide (Deprecated)
 description: Deploy any-llm-gateway using Docker and Docker Compose
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 This guide walks you through deploying `any-llm-gateway` using Docker and Docker Compose. Whether you're setting up a local development environment or deploying to production, this guide covers the essential steps and best practices for a secure, reliable deployment.
 

--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -3,10 +3,10 @@ title: Gateway Overview (Deprecated)
 description: FastAPI-based proxy server for budget enforcement, API key management, and usage analytics
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 ## What is any-llm-gateway?
 

--- a/docs/gateway/quickstart.md
+++ b/docs/gateway/quickstart.md
@@ -3,10 +3,10 @@ title: Quick Start (Deprecated)
 description: Set up any-llm-gateway and make your first LLM completion request
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 This guide will help you set up any-llm-gateway and make your first LLM completion request. The gateway acts as a proxy between your applications and LLM providers, providing cost control, usage tracking, and API key management.
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -3,10 +3,10 @@ title: Troubleshooting (Deprecated)
 description: Common issues and solutions for the any-llm gateway
 ---
 
-:::caution[Deprecation Notice]
+{% hint style="warning" %}
 The gateway bundled with any-llm is deprecated and will be removed on May 18, 2026.
 Please migrate to the standalone gateway at [github.com/mozilla-ai/gateway](https://github.com/mozilla-ai/gateway).
-:::
+{% endhint %}
 
 ## Database connection errors
 


### PR DESCRIPTION
## Description

The gateway deprecation notices were written using `:::caution[...]` (Docusaurus/Starlight syntax), which GitBook does not render — they were showing as raw text in the docs.

Replaced with `{% hint style="warning" %}` / `{% endhint %}` (GitBook native syntax) across all 8 gateway doc pages.

## PR Type

- 🐛 Bug Fix
- 📚 Documentation

## Relevant issues

Fixes rendering of deprecation notices added in #1034.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have run this code locally and verified it fixes the issue.
- [x] Documentation was updated where necessary.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)