### PR TITLE
fix(anthropic): rename `stop` to `stop_sequences` in request params

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -432,6 +432,10 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
     )
     result_kwargs["model"] = params.model_id
 
+    if "stop" in result_kwargs:
+        stop = result_kwargs.pop("stop")
+        result_kwargs["stop_sequences"] = [stop] if isinstance(stop, str) else stop
+
     system_message, filtered_messages = _convert_messages_for_anthropic(params.messages)
     if system_message:
         result_kwargs["system"] = system_message

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -119,6 +119,46 @@ async def test_completion_with_kwargs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completion_renames_stop_to_stop_sequences_list() -> None:
+    api_key = "test-api-key"
+    model = "model-id"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_anthropic_provider() as mock_anthropic:
+        provider = AnthropicProvider(api_key=api_key)
+        await provider._acompletion(
+            CompletionParams(model_id=model, messages=messages, stop=["END", "STOP"])
+        )
+
+        mock_anthropic.return_value.messages.create.assert_called_once_with(
+            model=model,
+            messages=messages,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            stop_sequences=["END", "STOP"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_completion_renames_stop_to_stop_sequences_string() -> None:
+    api_key = "test-api-key"
+    model = "model-id"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_anthropic_provider() as mock_anthropic:
+        provider = AnthropicProvider(api_key=api_key)
+        await provider._acompletion(
+            CompletionParams(model_id=model, messages=messages, stop="END")
+        )
+
+        mock_anthropic.return_value.messages.create.assert_called_once_with(
+            model=model,
+            messages=messages,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            stop_sequences=["END"],
+        )
+
+
+@pytest.mark.asyncio
 async def test_completion_with_tool_choice_required() -> None:
     api_key = "test-api-key"
     model = "model-id"

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -126,9 +126,7 @@ async def test_completion_renames_stop_to_stop_sequences_list() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(api_key=api_key)
-        await provider._acompletion(
-            CompletionParams(model_id=model, messages=messages, stop=["END", "STOP"])
-        )
+        await provider._acompletion(CompletionParams(model_id=model, messages=messages, stop=["END", "STOP"]))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,
@@ -146,9 +144,7 @@ async def test_completion_renames_stop_to_stop_sequences_string() -> None:
 
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(api_key=api_key)
-        await provider._acompletion(
-            CompletionParams(model_id=model, messages=messages, stop="END")
-        )
+        await provider._acompletion(CompletionParams(model_id=model, messages=messages, stop="END"))
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,


### PR DESCRIPTION
## Description
`CompletionParams.stop` follows OpenAI's surface (`str | list[str]`).
  In `anthropic/utils.py::_convert_params`, the parameter was forwarded 
  unchanged via `params.model_dump(...)`, so OpenAI-shaped requests with                                                                                                                                          
  `stop=["END"]` (or `stop="END"`) reached Anthropic under the wrong key
  and were either rejected or silently ignored.                                                                                                                                                                   
                                                                                   
  This PR pops `stop` after the model dump and re-emits it as           
  `stop_sequences`, normalising a single string into a one-element list.
  Gemini already does the equivalent rename in `gemini/base.py:117`;                                                                                                                                              
  OpenAI accepts `stop` natively, so this gap was specific to Anthropic
  and the providers that inherit from it (AzureAnthropic, VertexAnthropic,                                                                                                                                        
  Bedrock-Anthropic).                                                              
                                                                                                                                                                                                                  
  Two unit tests cover both shapes (`str` and `list[str]`); all 84                                                                                                                                                
  anthropic-derivative tests still pass.          


## PR Type

- 🐛 Bug Fix


## Relevant issues
None, discovered locally

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [X] I understand the code I am submitting.
- [X] I have added unit tests that prove my fix/feature works
- [X] I have run this code locally and verified it fixes the issue.
- [X] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [X] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [X] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [X] This is fully AI-generated.

## AI Usage Information


- AI Model used: Claude Opus 4.7
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
