### PR TITLE
fix(openrouter): normalize list_models response to valid Model schema

### DIFF
--- a/src/any_llm/providers/openrouter/openrouter.py
+++ b/src/any_llm/providers/openrouter/openrouter.py
@@ -1,10 +1,12 @@
+from collections.abc import Sequence
 from typing import Any
 
 from typing_extensions import override
 
 from any_llm.providers.openai.base import BaseOpenAIProvider
-from any_llm.providers.openrouter.utils import build_reasoning_directive
+from any_llm.providers.openrouter.utils import _convert_models_list, build_reasoning_directive
 from any_llm.types.completion import CompletionParams
+from any_llm.types.model import Model
 
 
 class OpenrouterProvider(BaseOpenAIProvider):
@@ -21,6 +23,12 @@ class OpenrouterProvider(BaseOpenAIProvider):
     SUPPORTS_EMBEDDING = True
     # OpenRouter does not expose a moderation endpoint.
     SUPPORTS_MODERATION = False
+
+    @staticmethod
+    @override
+    def _convert_list_models_response(response: Any) -> Sequence[Model]:
+        """Convert OpenRouter list models response to valid Model objects."""
+        return _convert_models_list(response)
 
     @staticmethod
     @override

--- a/src/any_llm/providers/openrouter/utils.py
+++ b/src/any_llm/providers/openrouter/utils.py
@@ -48,20 +48,22 @@ def _convert_models_list(response: Any) -> Sequence[Model]:
     OpenRouter's ``/api/v1/models`` endpoint omits the ``object`` and
     ``owned_by`` fields that the OpenAI ``Model`` schema requires. The OpenAI
     SDK silently accepts those missing fields via ``model_construct()``, but the
-    resulting objects fail round-trip serialization. This function rebuilds each
-    model with proper defaults so downstream consumers always receive
-    spec-compliant ``Model`` instances.
+    resulting objects fail round-trip serialization. This function fills the
+    missing required fields while preserving any extra OpenRouter attributes
+    (e.g. ``name``, ``pricing``) that may already be present on the SDK objects.
     """
     raw_models = response.data if hasattr(response, "data") else response
-    return [
-        Model(
-            id=model.id,
-            created=model.created if model.created is not None else 0,
-            object="model",
-            owned_by=model.owned_by if model.owned_by is not None else "openrouter",
-        )
-        for model in raw_models
-    ]
+    result: list[Model] = []
+    for model in raw_models:
+        data: dict[str, Any] = model.model_dump() if hasattr(model, "model_dump") else dict(vars(model))
+        if data.get("object") is None:
+            data["object"] = "model"
+        if data.get("owned_by") is None:
+            data["owned_by"] = "openrouter"
+        if data.get("created") is None:
+            data["created"] = 0
+        result.append(Model.model_validate(data))
+    return result
 
 
 def _normalize_reasoning_obj(obj: Any) -> dict[str, Any]:

--- a/src/any_llm/providers/openrouter/utils.py
+++ b/src/any_llm/providers/openrouter/utils.py
@@ -6,7 +6,12 @@ opt-in handling for reasoning capabilities.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from any_llm.types.model import Model
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def build_reasoning_directive(
@@ -35,6 +40,28 @@ def build_reasoning_directive(
 
     # Default: No reasoning (including for "auto")
     return None
+
+
+def _convert_models_list(response: Any) -> Sequence[Model]:
+    """Convert OpenRouter list models response to valid Model objects.
+
+    OpenRouter's ``/api/v1/models`` endpoint omits the ``object`` and
+    ``owned_by`` fields that the OpenAI ``Model`` schema requires. The OpenAI
+    SDK silently accepts those missing fields via ``model_construct()``, but the
+    resulting objects fail round-trip serialization. This function rebuilds each
+    model with proper defaults so downstream consumers always receive
+    spec-compliant ``Model`` instances.
+    """
+    raw_models = response.data if hasattr(response, "data") else response
+    return [
+        Model(
+            id=model.id,
+            created=model.created if model.created is not None else 0,
+            object="model",
+            owned_by=model.owned_by if model.owned_by is not None else "openrouter",
+        )
+        for model in raw_models
+    ]
 
 
 def _normalize_reasoning_obj(obj: Any) -> dict[str, Any]:

--- a/tests/unit/providers/test_openrouter_provider.py
+++ b/tests/unit/providers/test_openrouter_provider.py
@@ -264,8 +264,12 @@ def test_openrouter_remaps_max_tokens_to_max_completion_tokens() -> None:
     assert result["max_completion_tokens"] == 8192
 
 
-def _make_openrouter_model(**overrides: object) -> SimpleNamespace:
-    """Build a fake model object resembling what the OpenAI SDK constructs from an OpenRouter response."""
+def _make_openrouter_model(**overrides: object) -> Model:
+    """Build a fake model object resembling what the OpenAI SDK constructs from an OpenRouter response.
+
+    Uses ``Model.model_construct`` to match how the OpenAI SDK actually builds
+    model objects from raw API responses, including extra OpenRouter fields.
+    """
     defaults: dict[str, object] = {
         "id": "qwen/qwen3.7-max",
         "created": 1779376861,
@@ -273,7 +277,7 @@ def _make_openrouter_model(**overrides: object) -> SimpleNamespace:
         "owned_by": None,
     }
     defaults.update(overrides)
-    return SimpleNamespace(**defaults)
+    return Model.model_construct(**defaults)  # type: ignore[arg-type]
 
 
 def test_convert_models_list_fills_missing_object_and_owned_by() -> None:
@@ -349,3 +353,22 @@ def test_list_models_returns_valid_model_objects(mock_openai_class: MagicMock) -
     assert result[0].owned_by == "openrouter"
     assert result[1].id == "anthropic/claude-3.5-sonnet"
     assert result[1].owned_by == "anthropic"
+
+
+def test_convert_models_list_preserves_extra_openrouter_fields() -> None:
+    """Extra OpenRouter attributes (name, pricing, etc.) survive conversion."""
+    model = _make_openrouter_model(
+        name="Qwen3.7 Max",
+        pricing={"prompt": "0.001", "completion": "0.002"},
+    )
+    response = SimpleNamespace(data=[model])
+    result = _convert_models_list(response)
+
+    assert len(result) == 1
+    converted = result[0]
+    assert converted.id == "qwen/qwen3.7-max"
+    assert converted.object == "model"
+    assert converted.owned_by == "openrouter"
+    assert converted.model_extra is not None
+    assert converted.model_extra["name"] == "Qwen3.7 Max"
+    assert converted.model_extra["pricing"] == {"prompt": "0.001", "completion": "0.002"}

--- a/tests/unit/providers/test_openrouter_provider.py
+++ b/tests/unit/providers/test_openrouter_provider.py
@@ -1,8 +1,10 @@
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from any_llm.providers.openrouter import OpenrouterProvider
+from any_llm.providers.openrouter.utils import _convert_models_list
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionMessage,
@@ -10,6 +12,7 @@ from any_llm.types.completion import (
     CompletionParams,
     Reasoning,
 )
+from any_llm.types.model import Model
 
 
 @pytest.mark.asyncio
@@ -259,3 +262,90 @@ def test_openrouter_remaps_max_tokens_to_max_completion_tokens() -> None:
     result = OpenrouterProvider._convert_completion_params(params)
     assert "max_tokens" not in result
     assert result["max_completion_tokens"] == 8192
+
+
+def _make_openrouter_model(**overrides: object) -> SimpleNamespace:
+    """Build a fake model object resembling what the OpenAI SDK constructs from an OpenRouter response."""
+    defaults: dict[str, object] = {
+        "id": "qwen/qwen3.7-max",
+        "created": 1779376861,
+        "object": None,
+        "owned_by": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_convert_models_list_fills_missing_object_and_owned_by() -> None:
+    """Models with None object/owned_by are rebuilt with valid defaults."""
+    response = SimpleNamespace(data=[_make_openrouter_model()])
+    result = _convert_models_list(response)
+
+    assert len(result) == 1
+    model = result[0]
+    assert model.id == "qwen/qwen3.7-max"
+    assert model.object == "model"
+    assert model.owned_by == "openrouter"
+    assert model.created == 1779376861
+
+
+def test_convert_models_list_preserves_existing_owned_by() -> None:
+    """When the API does provide owned_by, it should be kept."""
+    response = SimpleNamespace(data=[_make_openrouter_model(owned_by="qwen")])
+    result = _convert_models_list(response)
+
+    assert result[0].owned_by == "qwen"
+
+
+def test_convert_models_list_defaults_created_to_zero_when_none() -> None:
+    """A None created timestamp falls back to 0."""
+    response = SimpleNamespace(data=[_make_openrouter_model(created=None)])
+    result = _convert_models_list(response)
+
+    assert result[0].created == 0
+
+
+def test_convert_models_list_handles_empty_response() -> None:
+    response = SimpleNamespace(data=[])
+    result = _convert_models_list(response)
+
+    assert result == []
+
+
+def test_convert_models_list_round_trip_serialization() -> None:
+    """Converted models must survive model_dump_json -> model_validate_json."""
+    response = SimpleNamespace(data=[_make_openrouter_model()])
+    models = _convert_models_list(response)
+
+    for model in models:
+        json_data = model.model_dump_json()
+        restored = Model.model_validate_json(json_data)
+        assert restored.id == model.id
+        assert restored.object == "model"
+        assert restored.owned_by == "openrouter"
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+def test_list_models_returns_valid_model_objects(mock_openai_class: MagicMock) -> None:
+    """End-to-end: OpenrouterProvider.list_models() returns spec-compliant Model objects."""
+    raw_models = [
+        _make_openrouter_model(id="openai/gpt-4o"),
+        _make_openrouter_model(id="anthropic/claude-3.5-sonnet", owned_by="anthropic"),
+    ]
+    mock_client = AsyncMock()
+    mock_client.models.list.return_value = SimpleNamespace(data=raw_models)
+    mock_openai_class.return_value = mock_client
+
+    provider = OpenrouterProvider(api_key="sk-test")
+    result = provider.list_models()
+
+    assert len(result) == 2
+    for model in result:
+        assert isinstance(model, Model)
+        assert model.object == "model"
+        assert model.owned_by is not None
+
+    assert result[0].id == "openai/gpt-4o"
+    assert result[0].owned_by == "openrouter"
+    assert result[1].id == "anthropic/claude-3.5-sonnet"
+    assert result[1].owned_by == "anthropic"


### PR DESCRIPTION
## Description

OpenRouter's `/api/v1/models` endpoint omits the `object` and `owned_by` fields that the OpenAI `Model` schema requires. The OpenAI SDK silently accepts these missing fields via `model_construct()` (which skips Pydantic validation), but the resulting `Model` objects have `None` for those required fields. This breaks round-trip serialization (`model_dump_json()` -> `Model.model_validate_json()`).

This PR adds a `_convert_models_list()` utility function and overrides `_convert_list_models_response` in `OpenrouterProvider` to rebuild each model with proper defaults (`object="model"`, `owned_by="openrouter"`), following the same pattern used by every other non-OpenAI provider (Groq, Anthropic, Ollama, Gemini, Mistral, etc.).

## PR Type

- Bug Fix

## Relevant issues

Fixes #1083

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude claude-opus-4-6
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: N/A

- [x] I am an AI Agent filling out this form (check box if true)