### PR TITLE
docs: redirect GitHub Pages docs to docs.mozilla.ai

### DIFF
--- a/.github/workflows/pages-redirect.yaml
+++ b/.github/workflows/pages-redirect.yaml
@@ -1,0 +1,85 @@
+name: GitHub Pages Redirects
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'scripts/generate_provider_table.py'
+      - 'scripts/generate_openapi.py'
+      - 'scripts/generate_api_docs.py'
+      - 'scripts/generate_cookbooks.py'
+      - 'scripts/convert_to_gitbook.py'
+      - 'scripts/generate_github_pages_redirects.py'
+      - '.github/workflows/pages-redirect.yaml'
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'scripts/generate_provider_table.py'
+      - 'scripts/generate_openapi.py'
+      - 'scripts/generate_api_docs.py'
+      - 'scripts/generate_cookbooks.py'
+      - 'scripts/convert_to_gitbook.py'
+      - 'scripts/generate_github_pages_redirects.py'
+      - '.github/workflows/pages-redirect.yaml'
+      - 'pyproject.toml'
+  workflow_dispatch:
+
+jobs:
+  redirect-site:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install the latest version of uv and set the python version to 3.13
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: 3.13
+          activate-environment: true
+
+      - name: Install Python dependencies
+        run: uv sync --group docs --extra all
+
+      - name: Build GitBook site
+        run: uv run python scripts/convert_to_gitbook.py
+
+      - name: Build GitHub Pages redirects
+        run: uv run python scripts/generate_github_pages_redirects.py
+
+      - name: Upload generated redirect site as PR artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages-redirect-preview
+          path: gh-pages-redirect/
+
+      - name: Deploy to gh-pages branch
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          mv gh-pages-redirect/ /tmp/gh-pages-redirect/
+
+          git fetch origin gh-pages || true
+          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf .
+          fi
+
+          rsync -a --delete --exclude='.git' /tmp/gh-pages-redirect/ .
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "docs: update GitHub Pages redirects from ${{ github.sha }}"
+            git push origin gh-pages
+          fi

--- a/scripts/generate_github_pages_redirects.py
+++ b/scripts/generate_github_pages_redirects.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Build a redirect-only GitHub Pages site for legacy any-llm docs URLs.
+
+Usage:
+    python scripts/generate_github_pages_redirects.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+DEFAULT_SOURCE_DIR = Path("site")
+DEFAULT_OUTPUT_DIR = Path("gh-pages-redirect")
+DEFAULT_BASE_URL = "https://docs.mozilla.ai/any-llm/"
+DEFAULT_PAGES_BASE_PATH = "/any-llm"
+PASSTHROUGH_FILES = ("openapi.json", "llms.txt", "llms-full.txt")
+PASSTHROUGH_DIRS = ("images",)
+
+
+def normalize_base_url(base_url: str) -> str:
+    """Return the destination docs URL with a single trailing slash."""
+    return base_url.rstrip("/") + "/"
+
+
+def normalize_pages_base_path(pages_base_path: str) -> str:
+    """Return the GitHub Pages project prefix with a leading slash."""
+    stripped = pages_base_path.strip("/")
+    return f"/{stripped}" if stripped else "/"
+
+
+def route_for_markdown_file(relative_path: Path) -> str:
+    """Convert a markdown file path into a route path."""
+    route_parts = list(relative_path.with_suffix("").parts)
+    if route_parts and route_parts[-1] == "index":
+        route_parts = route_parts[:-1]
+    return "/".join(route_parts)
+
+
+def legacy_route_aliases(route: str) -> set[str]:
+    """Return route aliases for legacy slug variants."""
+    if not route:
+        return set()
+
+    route_parts = route.split("/")
+    last_segment = route_parts[-1]
+    aliases = set()
+
+    for alias_segment in {
+        last_segment.replace("-", "_"),
+        last_segment.replace("_", "-"),
+    }:
+        if alias_segment and alias_segment != last_segment:
+            aliases.add("/".join([*route_parts[:-1], alias_segment]))
+
+    return aliases
+
+
+def collect_redirect_targets(source_dir: Path) -> dict[str, str]:
+    """Collect route-to-target mappings for markdown-backed pages."""
+    routes: dict[str, str] = {}
+
+    for markdown_file in source_dir.rglob("*.md"):
+        relative_path = markdown_file.relative_to(source_dir)
+        if relative_path.name == "SUMMARY.md":
+            continue
+
+        canonical_route = route_for_markdown_file(relative_path)
+        routes[canonical_route] = canonical_route
+
+        for alias_route in legacy_route_aliases(canonical_route):
+            routes[alias_route] = canonical_route
+
+    return routes
+
+
+def build_target_url(base_url: str, route: str) -> str:
+    """Build the redirect destination for a route."""
+    if not route:
+        return base_url
+
+    normalized_route = quote(route.strip("/"), safe="/")
+    return f"{base_url}{normalized_route}/"
+
+
+def redirect_page_html(target_url: str) -> str:
+    """Build a simple HTML redirect page."""
+    escaped_target_url = html.escape(target_url, quote=True)
+    serialized_target_url = json.dumps(target_url)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta name="robots" content="noindex">
+    <link rel="canonical" href="{escaped_target_url}">
+    <meta http-equiv="refresh" content="0; url={escaped_target_url}">
+    <script>
+      const target = new URL({serialized_target_url});
+      target.search = window.location.search;
+      target.hash = window.location.hash;
+      window.location.replace(target.toString());
+    </script>
+  </head>
+  <body>
+    <p>This documentation moved to <a href="{escaped_target_url}">{escaped_target_url}</a>.</p>
+  </body>
+</html>
+"""
+
+
+def not_found_page_html(base_url: str, pages_base_path: str) -> str:
+    """Build a smart 404 page that preserves deep links."""
+    escaped_base_url = html.escape(base_url, quote=True)
+    serialized_base_url = json.dumps(base_url)
+    serialized_pages_base_path = json.dumps(pages_base_path)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={escaped_base_url}">
+    <script>
+      const docsBaseUrl = new URL({serialized_base_url});
+      const pagesBasePath = {serialized_pages_base_path};
+
+      function normalizeRelativePath(pathname) {{
+        let relativePath = pathname;
+
+        if (relativePath === pagesBasePath) {{
+          relativePath = "/";
+        }} else if (relativePath.startsWith(`${{pagesBasePath}}/`)) {{
+          relativePath = relativePath.slice(pagesBasePath.length);
+        }}
+
+        if (relativePath.endsWith("/index.html")) {{
+          relativePath = relativePath.slice(0, -"/index.html".length) || "/";
+        }} else if (relativePath.endsWith(".html")) {{
+          relativePath = `${{relativePath.slice(0, -".html".length)}}/`;
+        }}
+
+        if (!relativePath.startsWith("/")) {{
+          relativePath = `/${{relativePath}}`;
+        }}
+
+        if (relativePath !== "/" && !relativePath.endsWith("/") && !/\\.[^/]+$/.test(relativePath)) {{
+          relativePath = `${{relativePath}}/`;
+        }}
+
+        return relativePath;
+      }}
+
+      const relativePath = normalizeRelativePath(window.location.pathname);
+      const target = new URL(relativePath.replace(/^\\//, ""), docsBaseUrl);
+      target.search = window.location.search;
+      target.hash = window.location.hash;
+      window.location.replace(target.toString());
+    </script>
+  </head>
+  <body>
+    <p>This documentation moved to <a href="{escaped_base_url}">{escaped_base_url}</a>.</p>
+  </body>
+</html>
+"""
+
+
+def write_file(path: Path, content: str) -> None:
+    """Write a UTF-8 text file, creating parent directories when needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def copy_passthrough_assets(source_dir: Path, output_dir: Path) -> None:
+    """Copy machine-readable artifacts that should stay directly accessible."""
+    for file_name in PASSTHROUGH_FILES:
+        source_path = source_dir / file_name
+        if not source_path.exists():
+            continue
+
+        destination_path = output_dir / file_name
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination_path)
+
+    for directory_name in PASSTHROUGH_DIRS:
+        source_path = source_dir / directory_name
+        if not source_path.exists():
+            continue
+
+        shutil.copytree(source_path, output_dir / directory_name)
+
+
+def build_redirect_site(
+    source_dir: Path,
+    output_dir: Path,
+    base_url: str,
+    pages_base_path: str,
+) -> int:
+    """Build the redirect site and return the number of redirect pages."""
+    normalized_base_url = normalize_base_url(base_url)
+    normalized_pages_base_path = normalize_pages_base_path(pages_base_path)
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    redirect_targets = collect_redirect_targets(source_dir)
+    redirect_count = 0
+
+    for route, target_route in sorted(redirect_targets.items()):
+        redirect_html = redirect_page_html(build_target_url(normalized_base_url, target_route))
+
+        if route:
+            directory_redirect_path = output_dir / route / "index.html"
+            file_redirect_path = output_dir / Path(route).with_suffix(".html")
+            write_file(directory_redirect_path, redirect_html)
+            write_file(file_redirect_path, redirect_html)
+            redirect_count += 2
+        else:
+            write_file(output_dir / "index.html", redirect_html)
+            redirect_count += 1
+
+    write_file(output_dir / "404.html", not_found_page_html(normalized_base_url, normalized_pages_base_path))
+    write_file(output_dir / ".nojekyll", "")
+    copy_passthrough_assets(source_dir, output_dir)
+
+    return redirect_count
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=DEFAULT_SOURCE_DIR,
+        help=f"Markdown site input directory. Defaults to {DEFAULT_SOURCE_DIR}.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Redirect site output directory. Defaults to {DEFAULT_OUTPUT_DIR}.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"Destination docs base URL. Defaults to {DEFAULT_BASE_URL}.",
+    )
+    parser.add_argument(
+        "--pages-base-path",
+        default=DEFAULT_PAGES_BASE_PATH,
+        help=f"GitHub Pages project path prefix. Defaults to {DEFAULT_PAGES_BASE_PATH}.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Build the redirect site for legacy GitHub Pages routes."""
+    args = parse_args()
+
+    if not args.source_dir.exists():
+        print(f"Input directory does not exist: {args.source_dir}", file=sys.stderr)
+        return 1
+
+    redirect_count = build_redirect_site(
+        source_dir=args.source_dir,
+        output_dir=args.output_dir,
+        base_url=args.base_url,
+        pages_base_path=args.pages_base_path,
+    )
+    print(f"Done - {redirect_count} redirect pages written to {args.output_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_github_pages_redirects.py
+++ b/scripts/generate_github_pages_redirects.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Build a redirect-only GitHub Pages site for legacy any-llm docs URLs.
 
 Usage:

--- a/tests/unit/test_github_pages_redirects.py
+++ b/tests/unit/test_github_pages_redirects.py
@@ -1,15 +1,25 @@
-import subprocess
-import sys
+import importlib.util
 from pathlib import Path
-
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_github_pages_redirects.py"
 
 
+def _load_redirect_generator_module() -> Any:
+    spec = importlib.util.spec_from_file_location("generate_github_pages_redirects", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_generate_github_pages_redirects(tmp_path: Path) -> None:
     source_dir = tmp_path / "site"
     output_dir = tmp_path / "gh-pages-redirect"
+    redirect_generator = _load_redirect_generator_module()
 
     (source_dir / "api").mkdir(parents=True)
     (source_dir / "gateway").mkdir(parents=True)
@@ -24,19 +34,11 @@ def test_generate_github_pages_redirects(tmp_path: Path) -> None:
     (source_dir / "llms.txt").write_text("llms\n", encoding="utf-8")
     (source_dir / "images" / "logo.png").write_bytes(b"png")
 
-    subprocess.run(
-        [
-            sys.executable,
-            str(SCRIPT_PATH),
-            "--source-dir",
-            str(source_dir),
-            "--output-dir",
-            str(output_dir),
-        ],
-        check=True,
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
+    redirect_count = redirect_generator.build_redirect_site(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        base_url=redirect_generator.DEFAULT_BASE_URL,
+        pages_base_path=redirect_generator.DEFAULT_PAGES_BASE_PATH,
     )
 
     root_redirect = (output_dir / "index.html").read_text(encoding="utf-8")
@@ -44,9 +46,10 @@ def test_generate_github_pages_redirects(tmp_path: Path) -> None:
     alias_redirect = (output_dir / "api" / "any_llm" / "index.html").read_text(encoding="utf-8")
     not_found_redirect = (output_dir / "404.html").read_text(encoding="utf-8")
 
-    assert 'https://docs.mozilla.ai/any-llm/' in root_redirect
-    assert 'https://docs.mozilla.ai/any-llm/quickstart/' in quickstart_redirect
-    assert 'https://docs.mozilla.ai/any-llm/api/any-llm/' in alias_redirect
+    assert redirect_count > 0
+    assert "https://docs.mozilla.ai/any-llm/" in root_redirect
+    assert "https://docs.mozilla.ai/any-llm/quickstart/" in quickstart_redirect
+    assert "https://docs.mozilla.ai/any-llm/api/any-llm/" in alias_redirect
     assert (output_dir / "quickstart.html").exists()
     assert not (output_dir / "SUMMARY.html").exists()
     assert (output_dir / ".nojekyll").exists()

--- a/tests/unit/test_github_pages_redirects.py
+++ b/tests/unit/test_github_pages_redirects.py
@@ -1,6 +1,9 @@
 import importlib.util
+import runpy
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_github_pages_redirects.py"
@@ -16,23 +19,32 @@ def _load_redirect_generator_module() -> Any:
     return module
 
 
-def test_generate_github_pages_redirects(tmp_path: Path) -> None:
-    source_dir = tmp_path / "site"
-    output_dir = tmp_path / "gh-pages-redirect"
-    redirect_generator = _load_redirect_generator_module()
-
+def _write_sample_site(source_dir: Path, *, include_passthroughs: bool = True, include_images: bool = True) -> None:
     (source_dir / "api").mkdir(parents=True)
     (source_dir / "gateway").mkdir(parents=True)
-    (source_dir / "images").mkdir(parents=True)
+    if include_images:
+        (source_dir / "images").mkdir(parents=True)
 
     (source_dir / "index.md").write_text("# Home\n", encoding="utf-8")
     (source_dir / "quickstart.md").write_text("# Quickstart\n", encoding="utf-8")
     (source_dir / "api" / "any-llm.md").write_text("# AnyLLM\n", encoding="utf-8")
     (source_dir / "gateway" / "overview.md").write_text("# Overview\n", encoding="utf-8")
     (source_dir / "SUMMARY.md").write_text("# Summary\n", encoding="utf-8")
-    (source_dir / "openapi.json").write_text('{"openapi":"3.1.0"}\n', encoding="utf-8")
-    (source_dir / "llms.txt").write_text("llms\n", encoding="utf-8")
-    (source_dir / "images" / "logo.png").write_bytes(b"png")
+
+    if include_passthroughs:
+        (source_dir / "openapi.json").write_text('{"openapi":"3.1.0"}\n', encoding="utf-8")
+        (source_dir / "llms.txt").write_text("llms\n", encoding="utf-8")
+
+    if include_images:
+        (source_dir / "images" / "logo.png").write_bytes(b"png")
+
+
+def test_generate_github_pages_redirects(tmp_path: Path) -> None:
+    source_dir = tmp_path / "site"
+    output_dir = tmp_path / "gh-pages-redirect"
+    redirect_generator = _load_redirect_generator_module()
+
+    _write_sample_site(source_dir)
 
     redirect_count = redirect_generator.build_redirect_site(
         source_dir=source_dir,
@@ -58,3 +70,115 @@ def test_generate_github_pages_redirects(tmp_path: Path) -> None:
     assert (output_dir / "images" / "logo.png").read_bytes() == b"png"
     assert 'const pagesBasePath = "/any-llm";' in not_found_redirect
     assert 'const docsBaseUrl = new URL("https://docs.mozilla.ai/any-llm/");' in not_found_redirect
+
+
+def test_build_redirect_site_replaces_existing_output_and_skips_missing_passthroughs(tmp_path: Path) -> None:
+    source_dir = tmp_path / "site"
+    output_dir = tmp_path / "gh-pages-redirect"
+    redirect_generator = _load_redirect_generator_module()
+
+    _write_sample_site(source_dir, include_passthroughs=False, include_images=False)
+    output_dir.mkdir(parents=True)
+    (output_dir / "stale.txt").write_text("old\n", encoding="utf-8")
+
+    redirect_count = redirect_generator.build_redirect_site(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        base_url="https://docs.mozilla.ai/any-llm",
+        pages_base_path="any-llm",
+    )
+
+    assert redirect_count > 0
+    assert not (output_dir / "stale.txt").exists()
+    assert (output_dir / "index.html").exists()
+    assert not (output_dir / "openapi.json").exists()
+    assert not (output_dir / "llms.txt").exists()
+    assert not (output_dir / "images").exists()
+
+
+def test_parse_args_and_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    source_dir = tmp_path / "site"
+    output_dir = tmp_path / "custom-output"
+    redirect_generator = _load_redirect_generator_module()
+
+    _write_sample_site(source_dir, include_images=False)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "generate_github_pages_redirects.py",
+            "--source-dir",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--base-url",
+            "https://docs.mozilla.ai/any-llm",
+            "--pages-base-path",
+            "any-llm",
+        ],
+    )
+
+    args = redirect_generator.parse_args()
+
+    assert args.source_dir == source_dir
+    assert args.output_dir == output_dir
+    assert args.base_url == "https://docs.mozilla.ai/any-llm"
+    assert args.pages_base_path == "any-llm"
+
+    exit_code = redirect_generator.main()
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Done - " in stdout
+    assert (output_dir / "404.html").exists()
+
+
+def test_main_returns_error_for_missing_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_source = tmp_path / "missing-site"
+    output_dir = tmp_path / "gh-pages-redirect"
+    redirect_generator = _load_redirect_generator_module()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "generate_github_pages_redirects.py",
+            "--source-dir",
+            str(missing_source),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    exit_code = redirect_generator.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert f"Input directory does not exist: {missing_source}" in captured.err
+
+
+def test_script_entrypoint_exits_with_main_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source_dir = tmp_path / "site"
+    output_dir = tmp_path / "entrypoint-output"
+
+    _write_sample_site(source_dir, include_images=False)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(SCRIPT_PATH),
+            "--source-dir",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(SCRIPT_PATH), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    assert (output_dir / "index.html").exists()

--- a/tests/unit/test_github_pages_redirects.py
+++ b/tests/unit/test_github_pages_redirects.py
@@ -96,7 +96,9 @@ def test_build_redirect_site_replaces_existing_output_and_skips_missing_passthro
     assert not (output_dir / "images").exists()
 
 
-def test_parse_args_and_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_args_and_main_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     source_dir = tmp_path / "site"
     output_dir = tmp_path / "custom-output"
     redirect_generator = _load_redirect_generator_module()

--- a/tests/unit/test_github_pages_redirects.py
+++ b/tests/unit/test_github_pages_redirects.py
@@ -1,0 +1,57 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_github_pages_redirects.py"
+
+
+def test_generate_github_pages_redirects(tmp_path: Path) -> None:
+    source_dir = tmp_path / "site"
+    output_dir = tmp_path / "gh-pages-redirect"
+
+    (source_dir / "api").mkdir(parents=True)
+    (source_dir / "gateway").mkdir(parents=True)
+    (source_dir / "images").mkdir(parents=True)
+
+    (source_dir / "index.md").write_text("# Home\n", encoding="utf-8")
+    (source_dir / "quickstart.md").write_text("# Quickstart\n", encoding="utf-8")
+    (source_dir / "api" / "any-llm.md").write_text("# AnyLLM\n", encoding="utf-8")
+    (source_dir / "gateway" / "overview.md").write_text("# Overview\n", encoding="utf-8")
+    (source_dir / "SUMMARY.md").write_text("# Summary\n", encoding="utf-8")
+    (source_dir / "openapi.json").write_text('{"openapi":"3.1.0"}\n', encoding="utf-8")
+    (source_dir / "llms.txt").write_text("llms\n", encoding="utf-8")
+    (source_dir / "images" / "logo.png").write_bytes(b"png")
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--source-dir",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    root_redirect = (output_dir / "index.html").read_text(encoding="utf-8")
+    quickstart_redirect = (output_dir / "quickstart" / "index.html").read_text(encoding="utf-8")
+    alias_redirect = (output_dir / "api" / "any_llm" / "index.html").read_text(encoding="utf-8")
+    not_found_redirect = (output_dir / "404.html").read_text(encoding="utf-8")
+
+    assert 'https://docs.mozilla.ai/any-llm/' in root_redirect
+    assert 'https://docs.mozilla.ai/any-llm/quickstart/' in quickstart_redirect
+    assert 'https://docs.mozilla.ai/any-llm/api/any-llm/' in alias_redirect
+    assert (output_dir / "quickstart.html").exists()
+    assert not (output_dir / "SUMMARY.html").exists()
+    assert (output_dir / ".nojekyll").exists()
+    assert (output_dir / "openapi.json").read_text(encoding="utf-8") == '{"openapi":"3.1.0"}\n'
+    assert (output_dir / "llms.txt").read_text(encoding="utf-8") == "llms\n"
+    assert (output_dir / "images" / "logo.png").read_bytes() == b"png"
+    assert 'const pagesBasePath = "/any-llm";' in not_found_redirect
+    assert 'const docsBaseUrl = new URL("https://docs.mozilla.ai/any-llm/");' in not_found_redirect


### PR DESCRIPTION
Retire GitHub pages, and redirect all users to GitBook

## Description
Redirect users from GitHub pages to docs.mozilla.ai


## PR Type

- 📚 Documentation
- 🚦 Infrastructure

## Relevant issues

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [X] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [X] I have run this code locally and verified it fixes the issue.
- [X] New and existing tests pass locally
- [X] Documentation was updated where necessary
- [X] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [X] **AI Usage:**
    - [ ] No AI was used.
    - X AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
