### PR TITLE
fix: use NullHandler instead of setup_logger at import time

### DIFF
--- a/src/any_llm/logging.py
+++ b/src/any_llm/logging.py
@@ -38,4 +38,4 @@ def setup_logger(
     logger.addHandler(handler)
 
 
-setup_logger()
+logger.addHandler(logging.NullHandler())

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -506,7 +506,7 @@ def test_convert_batch_jobs_list_empty() -> None:
     assert result == []
 
 
-def test_convert_batch_job_unknown_status_logs_warning(capsys: pytest.CaptureFixture[str]) -> None:
+def test_convert_batch_job_unknown_status_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     """Test that unknown Mistral status logs a warning."""
     pytest.importorskip("mistralai")
     from any_llm.providers.mistral.utils import _convert_batch_job_to_openai
@@ -531,9 +531,8 @@ def test_convert_batch_job_unknown_status_logs_warning(capsys: pytest.CaptureFix
     result = _convert_batch_job_to_openai(mock_batch_job)
 
     assert result.status == "in_progress"  # Falls back to in_progress
-    captured = capsys.readouterr()
-    assert "Unknown Mistral batch status" in captured.out
-    assert "UNKNOWN_STATUS" in captured.out
+    assert "Unknown Mistral batch status" in caplog.text
+    assert "UNKNOWN_STATUS" in caplog.text
 
 
 def test_convert_batch_job_with_timeout_hours() -> None:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,28 @@
+import logging
+
+from any_llm.logging import logger
+
+
+def test_logger_has_null_handler_at_import() -> None:
+    """Test that the library logger uses NullHandler by default.
+
+    Libraries should use NullHandler so that importing the library does not
+    configure logging for the application. Users can then configure their own
+    handlers if they want to see log output.
+    See: https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+    """
+    null_handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+    assert len(null_handlers) >= 1
+
+
+def test_logger_does_not_install_rich_handler_at_import() -> None:
+    """Test that importing the library does not install RichHandler on the logger."""
+    from rich.logging import RichHandler
+
+    rich_handlers = [h for h in logger.handlers if isinstance(h, RichHandler)]
+    assert len(rich_handlers) == 0
+
+
+def test_logger_name_is_any_llm() -> None:
+    """Test that the logger name matches the library package name."""
+    assert logger.name == "any_llm"


### PR DESCRIPTION
## Description
Replace unconditional `setup_logger()` at module level with `NullHandler` per Python library logging best practices.

## Problem

`setup_logger()` was called unconditionally at module level in `logging.py`, which installed a `RichHandler` on the `any_llm` logger whenever the library was imported. This violates Python library logging best practice - libraries should use `NullHandler` so that importing them does not reconfigure logging for the entire application.

Per [Python docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):
> It is strongly advised that you do not add any handlers other than NullHandler to your library loggers.

## Fix

Replace `setup_logger()` at module level with `logger.addHandler(logging.NullHandler())`. The `setup_logger()` function is preserved so users can still call it explicitly to enable RichHandler output.

## PR Type
- 🐛 Bug Fix

## Relevant issues
<!-- N/A -->

## Testing

Added `tests/unit/test_logging.py` with 3 tests verifying:
- Logger has NullHandler at import time
- No RichHandler is installed at import time
- Logger name matches the package name

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [x] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: N/A
- AI Developer Tool used: N/A
- Any other info you like to share: N/A

- [ ] I am an AI Agent filling out this form (check box if true)