### PR TITLE
fix: stop reconfiguring consumer logging on import (Fixes #1024)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "openai>=1.99.3",
   "openresponses-types>=2.3.0.post1",
   "anthropic>=0.83.0",
-  "rich",
   "httpx",
   "typing_extensions>=4.5.0",
 ]
@@ -28,6 +27,10 @@ platform = [
   "any-llm-platform-client>=0.3.0",
   "opentelemetry-sdk>=1.30.0",
   "opentelemetry-exporter-otlp-proto-http>=1.30.0",
+]
+
+rich = [
+  "rich",
 ]
 
 perplexity = []
@@ -126,6 +129,7 @@ vllm = []
 # Deprecated: the gateway is moving to a standalone package.
 # See https://github.com/mozilla-ai/gateway
 gateway = [
+  "rich",
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.0",
   "sqlalchemy>=2.0.0",

--- a/src/any_llm/gateway/log_config.py
+++ b/src/any_llm/gateway/log_config.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any
 
-from rich.logging import RichHandler
-
 logger = logging.getLogger("gateway")
 
 
@@ -10,24 +8,35 @@ def setup_logger(
     level: int = logging.WARNING,
     rich_tracebacks: bool = True,
     log_format: str | None = None,
-    propagate: bool = False,
+    propagate: bool = True,
+    reset: bool = False,
     **kwargs: Any,
 ) -> None:
     """Configure the gateway logger with the specified settings.
 
     Args:
-        level: The logging level to use (default: logging.INFO)
+        level: The logging level to use (default: logging.WARNING)
         rich_tracebacks: Whether to enable rich tracebacks (default: True)
         log_format: Optional custom log format string
-        propagate: Whether to propagate logs to parent loggers (default: False)
+        propagate: Whether to propagate logs to parent loggers (default: True)
+        reset: If True, remove existing handlers before attaching a new one (default: False)
         **kwargs: Additional keyword arguments to pass to RichHandler
 
     """
     logger.setLevel(level)
     logger.propagate = propagate
 
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
+    if reset:
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+
+    try:
+        from rich.logging import RichHandler
+    except ImportError:
+        raise ImportError(
+            "rich is required for setup_logger(). "
+            "Install it with: pip install 'any-llm-sdk[rich]'"
+        ) from None
 
     handler = RichHandler(rich_tracebacks=rich_tracebacks, markup=True, **kwargs)
 
@@ -38,4 +47,4 @@ def setup_logger(
     logger.addHandler(handler)
 
 
-setup_logger()
+logger.addHandler(logging.NullHandler())

--- a/src/any_llm/logging.py
+++ b/src/any_llm/logging.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any
 
-from rich.logging import RichHandler
-
 logger = logging.getLogger("any_llm")
 
 
@@ -10,24 +8,35 @@ def setup_logger(
     level: int = logging.WARNING,
     rich_tracebacks: bool = True,
     log_format: str | None = None,
-    propagate: bool = False,
+    propagate: bool = True,
+    reset: bool = False,
     **kwargs: Any,
 ) -> None:
     """Configure the any_llm logger with the specified settings.
 
     Args:
-        level: The logging level to use (default: logging.INFO)
+        level: The logging level to use (default: logging.WARNING)
         rich_tracebacks: Whether to enable rich tracebacks (default: True)
         log_format: Optional custom log format string
-        propagate: Whether to propagate logs to parent loggers (default: False)
+        propagate: Whether to propagate logs to parent loggers (default: True)
+        reset: If True, remove existing handlers before attaching a new one (default: False)
         **kwargs: Additional keyword arguments to pass to RichHandler
 
     """
     logger.setLevel(level)
     logger.propagate = propagate
 
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
+    if reset:
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+
+    try:
+        from rich.logging import RichHandler
+    except ImportError:
+        raise ImportError(
+            "rich is required for setup_logger(). "
+            "Install it with: pip install 'any-llm-sdk[rich]'"
+        ) from None
 
     handler = RichHandler(rich_tracebacks=rich_tracebacks, markup=True, **kwargs)
 
@@ -38,4 +47,4 @@ def setup_logger(
     logger.addHandler(handler)
 
 
-setup_logger()
+logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
## Description
Fixes #1024 by implementing Python logging best practices for libraries.

### `logging.py` & `gateway/log_config.py`
1. Replace module-level `setup_logger()` with `NullHandler` pattern
2. Change `propagate` default from `False` to `True`
3. Add `reset` parameter for opt-in handler removal
4. Lazy-import `RichHandler` with helpful ImportError

### `pyproject.toml`
5. Move `rich` from hard dependency to optional extra (`pip install any-llm-sdk[rich]`)

## PR Type
- [x] Bug Fix

## Relevant issues
Fixes #1024

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: DeepSeek V4 (via OpenClaw)
- AI Developer Tool used: OpenClaw
- Any other info you'd like to share: This PR was created by an AI agent following the project's contributing guidelines.

- [x] I am an AI Agent filling out this form (check box if true)
