### PR TITLE
fix: use non-empty placeholder API key for local providers

### DIFF
--- a/src/any_llm/providers/llamacpp/llamacpp.py
+++ b/src/any_llm/providers/llamacpp/llamacpp.py
@@ -17,4 +17,4 @@ class LlamacppProvider(BaseOpenAIProvider):
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        return ""
+        return "no-key-required"

--- a/src/any_llm/providers/llamafile/llamafile.py
+++ b/src/any_llm/providers/llamafile/llamafile.py
@@ -25,7 +25,7 @@ class LlamafileProvider(BaseOpenAIProvider):
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        return ""
+        return "no-key-required"
 
     @staticmethod
     @override

--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -19,4 +19,4 @@ class LmstudioProvider(BaseOpenAIProvider):
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        return ""
+        return "no-key-required"

--- a/src/any_llm/providers/vllm/vllm.py
+++ b/src/any_llm/providers/vllm/vllm.py
@@ -19,4 +19,4 @@ class VllmProvider(BaseOpenAIProvider):
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
         # vLLM server by default doesn't require an API key
         # but can be configured to use one via --api-key flag
-        return api_key or ""
+        return api_key or "no-key-required"

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -43,6 +43,7 @@ class Choice(OpenAIChoice):
 
 class ChatCompletion(OpenAIChatCompletion):
     choices: list[Choice]  # type: ignore[assignment]
+    service_tier: str | None = None  # type: ignore[assignment]
 
 
 ContentType = TypeVar("ContentType")
@@ -70,6 +71,7 @@ class ChunkChoice(OpenAIChunkChoice):
 
 class ChatCompletionChunk(OpenAIChatCompletionChunk):
     choices: list[ChunkChoice]  # type: ignore[assignment]
+    service_tier: str | None = None  # type: ignore[assignment]
 
 
 class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionToolCall):

--- a/tests/unit/providers/test_openai_utils.py
+++ b/tests/unit/providers/test_openai_utils.py
@@ -1,8 +1,11 @@
 import pytest
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
 
 from any_llm.exceptions import ProviderError
+from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.providers.openai.utils import _convert_chat_completion
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
 
 
 def test_convert_chat_completion_with_empty_response() -> None:
@@ -46,3 +49,85 @@ def test_convert_chat_completion_with_partial_none_response() -> None:
 
     with pytest.raises(ValidationError):
         _convert_chat_completion(openai_response)
+
+
+def test_chat_completion_accepts_nonstandard_service_tier() -> None:
+    """Providers like OpenRouter may return service_tier values outside the OpenAI literal set."""
+    completion = ChatCompletion.model_validate(
+        {
+            "id": "test-id",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "Hello"},
+                }
+            ],
+            "service_tier": "standard",
+        }
+    )
+    assert completion.service_tier == "standard"
+
+
+def test_chat_completion_chunk_accepts_nonstandard_service_tier() -> None:
+    """Providers like OpenRouter may return service_tier values outside the OpenAI literal set."""
+    chunk = ChatCompletionChunk.model_validate(
+        {
+            "id": "test-id",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hi"},
+                    "finish_reason": None,
+                }
+            ],
+            "service_tier": "standard",
+        }
+    )
+    assert chunk.service_tier == "standard"
+
+
+def test_convert_completion_response_with_nonstandard_service_tier() -> None:
+    """The full conversion pipeline should handle non-standard service_tier values."""
+    openai_response = OpenAIChatCompletion.model_construct(
+        id="test-id",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Hello"},
+            }
+        ],
+        created=1234567890,
+        model="test-model",
+        object="chat.completion",
+        service_tier="standard",
+    )
+    result = _convert_chat_completion(openai_response)
+    assert result.service_tier == "standard"
+
+
+def test_convert_chunk_response_with_nonstandard_service_tier() -> None:
+    """The chunk conversion pipeline should handle non-standard service_tier values."""
+    openai_chunk = OpenAIChatCompletionChunk.model_construct(
+        id="test-id",
+        choices=[
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "Hi"},
+                "finish_reason": None,
+            }
+        ],
+        created=1234567890,
+        model="test-model",
+        object="chat.completion.chunk",
+        service_tier="standard",
+    )
+    result = BaseOpenAIProvider._convert_completion_chunk_response(openai_chunk)
+    assert result.service_tier == "standard"


### PR DESCRIPTION
## Description

Two fixes for compatibility with `openai` SDK `2.34.0` and third-party providers.

### 1. Empty API key rejection for local providers

`openai` SDK 2.34.0 (released between the last green main run and today) now rejects empty strings and `None` as `api_key` when instantiating `AsyncOpenAI`. Four providers that do not require an API key (llamacpp, llamafile, lmstudio, vllm) were returning `""` from `_verify_and_set_api_key`, which causes `openai.OpenAIError: Missing credentials` at client creation time.

This replaces the empty string with `"no-key-required"` so the SDK accepts the value while the providers remain functional without real credentials. The placeholder is never sent to a remote API since these providers talk to local servers.

**Affected providers:**
- `llamacpp` (was returning `""`)
- `llamafile` (was returning `""`)
- `lmstudio` (was returning `""`)
- `vllm` (was returning `api_key or ""`, now returns `api_key or "no-key-required"`)

**Evidence this is not a pre-existing failure:**
- Last passing main CI run (2026-05-11T15:31 UTC) used `openai==2.33.0`
- All CI runs since ~18:17 UTC use `openai==2.34.0` and fail with the same 19 tests
- An unrelated PR (`fix/anthropic-stop-sequences`) also fails identically

### 2. Non-standard `service_tier` values from third-party providers

OpenRouter returns `service_tier: "standard"` in its API responses, but the OpenAI SDK's `ChatCompletion` type restricts `service_tier` to `Literal["auto", "default", "flex", "scale", "priority"]`. Since `any_llm` wraps many providers beyond OpenAI, the `service_tier` field should accept any string value.

This overrides the inherited `Literal` type with `str | None` in both `ChatCompletion` and `ChatCompletionChunk`, consistent with how `ResponsesParams` already types this field. This is not OpenRouter-specific; any third-party provider can return non-standard values.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A (caused by upstream openai SDK 2.34.0 release and OpenRouter response format)

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Diagnosed root causes by comparing openai SDK versions between passing/failing CI runs and analyzing pydantic validation errors from OpenRouter integration tests

- [x] I am an AI Agent filling out this form (check box if true)