### PR TITLE
fix(tests): replace deprecated Nebius and SambaNova integration models

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,8 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.MOONSHOT: "kimi-k2-thinking",
         LLMProvider.BEDROCK: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",
-        LLMProvider.NEBIUS: "openai/gpt-oss-20b",
-        LLMProvider.SAMBANOVA: "DeepSeek-R1-0528",
+        LLMProvider.NEBIUS: "openai/gpt-oss-120b",
+        LLMProvider.SAMBANOVA: "gpt-oss-120b",
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
         LLMProvider.PORTKEY: "@nebius-any-llm/Qwen/Qwen3-32B",
         LLMProvider.MINIMAX: "MiniMax-M2",
@@ -60,7 +60,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
         LLMProvider.XAI: "grok-3-mini-latest",
         LLMProvider.INCEPTION: "mercury",
-        LLMProvider.NEBIUS: "openai/gpt-oss-20b",
+        LLMProvider.NEBIUS: "openai/gpt-oss-120b",
         LLMProvider.OLLAMA: "llama3.2:1b",
         LLMProvider.LLAMAFILE: "N/A",
         LLMProvider.LMSTUDIO: "google/gemma-3-4b",  # You must have LM Studio running and the server enabled
@@ -93,7 +93,7 @@ def provider_image_model_map(provider_model_map: dict[LLMProvider, str]) -> dict
         LLMProvider.OPENAI: "gpt-5-mini",  # Slightly more powerful so that it doesn't get caught in a loop of logic
         LLMProvider.WATSONX: "meta-llama/llama-guard-3-11b-vision",
         LLMProvider.SAMBANOVA: "Llama-4-Maverick-17B-128E-Instruct",
-        LLMProvider.NEBIUS: "openai/gpt-oss-20b",
+        LLMProvider.NEBIUS: "Qwen/Qwen2.5-VL-72B-Instruct",
         LLMProvider.OPENROUTER: "google/gemini-2.5-flash-lite",
         LLMProvider.OLLAMA: "llava-phi3",  # Fast vision model compatible with OpenAI format
         LLMProvider.FIREWORKS: "accounts/fireworks/models/kimi-k2p5",


### PR DESCRIPTION
## Summary

Two integration-test models have been retired by their providers, causing 15 failures in the latest CI run:

- **Nebius**: `openai/gpt-oss-20b` 404s on the inference API and is officially scheduled for removal on 2026-04-13 (per the [Nebius Token Factory deprecation page](https://docs.tokenfactory.nebius.com/other-capabilities/deprecation-info)).
- **SambaNova**: `DeepSeek-R1-0528` is on the [March 2026 production-model removal list](https://community.sambanova.ai/t/march-26-model-removal-deprecation/1626) and now returns "model is not available."

This PR points the affected fixtures at currently-supported models.

### Nebius (`tests/conftest.py`)

| Fixture | Old | New |
| --- | --- | --- |
| `provider_model_map` | `openai/gpt-oss-20b` | `openai/gpt-oss-120b` |
| `provider_reasoning_model_map` | `openai/gpt-oss-20b` | `openai/gpt-oss-120b` |
| `provider_image_model_map` | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-VL-72B-Instruct` |

`gpt-oss-120b` is the natural same-family successor and is listed in Nebius'\''s catalog (confirmed via OpenRouter'\''s Nebius routing list and Artificial Analysis'\''s Nebius provider page). It supports tool calling, structured outputs, and `reasoning_effort`, which covers every failing chat / reasoning / agent-loop / response-format / streaming test.

For the image map, the previous `openai/gpt-oss-20b` had no vision capability, so I switched to `Qwen/Qwen2.5-VL-72B-Instruct`, an actual VL model on Nebius. This makes `test_completion_with_image[nebius]` a real vision test instead of relying on the API silently degrading.

### SambaNova (`tests/conftest.py`)

| Fixture | Old | New |
| --- | --- | --- |
| `provider_reasoning_model_map` | `DeepSeek-R1-0528` | `gpt-oss-120b` |

`gpt-oss-120b` is in [SambaNova'\''s /v1/models response](https://api.sambanova.ai/v1/models), [supports `reasoning_effort` low/medium/high](https://sambanova.ai/blog/start-building-with-lightning-fast-gpt-oss-120b-on-sambacloud) on the OpenAI-compatible API, and emits reasoning content via the standard fields that `XMLReasoningOpenAIProvider` already handles, so the existing reasoning extraction path keeps working without touching provider code.

I considered DeepSeek-V3.1 / V3.2 (the spiritual successors to R1) but they require `chat_template_kwargs.enable_thinking=true` to actually produce thinking traces; the reasoning tests only pass `reasoning_effort="low"`, so V3.x would silently return empty reasoning. `gpt-oss-120b` honors `reasoning_effort` directly.

## PR Type

- Bug Fix

## Test plan

- [ ] CI integration tests for Nebius: `test_completion_reasoning`, `test_completion_reasoning_streaming`, `test_async_completion`, `test_async_completion_parallel`, `test_messages_*`, `test_streaming_completion_async`, `test_response_format`, `test_response_format_dataclass`, `test_agent_loop_*`, `test_completion_with_image` all green.
- [ ] CI integration tests for SambaNova: `test_completion_reasoning` and `test_completion_reasoning_streaming` green.

Marking as draft for now; the relevant proof is the integration job result.

## AI usage disclosure

Drafted by Claude (Opus 4.7) via discussion with @njbrake; reasoning and decisions are mine, prose is Claude'\''s.

Generated with [Claude Code](https://claude.com/claude-code)