### PR TITLE
fix: resolve gateway credentials and SambaNova embedding integration test failures

### DIFF
--- a/src/any_llm/providers/gateway/gateway.py
+++ b/src/any_llm/providers/gateway/gateway.py
@@ -128,20 +128,24 @@ class GatewayProvider(BaseOpenAIProvider):
 
         # Non-platform mode (existing behavior)
         self.platform_mode = False
-        api_key = self._verify_and_set_api_key(api_key)
-        if api_key:
+        real_key = api_key or os.getenv(self.ENV_API_KEY_NAME, "")
+        if real_key:
             if "default_headers" not in kwargs:
                 kwargs["default_headers"] = {}
             elif kwargs["default_headers"].get(GATEWAY_HEADER_NAME):
                 msg = f"{GATEWAY_HEADER_NAME} header is already set, overriding with new API key"
                 logger.info(msg)
-            kwargs["default_headers"][GATEWAY_HEADER_NAME] = f"Bearer {api_key}"
-        super().__init__(api_key=api_key, api_base=resolved_api_base, **kwargs)
+            kwargs["default_headers"][GATEWAY_HEADER_NAME] = f"Bearer {real_key}"
+        super().__init__(api_key=real_key or None, api_base=resolved_api_base, **kwargs)
 
     @override
-    def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        """Unlike other providers, the gateway provider does not require an API key."""
-        return api_key or os.getenv(self.ENV_API_KEY_NAME, "")
+    def _verify_and_set_api_key(self, api_key: str | None = None) -> str:
+        """Unlike other providers, the gateway provider does not require an API key.
+
+        Returns a non-empty placeholder when no key is available so the
+        OpenAI SDK client-side validation (>= 2.34.0) is satisfied.
+        """
+        return api_key or os.getenv(self.ENV_API_KEY_NAME) or "no-key-required"
 
     # -- Platform-mode error handling -----------------------------------------
 

--- a/src/any_llm/providers/sambanova/sambanova.py
+++ b/src/any_llm/providers/sambanova/sambanova.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from openai.types import CreateEmbeddingResponse
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
 from typing_extensions import override
@@ -22,6 +23,36 @@ class SambanovaProvider(XMLReasoningOpenAIProvider):
 
     SUPPORTS_COMPLETION_PDF = False
     SUPPORTS_COMPLETION_REASONING = True
+
+    @override
+    async def _aembedding(
+        self,
+        model: str,
+        inputs: str | list[str],
+        **kwargs: Any,
+    ) -> CreateEmbeddingResponse:
+        """SambaNova does not support the ``encoding_format`` parameter.
+
+        The OpenAI SDK injects ``encoding_format`` into every
+        ``embeddings.create()`` call automatically.  We bypass that by
+        calling the client-level ``post()`` directly so only the
+        parameters SambaNova accepts are included in the request body.
+        """
+        if not self.SUPPORTS_EMBEDDING:
+            msg = "This provider does not support embeddings."
+            raise NotImplementedError(msg)
+
+        body: dict[str, Any] = {"input": inputs, "model": model}
+        if "dimensions" in kwargs:
+            body["dimensions"] = kwargs["dimensions"]
+
+        return self._convert_embedding_response(
+            await self.client.post(
+                "/embeddings",
+                body=body,
+                cast_to=CreateEmbeddingResponse,
+            )
+        )
 
     @staticmethod
     @override

--- a/tests/unit/providers/test_gateway_provider.py
+++ b/tests/unit/providers/test_gateway_provider.py
@@ -51,7 +51,8 @@ def test_gateway_init_without_api_key(mock_openai_class: MagicMock) -> None:
     mock_openai_class.assert_called_once()
     call_kwargs = mock_openai_class.call_args[1]
     assert call_kwargs["base_url"] == "https://gateway.example.com"
-    assert call_kwargs["api_key"] == ""
+    # When no key is provided, a placeholder is used to satisfy the OpenAI SDK (>= 2.34.0)
+    assert call_kwargs["api_key"] == "no-key-required"
 
 
 @patch("any_llm.providers.openai.base.AsyncOpenAI")
@@ -94,7 +95,8 @@ def test_gateway_init_without_any_api_key(mock_openai_class: MagicMock) -> None:
     GatewayProvider(api_base="https://gateway.example.com")
 
     call_kwargs = mock_openai_class.call_args[1]
-    assert call_kwargs["api_key"] == ""
+    # When no key is provided, a placeholder is used to satisfy the OpenAI SDK (>= 2.34.0)
+    assert call_kwargs["api_key"] == "no-key-required"
     assert "default_headers" not in call_kwargs or GATEWAY_HEADER_NAME not in call_kwargs.get("default_headers", {})
 
 
@@ -114,11 +116,11 @@ def test_verify_api_key_with_env_variable() -> None:
 
 
 @patch.dict(os.environ, {}, clear=True)
-def test_verify_api_key_none_returns_empty() -> None:
+def test_verify_api_key_none_returns_placeholder() -> None:
     with patch("any_llm.providers.openai.base.AsyncOpenAI"):
         provider = GatewayProvider(api_base="https://gateway.example.com")
         result = provider._verify_and_set_api_key(None)
-        assert result == ""
+        assert result == "no-key-required"
 
 
 @patch("any_llm.providers.openai.base.AsyncOpenAI")

--- a/tests/unit/providers/test_sambanova_provider.py
+++ b/tests/unit/providers/test_sambanova_provider.py
@@ -202,3 +202,34 @@ async def test_sambanova_embedding_with_list_input(mock_openai_class: MagicMock)
 
     body = mock_client.post.call_args.kwargs["body"]
     assert body["input"] == ["Hello", "world"]
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_sambanova_embedding_raises_when_unsupported(mock_openai_class: MagicMock) -> None:
+    """_aembedding should raise NotImplementedError when SUPPORTS_EMBEDDING is False."""
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+
+    provider = SambanovaProvider(api_key="test-key")
+    provider.SUPPORTS_EMBEDDING = False
+
+    with pytest.raises(NotImplementedError, match="does not support embeddings"):
+        await provider._aembedding("test-model", "Hello world")
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_sambanova_embedding_without_dimensions(mock_openai_class: MagicMock) -> None:
+    """When dimensions is not passed, the body should not include it."""
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.post = AsyncMock(return_value=_make_embedding_response())
+
+    provider = SambanovaProvider(api_key="test-key")
+    await provider._aembedding("test-model", "Hello world")
+
+    body = mock_client.post.call_args.kwargs["body"]
+    assert "dimensions" not in body
+    assert body["input"] == "Hello world"
+    assert body["model"] == "test-model"

--- a/tests/unit/providers/test_sambanova_provider.py
+++ b/tests/unit/providers/test_sambanova_provider.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types import CreateEmbeddingResponse, Embedding
+from openai.types.create_embedding_response import Usage
 from pydantic import BaseModel
 
 from any_llm.providers.sambanova.sambanova import SambanovaProvider
@@ -136,3 +138,67 @@ async def test_sambanova_without_response_format(mock_openai_class: MagicMock) -
 
     # Verify the create method was called
     mock_client.chat.completions.create.assert_called_once()
+
+
+def _make_embedding_response() -> CreateEmbeddingResponse:
+    return CreateEmbeddingResponse(
+        data=[Embedding(embedding=[0.1, 0.2, 0.3], index=0, object="embedding")],
+        model="test-model",
+        object="list",
+        usage=Usage(prompt_tokens=5, total_tokens=5),
+    )
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_sambanova_embedding_omits_encoding_format(mock_openai_class: MagicMock) -> None:
+    """SambaNova does not support the encoding_format parameter.
+
+    The override should call client.post() directly instead of
+    client.embeddings.create() so the SDK does not inject encoding_format.
+    """
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.post = AsyncMock(return_value=_make_embedding_response())
+
+    provider = SambanovaProvider(api_key="test-key")
+    result = await provider._aembedding("test-model", "Hello world")
+
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    body = call_kwargs.kwargs["body"]
+    assert "encoding_format" not in body
+    assert body["input"] == "Hello world"
+    assert body["model"] == "test-model"
+    assert isinstance(result, CreateEmbeddingResponse)
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_sambanova_embedding_passes_dimensions(mock_openai_class: MagicMock) -> None:
+    """The dimensions kwarg should be forwarded in the request body."""
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.post = AsyncMock(return_value=_make_embedding_response())
+
+    provider = SambanovaProvider(api_key="test-key")
+    await provider._aembedding("test-model", "Hello world", dimensions=512)
+
+    body = mock_client.post.call_args.kwargs["body"]
+    assert body["dimensions"] == 512
+    assert "encoding_format" not in body
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_sambanova_embedding_with_list_input(mock_openai_class: MagicMock) -> None:
+    """A list of strings should be forwarded as the input value."""
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.post = AsyncMock(return_value=_make_embedding_response())
+
+    provider = SambanovaProvider(api_key="test-key")
+    await provider._aembedding("test-model", ["Hello", "world"])
+
+    body = mock_client.post.call_args.kwargs["body"]
+    assert body["input"] == ["Hello", "world"]


### PR DESCRIPTION
## Description

Fix two integration test failures on main caused by different root issues:

**1. Gateway provider: OpenAI SDK >= 2.34.0 credential validation**

The OpenAI SDK 2.34.0 started rejecting empty strings and `None` as `api_key` in the `AsyncOpenAI` constructor. The gateway provider was missed in the earlier fix (e97d26d) that addressed this for llamacpp, llamafile, lmstudio, and vllm. All 19 `gateway` tests in `run-local-integration-tests` were failing with:

```
openai.OpenAIError: Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.
```

The fix:
- `_verify_and_set_api_key` now returns `"no-key-required"` instead of `""` when no key is available, matching the pattern used by the other local providers
- `__init__` separates the real key (used for the `AnyLLM-Key` auth header) from the placeholder passed to the SDK, so the header is only set when a real key exists

**2. SambaNova embedding: `encoding_format` parameter rejection**

The OpenAI SDK injects `encoding_format` into every `embeddings.create()` call automatically (defaulting to `"base64"`). SambaNova's API does not support this parameter and returns:

```
openai.BadRequestError: Error code: 400 - Unknown parameter: 'encoding_format'
```

The fix overrides `_aembedding` to call `client.post()` directly, sending only the parameters SambaNova accepts (`input`, `model`, `dimensions`).

## PR Type

- Bug Fix

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4
- AI Developer Tool used: OpenCode
- Any other info you would like to share: Used CQ knowledge commons to identify the OpenAI SDK 2.34.0 breaking change pattern

- [x] I am an AI Agent filling out this form (check box if true)