### PR TITLE
feat(cohere): support embeddings and image inputs

### DIFF
--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -103,7 +103,8 @@ class CohereProvider(AnyLLM):
     @override
     def _convert_embedding_response(response: Any) -> CreateEmbeddingResponse:
         """Convert Cohere EmbedByTypeResponse to OpenAI CreateEmbeddingResponse."""
-        return _convert_cohere_embedding_response(response)
+        model = response.get("model", "cohere")
+        return _convert_cohere_embedding_response(model, response["result"])
 
     @override
     async def _aembedding(
@@ -113,8 +114,9 @@ class CohereProvider(AnyLLM):
         **kwargs: Any,
     ) -> CreateEmbeddingResponse:
         embedding_kwargs = self._convert_embedding_params(inputs, **kwargs)
-        response = await self.client.embed(model=model, **embedding_kwargs)
-        return self._convert_embedding_response(response)
+        result = await self.client.embed(model=model, **embedding_kwargs)
+        response_data = {"model": model, "result": result}
+        return self._convert_embedding_response(response_data)
 
     @staticmethod
     @override

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -14,6 +14,7 @@ try:
     from cohere import V2ChatResponse
 
     from .utils import (
+        _convert_cohere_embedding_response,
         _convert_cohere_rerank_response,
         _convert_models_list,
         _convert_response,
@@ -43,9 +44,9 @@ class CohereProvider(AnyLLM):
     SUPPORTS_COMPLETION = True
     SUPPORTS_RESPONSES = False
     SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_COMPLETION_IMAGE = False
+    SUPPORTS_COMPLETION_IMAGE = True
     SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_EMBEDDING = False
+    SUPPORTS_EMBEDDING = True
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = False
     SUPPORTS_RERANK = True
@@ -84,16 +85,36 @@ class CohereProvider(AnyLLM):
     @staticmethod
     @override
     def _convert_embedding_params(params: Any, **kwargs: Any) -> dict[str, Any]:
-        """Convert embedding parameters for Cohere."""
-        msg = "Cohere does not support embeddings"
-        raise NotImplementedError(msg)
+        """Convert embedding parameters for Cohere.
+
+        Cohere requires ``input_type`` (one of ``search_document``,
+        ``search_query``, ``classification``, ``clustering``, ``image``).
+        Callers may pass it via **kwargs; the default is ``search_document``.
+        """
+        if isinstance(params, str):
+            params = [params]
+        converted: dict[str, Any] = {"texts": params}
+        converted["input_type"] = kwargs.pop("input_type", "search_document")
+        converted["embedding_types"] = kwargs.pop("embedding_types", ["float"])
+        converted.update(kwargs)
+        return converted
 
     @staticmethod
     @override
     def _convert_embedding_response(response: Any) -> CreateEmbeddingResponse:
-        """Convert Cohere embedding response to OpenAI format."""
-        msg = "Cohere does not support embeddings"
-        raise NotImplementedError(msg)
+        """Convert Cohere EmbedByTypeResponse to OpenAI CreateEmbeddingResponse."""
+        return _convert_cohere_embedding_response(response)
+
+    @override
+    async def _aembedding(
+        self,
+        model: str,
+        inputs: str | list[str],
+        **kwargs: Any,
+    ) -> CreateEmbeddingResponse:
+        embedding_kwargs = self._convert_embedding_params(inputs, **kwargs)
+        response = await self.client.embed(model=model, **embedding_kwargs)
+        return self._convert_embedding_response(response)
 
     @staticmethod
     @override

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -266,10 +266,21 @@ def _convert_cohere_rerank_response(response: Any) -> RerankResponse:
     )
 
 
-def _convert_cohere_embedding_response(response: Any) -> CreateEmbeddingResponse:
+_EMBEDDING_TYPE_FIELDS = ("float_", "int8", "uint8", "binary", "ubinary")
+
+
+def _extract_vectors(embeddings_data: Any) -> list[list[float]]:
+    """Return the first non-empty embedding vectors from a Cohere EmbedByTypeResponseEmbeddings."""
+    for field in _EMBEDDING_TYPE_FIELDS:
+        vectors = getattr(embeddings_data, field, None)
+        if vectors:
+            return [[float(v) for v in vec] for vec in vectors]
+    return []
+
+
+def _convert_cohere_embedding_response(model: str, response: Any) -> CreateEmbeddingResponse:
     """Convert a Cohere EmbedByTypeResponse to an OpenAI CreateEmbeddingResponse."""
-    embeddings_data = response.embeddings
-    vectors: list[list[float]] = getattr(embeddings_data, "float_", None) or []
+    vectors = _extract_vectors(response.embeddings)
 
     openai_embeddings = [Embedding(embedding=vector, index=i, object="embedding") for i, vector in enumerate(vectors)]
 
@@ -281,7 +292,7 @@ def _convert_cohere_embedding_response(response: Any) -> CreateEmbeddingResponse
 
     return CreateEmbeddingResponse(
         data=openai_embeddings,
-        model=response.id or "cohere",
+        model=model,
         object="list",
         usage=Usage(prompt_tokens=prompt_tokens, total_tokens=total_tokens),
     )

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -11,8 +11,11 @@ from any_llm.types.completion import (
     ChatCompletionMessageFunctionToolCall,
     Choice,
     CompletionUsage,
+    CreateEmbeddingResponse,
+    Embedding,
     Function,
     Reasoning,
+    Usage,
 )
 from any_llm.types.model import Model
 from any_llm.types.rerank import RerankMeta, RerankResponse, RerankResult, RerankUsage
@@ -260,6 +263,27 @@ def _convert_cohere_rerank_response(response: Any) -> RerankResponse:
         results=results,
         meta=meta,
         usage=usage,
+    )
+
+
+def _convert_cohere_embedding_response(response: Any) -> CreateEmbeddingResponse:
+    """Convert a Cohere EmbedByTypeResponse to an OpenAI CreateEmbeddingResponse."""
+    embeddings_data = response.embeddings
+    vectors: list[list[float]] = getattr(embeddings_data, "float_", None) or []
+
+    openai_embeddings = [Embedding(embedding=vector, index=i, object="embedding") for i, vector in enumerate(vectors)]
+
+    prompt_tokens = 0
+    total_tokens = 0
+    if response.meta and response.meta.tokens:
+        prompt_tokens = int(response.meta.tokens.input_tokens or 0)
+        total_tokens = prompt_tokens
+
+    return CreateEmbeddingResponse(
+        data=openai_embeddings,
+        model=response.id or "cohere",
+        object="list",
+        usage=Usage(prompt_tokens=prompt_tokens, total_tokens=total_tokens),
     )
 
 

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -266,17 +266,15 @@ def _convert_cohere_rerank_response(response: Any) -> RerankResponse:
     )
 
 
-_NUMERIC_EMBEDDING_FIELDS = ("float_", "int8", "uint8")
+_EMBEDDING_TYPE_FIELDS = ("float_", "int8", "uint8", "binary", "ubinary")
 
 
 def _extract_vectors(embeddings_data: Any) -> list[list[float]]:
-    """Return the first non-empty numeric embedding vectors from a Cohere EmbedByTypeResponseEmbeddings.
+    """Return the first non-empty embedding vectors from a Cohere EmbedByTypeResponseEmbeddings.
 
-    Only ``float_``, ``int8``, and ``uint8`` are considered. The ``binary``
-    and ``ubinary`` fields are packed bit arrays and cannot be meaningfully
-    converted to float vectors.
+    Integer-typed fields (int8, uint8, binary, ubinary) are cast to float.
     """
-    for field in _NUMERIC_EMBEDDING_FIELDS:
+    for field in _EMBEDDING_TYPE_FIELDS:
         vectors = getattr(embeddings_data, field, None)
         if vectors:
             return [[float(v) for v in vec] for vec in vectors]

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -266,12 +266,17 @@ def _convert_cohere_rerank_response(response: Any) -> RerankResponse:
     )
 
 
-_EMBEDDING_TYPE_FIELDS = ("float_", "int8", "uint8", "binary", "ubinary")
+_NUMERIC_EMBEDDING_FIELDS = ("float_", "int8", "uint8")
 
 
 def _extract_vectors(embeddings_data: Any) -> list[list[float]]:
-    """Return the first non-empty embedding vectors from a Cohere EmbedByTypeResponseEmbeddings."""
-    for field in _EMBEDDING_TYPE_FIELDS:
+    """Return the first non-empty numeric embedding vectors from a Cohere EmbedByTypeResponseEmbeddings.
+
+    Only ``float_``, ``int8``, and ``uint8`` are considered. The ``binary``
+    and ``ubinary`` fields are packed bit arrays and cannot be meaningfully
+    converted to float vectors.
+    """
+    for field in _NUMERIC_EMBEDDING_FIELDS:
         vectors = getattr(embeddings_data, field, None)
         if vectors:
             return [[float(v) for v in vec] for vec in vectors]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ def embedding_provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.SAMBANOVA: "Meta-Llama-3.1-8B-Instruct",
         LLMProvider.MISTRAL: "mistral-embed",
         LLMProvider.BEDROCK: "amazon.titan-embed-text-v2:0",
+        LLMProvider.COHERE: "embed-v4.0",
         LLMProvider.SAGEMAKER: "<sagemaker_endpoint_name>",
         LLMProvider.OLLAMA: "gpt-oss:20b",
         LLMProvider.LLAMAFILE: "N/A",

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -6,11 +6,12 @@ from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.cohere.utils import (
+    _convert_cohere_embedding_response,
     _convert_response,
     _create_openai_chunk_from_cohere_chunk,
     _patch_messages,
 )
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import CompletionParams, CreateEmbeddingResponse
 
 
 def _mk_provider() -> Any:
@@ -346,3 +347,287 @@ def test_streaming_tool_call_index_defaults_to_zero_when_none() -> None:
     result = _create_openai_chunk_from_cohere_chunk(chunk)
 
     assert result.choices[0].delta.tool_calls[0].index == 0  # type: ignore[index]
+
+
+def _mock_embed_by_type_response(
+    vectors: list[list[float]],
+    input_tokens: int = 10,
+    response_id: str = "emb-123",
+) -> Mock:
+    """Create a mock Cohere EmbedByTypeResponse."""
+    response = Mock()
+    response.id = response_id
+    response.embeddings = Mock()
+    response.embeddings.float_ = vectors
+    response.meta = Mock()
+    response.meta.tokens = Mock()
+    response.meta.tokens.input_tokens = input_tokens
+    return response
+
+
+def test_convert_cohere_embedding_response_single_vector() -> None:
+    vectors = [[0.1, 0.2, 0.3]]
+    mock_response = _mock_embed_by_type_response(vectors, input_tokens=5)
+
+    result = _convert_cohere_embedding_response(mock_response)
+
+    assert isinstance(result, CreateEmbeddingResponse)
+    assert len(result.data) == 1
+    assert result.data[0].embedding == [0.1, 0.2, 0.3]
+    assert result.data[0].index == 0
+    assert result.data[0].object == "embedding"
+    assert result.usage.prompt_tokens == 5
+    assert result.usage.total_tokens == 5
+    assert result.object == "list"
+
+
+def test_convert_cohere_embedding_response_multiple_vectors() -> None:
+    vectors = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+    mock_response = _mock_embed_by_type_response(vectors, input_tokens=15)
+
+    result = _convert_cohere_embedding_response(mock_response)
+
+    assert len(result.data) == 3
+    for i, embedding in enumerate(result.data):
+        assert embedding.index == i
+        assert embedding.embedding == vectors[i]
+    assert result.usage.prompt_tokens == 15
+
+
+def test_convert_cohere_embedding_response_no_meta() -> None:
+    vectors = [[0.1, 0.2]]
+    mock_response = _mock_embed_by_type_response(vectors)
+    mock_response.meta = None
+
+    result = _convert_cohere_embedding_response(mock_response)
+
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.total_tokens == 0
+    assert len(result.data) == 1
+
+
+def test_convert_cohere_embedding_response_empty_vectors() -> None:
+    mock_response = _mock_embed_by_type_response(vectors=[])
+
+    result = _convert_cohere_embedding_response(mock_response)
+
+    assert len(result.data) == 0
+    assert result.object == "list"
+
+
+def test_convert_embedding_params_single_string() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    result = CohereProvider._convert_embedding_params("hello world")
+
+    assert result["texts"] == ["hello world"]
+    assert result["input_type"] == "search_document"
+    assert result["embedding_types"] == ["float"]
+
+
+def test_convert_embedding_params_list_of_strings() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    result = CohereProvider._convert_embedding_params(["hello", "world"])
+
+    assert result["texts"] == ["hello", "world"]
+    assert result["input_type"] == "search_document"
+
+
+def test_convert_embedding_params_custom_input_type() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    result = CohereProvider._convert_embedding_params("query text", input_type="search_query")
+
+    assert result["texts"] == ["query text"]
+    assert result["input_type"] == "search_query"
+
+
+def test_convert_embedding_params_custom_embedding_types() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    result = CohereProvider._convert_embedding_params("text", embedding_types=["float", "int8"])
+
+    assert result["embedding_types"] == ["float", "int8"]
+
+
+def test_convert_embedding_params_extra_kwargs() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    result = CohereProvider._convert_embedding_params("text", truncate="END")
+
+    assert result["truncate"] == "END"
+    assert result["texts"] == ["text"]
+
+
+@pytest.mark.asyncio
+async def test_aembedding_calls_client() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    mock_response = _mock_embed_by_type_response([[0.1, 0.2, 0.3]])
+
+    with patch("any_llm.providers.cohere.cohere.cohere") as mock_cohere:
+        mock_client = Mock()
+        mock_cohere.AsyncClientV2.return_value = mock_client
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        provider = CohereProvider(api_key="test-key")
+        result = await provider._aembedding("embed-v4.0", "hello world")
+
+        assert isinstance(result, CreateEmbeddingResponse)
+        assert len(result.data) == 1
+        mock_client.embed.assert_called_once()
+        call_kwargs = mock_client.embed.call_args[1]
+        assert call_kwargs["model"] == "embed-v4.0"
+        assert call_kwargs["texts"] == ["hello world"]
+        assert call_kwargs["input_type"] == "search_document"
+
+
+@pytest.mark.asyncio
+async def test_aembedding_passes_custom_input_type() -> None:
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    mock_response = _mock_embed_by_type_response([[0.1, 0.2]])
+
+    with patch("any_llm.providers.cohere.cohere.cohere") as mock_cohere:
+        mock_client = Mock()
+        mock_cohere.AsyncClientV2.return_value = mock_client
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        provider = CohereProvider(api_key="test-key")
+        await provider._aembedding("embed-v4.0", ["query"], input_type="search_query")
+
+        call_kwargs = mock_client.embed.call_args[1]
+        assert call_kwargs["input_type"] == "search_query"
+        assert call_kwargs["texts"] == ["query"]
+
+
+def test_patch_messages_preserves_multimodal_user_content() -> None:
+    """Verify _patch_messages passes through user messages with image content blocks."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+            ],
+        },
+    ]
+
+    result = _patch_messages(messages)
+
+    assert len(result) == 1
+    assert result[0]["role"] == "user"
+    assert isinstance(result[0]["content"], list)
+    assert len(result[0]["content"]) == 2
+    assert result[0]["content"][0] == {"type": "text", "text": "What is in this image?"}
+    assert result[0]["content"][1] == {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+
+
+def test_patch_messages_preserves_base64_image_content() -> None:
+    """Verify _patch_messages preserves data URI image content blocks."""
+    data_uri = "data:image/png;base64,iVBORw0KGgoAAAANS"
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this."},
+                {"type": "image_url", "image_url": {"url": data_uri}},
+            ],
+        },
+    ]
+
+    result = _patch_messages(messages)
+
+    assert result[0]["content"][1]["image_url"]["url"] == data_uri
+
+
+def test_patch_messages_multimodal_with_tool_calls() -> None:
+    """Image content in earlier user messages is preserved alongside tool call flows."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "Let me look that up.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "analyze_image"}}],
+        },
+        {"role": "tool", "name": "analyze_image", "content": "A cat", "tool_call_id": "call_1"},
+        {"role": "assistant", "content": "It's a cat."},
+    ]
+
+    result = _patch_messages(messages)
+
+    assert isinstance(result[0]["content"], list)
+    assert len(result[0]["content"]) == 2
+
+    assistant_with_tools = result[1]
+    assert "content" not in assistant_with_tools
+    assert assistant_with_tools["tool_plan"] == "Let me look that up."
+
+    tool_msg = result[2]
+    assert "name" not in tool_msg
+
+
+@pytest.mark.asyncio
+async def test_completion_with_image_content() -> None:
+    """End-to-end: image content blocks are forwarded to the Cohere chat API."""
+    pytest.importorskip("cohere")
+    from any_llm.providers.cohere.cohere import CohereProvider
+
+    mock_response = Mock()
+    mock_response.id = "resp-img"
+    mock_response.created = 0
+    mock_response.finish_reason = "COMPLETE"
+    mock_response.message = Mock()
+    mock_response.message.tool_calls = None
+    mock_response.message.tool_plan = None
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = "A landscape photo."
+    mock_response.message.content = [text_block]
+    mock_response.usage = Mock()
+    mock_response.usage.tokens = Mock()
+    mock_response.usage.tokens.input_tokens = 50
+    mock_response.usage.tokens.output_tokens = 10
+
+    with patch("any_llm.providers.cohere.cohere.cohere") as mock_cohere:
+        mock_client = Mock()
+        mock_cohere.AsyncClientV2.return_value = mock_client
+        mock_client.chat = AsyncMock(return_value=mock_response)
+
+        provider = CohereProvider(api_key="test-key")
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="command-a-03-2025",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What is in this image?"},
+                            {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}},
+                        ],
+                    }
+                ],
+            ),
+        )
+
+        assert result.choices[0].message.content == "A landscape photo."  # type: ignore[union-attr]
+
+        call_kwargs = mock_client.chat.call_args
+        sent_messages = call_kwargs[1]["messages"]
+        user_msg = sent_messages[0]
+        assert isinstance(user_msg["content"], list)
+        assert user_msg["content"][1]["type"] == "image_url"

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -363,8 +363,6 @@ def _mock_embed_by_type_response(
     response.embeddings.float_ = vectors
     response.embeddings.int8 = int8_vectors
     response.embeddings.uint8 = None
-    response.embeddings.binary = None
-    response.embeddings.ubinary = None
     response.meta = Mock()
     response.meta.tokens = Mock()
     response.meta.tokens.input_tokens = input_tokens

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -363,6 +363,8 @@ def _mock_embed_by_type_response(
     response.embeddings.float_ = vectors
     response.embeddings.int8 = int8_vectors
     response.embeddings.uint8 = None
+    response.embeddings.binary = None
+    response.embeddings.ubinary = None
     response.meta = Mock()
     response.meta.tokens = Mock()
     response.meta.tokens.input_tokens = input_tokens

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -350,15 +350,21 @@ def test_streaming_tool_call_index_defaults_to_zero_when_none() -> None:
 
 
 def _mock_embed_by_type_response(
-    vectors: list[list[float]],
+    vectors: list[list[float]] | None = None,
+    *,
+    int8_vectors: list[list[int]] | None = None,
     input_tokens: int = 10,
     response_id: str = "emb-123",
 ) -> Mock:
     """Create a mock Cohere EmbedByTypeResponse."""
     response = Mock()
     response.id = response_id
-    response.embeddings = Mock()
+    response.embeddings = Mock(spec=[])
     response.embeddings.float_ = vectors
+    response.embeddings.int8 = int8_vectors
+    response.embeddings.uint8 = None
+    response.embeddings.binary = None
+    response.embeddings.ubinary = None
     response.meta = Mock()
     response.meta.tokens = Mock()
     response.meta.tokens.input_tokens = input_tokens
@@ -369,9 +375,10 @@ def test_convert_cohere_embedding_response_single_vector() -> None:
     vectors = [[0.1, 0.2, 0.3]]
     mock_response = _mock_embed_by_type_response(vectors, input_tokens=5)
 
-    result = _convert_cohere_embedding_response(mock_response)
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
 
     assert isinstance(result, CreateEmbeddingResponse)
+    assert result.model == "embed-v4.0"
     assert len(result.data) == 1
     assert result.data[0].embedding == [0.1, 0.2, 0.3]
     assert result.data[0].index == 0
@@ -385,8 +392,9 @@ def test_convert_cohere_embedding_response_multiple_vectors() -> None:
     vectors = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
     mock_response = _mock_embed_by_type_response(vectors, input_tokens=15)
 
-    result = _convert_cohere_embedding_response(mock_response)
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
 
+    assert result.model == "embed-v4.0"
     assert len(result.data) == 3
     for i, embedding in enumerate(result.data):
         assert embedding.index == i
@@ -399,8 +407,9 @@ def test_convert_cohere_embedding_response_no_meta() -> None:
     mock_response = _mock_embed_by_type_response(vectors)
     mock_response.meta = None
 
-    result = _convert_cohere_embedding_response(mock_response)
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
 
+    assert result.model == "embed-v4.0"
     assert result.usage.prompt_tokens == 0
     assert result.usage.total_tokens == 0
     assert len(result.data) == 1
@@ -409,10 +418,21 @@ def test_convert_cohere_embedding_response_no_meta() -> None:
 def test_convert_cohere_embedding_response_empty_vectors() -> None:
     mock_response = _mock_embed_by_type_response(vectors=[])
 
-    result = _convert_cohere_embedding_response(mock_response)
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
 
     assert len(result.data) == 0
     assert result.object == "list"
+
+
+def test_convert_cohere_embedding_response_falls_back_to_int8() -> None:
+    """When float_ is empty but int8 has data, int8 vectors are returned as floats."""
+    mock_response = _mock_embed_by_type_response(vectors=None, int8_vectors=[[1, 2, 3], [4, 5, 6]])
+
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
+
+    assert len(result.data) == 2
+    assert result.data[0].embedding == [1.0, 2.0, 3.0]
+    assert result.data[1].embedding == [4.0, 5.0, 6.0]
 
 
 def test_convert_embedding_params_single_string() -> None:
@@ -481,6 +501,7 @@ async def test_aembedding_calls_client() -> None:
         result = await provider._aembedding("embed-v4.0", "hello world")
 
         assert isinstance(result, CreateEmbeddingResponse)
+        assert result.model == "embed-v4.0"
         assert len(result.data) == 1
         mock_client.embed.assert_called_once()
         call_kwargs = mock_client.embed.call_args[1]


### PR DESCRIPTION
## Description

Add embeddings and image input support to the Cohere provider.

**Embeddings (#519):**
- Enable `SUPPORTS_EMBEDDING = True`
- Implement `_convert_embedding_params`, `_convert_embedding_response`, and `_aembedding` using Cohere's `AsyncClientV2.embed()` API
- Add `_convert_cohere_embedding_response` utility to convert Cohere's `EmbedByTypeResponse` (grouped by type: float, int8, etc.) to OpenAI `CreateEmbeddingResponse` format
- Default `input_type` to `search_document` (Cohere requires this parameter); callers can override via `**kwargs`
- Default `embedding_types` to `["float"]`; callers can override for other types
- Add Cohere to `embedding_provider_model_map` with `embed-v4.0`

**Image inputs (#520):**
- Enable `SUPPORTS_COMPLETION_IMAGE = True`
- Cohere's chat API natively accepts OpenAI-compatible `image_url` content blocks, so no conversion is needed
- Verified that `_patch_messages` correctly preserves multimodal (list-type) content in user messages

## PR Type

- :new: New Feature

## Relevant issues

Fixes #519
Fixes #520

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Implementation follows existing provider patterns (Mistral, Voyage) for embeddings and existing multimodal patterns (Anthropic, Gemini) for image inputs.

- [x] I am an AI Agent filling out this form (check box if true)