### PR TITLE
feat(azure): add Entra ID auth and update Foundry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </a>
 
 **Communicate with any LLM provider using a single, unified interface.**
-Switch between OpenAI, Anthropic, Mistral, Ollama, and more without changing your code.
+Switch between OpenAI, Anthropic, Azure / Microsoft Foundry, Mistral, Ollama, and more without changing your code.
 
 [Documentation](https://docs.mozilla.ai/any-llm/) | [otari.ai](https://otari.ai/) | [Try the Demos](#-try-it) | [Contributing](#-contributing)
 

--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import override
@@ -25,18 +26,31 @@ if TYPE_CHECKING:
 
     from azure.ai.inference import aio  # noqa: TC004
     from azure.ai.inference.models import ChatCompletions, EmbeddingsResult, StreamingChatCompletionsUpdate
+    from azure.core.credentials_async import AsyncTokenCredential
 
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
     from any_llm.types.model import Model
 
 
 class AzureProvider(AnyLLM):
-    """Azure Provider using the official Azure AI Inference SDK."""
+    """Azure Provider using the official Azure AI Inference SDK.
+
+    Supports two authentication modes:
+
+    * **API key** (default): Set ``AZURE_API_KEY`` or pass ``api_key``.
+    * **Microsoft Entra ID**: Pass a ``credential`` that implements the
+      ``azure.core.credentials_async.AsyncTokenCredential`` protocol
+      (e.g. ``DefaultAzureCredential``). When a ``credential`` is
+      provided the ``api_key`` parameter is ignored. This is the
+      recommended authentication method for Microsoft Foundry deployments.
+    """
 
     PROVIDER_NAME = "azure"
     ENV_API_KEY_NAME = "AZURE_API_KEY"
     ENV_API_BASE_NAME = "AZURE_AI_CHAT_ENDPOINT"
-    PROVIDER_DOCUMENTATION_URL = "https://azure.microsoft.com/en-us/products/ai-services/openai-service"
+    PROVIDER_DOCUMENTATION_URL = (
+        "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure"
+    )
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION_IMAGE = False
     SUPPORTS_COMPLETION_PDF = False
@@ -54,6 +68,14 @@ class AzureProvider(AnyLLM):
     embeddings_client: aio.EmbeddingsClient
 
     @override
+    def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
+        # Allow api_key to be None when a TokenCredential is used for
+        # Microsoft Entra ID authentication.
+        if not api_key:
+            api_key = os.getenv(self.ENV_API_KEY_NAME)
+        return api_key
+
+    @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         if not api_base:
             msg = (
@@ -62,14 +84,21 @@ class AzureProvider(AnyLLM):
             )
             raise ValueError(msg)
 
+        token_credential: AsyncTokenCredential | None = kwargs.pop("credential", None)
+
+        if token_credential is not None:
+            credential: AzureKeyCredential | AsyncTokenCredential = token_credential
+        else:
+            credential = AzureKeyCredential(api_key or "")
+
         self.chat_client = aio.ChatCompletionsClient(
             endpoint=api_base,
-            credential=AzureKeyCredential(api_key or ""),
+            credential=credential,
             **kwargs,
         )
         self.embeddings_client = aio.EmbeddingsClient(
             endpoint=api_base,
-            credential=AzureKeyCredential(api_key or ""),
+            credential=credential,
             **kwargs,
         )
 

--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -78,13 +78,6 @@ class AzureProvider(AnyLLM):
 
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
-        if not api_base:
-            msg = (
-                "For Azure, api_base is required. Check your deployment page for a URL like this - "
-                "https://<model-deployment-name>.<region>.models.ai.azure.com"
-            )
-            raise ValueError(msg)
-
         token_credential: AsyncTokenCredential | None = kwargs.pop("credential", None)
 
         if token_credential is not None:
@@ -93,6 +86,13 @@ class AzureProvider(AnyLLM):
             credential = AzureKeyCredential(api_key)
         else:
             raise MissingApiKeyError(self.PROVIDER_NAME, self.ENV_API_KEY_NAME)
+
+        if not api_base:
+            msg = (
+                "For Azure, api_base is required. Check your deployment page for a URL like this - "
+                "https://<model-deployment-name>.<region>.models.ai.azure.com"
+            )
+            raise ValueError(msg)
 
         self.chat_client = aio.ChatCompletionsClient(
             endpoint=api_base,

--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
+from any_llm.exceptions import MissingApiKeyError
 
 MISSING_PACKAGES_ERROR = None
 try:
@@ -88,8 +89,10 @@ class AzureProvider(AnyLLM):
 
         if token_credential is not None:
             credential: AzureKeyCredential | AsyncTokenCredential = token_credential
+        elif api_key:
+            credential = AzureKeyCredential(api_key)
         else:
-            credential = AzureKeyCredential(api_key or "")
+            raise MissingApiKeyError(self.PROVIDER_NAME, self.ENV_API_KEY_NAME)
 
         self.chat_client = aio.ChatCompletionsClient(
             endpoint=api_base,

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from azure.ai.inference.models import JsonSchemaFormat
 
+from any_llm.exceptions import MissingApiKeyError
 from any_llm.providers.azure.azure import AzureProvider
 from any_llm.providers.azure.utils import _convert_response_format
 from any_llm.types.completion import CompletionParams
@@ -219,13 +220,10 @@ async def test_azure_token_credential_ignores_api_key() -> None:
         )
 
 
-def test_azure_no_api_key_no_credential_allowed() -> None:
-    """Test that the provider can be created without an API key (for Entra ID use cases)."""
+def test_azure_no_api_key_no_credential_raises() -> None:
+    """Test that omitting both api_key and credential raises MissingApiKeyError."""
     custom_endpoint = "https://test.eu.models.ai.azure.com"
 
-    with mock_azure_provider() as (_, _, mock_chat_client):
-        with patch("any_llm.providers.azure.azure.AzureKeyCredential") as mock_azure_key_credential:
+    with mock_azure_provider():
+        with pytest.raises(MissingApiKeyError):
             AzureProvider(api_base=custom_endpoint)
-
-            mock_azure_key_credential.assert_called_once_with("")
-            mock_chat_client.assert_called_once()

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -178,3 +178,54 @@ def test_convert_response_format_from_dict_invalid() -> None:
 
     with pytest.raises(ValueError, match="Response format must be a structured type or a dict with a json_schema key"):
         _convert_response_format(invalid_dict)
+
+
+@pytest.mark.asyncio
+async def test_azure_with_token_credential() -> None:
+    """Test that AzureProvider accepts a TokenCredential for Entra ID auth."""
+    custom_endpoint = "https://test.eu.models.ai.azure.com"
+    mock_credential = MagicMock()
+
+    messages = [{"role": "user", "content": "Hello"}]
+    with mock_azure_provider() as (mock_client, mock_convert_response, mock_chat_client):
+        provider = AzureProvider(api_base=custom_endpoint, credential=mock_credential)
+        await provider._acompletion(CompletionParams(model_id="model-id", messages=messages))
+
+        mock_chat_client.assert_called_once_with(
+            endpoint=custom_endpoint,
+            credential=mock_credential,
+        )
+
+        mock_client.complete.assert_called_once_with(
+            model="model-id",
+            messages=messages,
+        )
+
+        mock_convert_response.assert_called_once_with(mock_client.complete.return_value)
+
+
+@pytest.mark.asyncio
+async def test_azure_token_credential_ignores_api_key() -> None:
+    """Test that when a credential is provided, api_key is ignored."""
+    custom_endpoint = "https://test.eu.models.ai.azure.com"
+    mock_credential = MagicMock()
+
+    with mock_azure_provider() as (_, _, mock_chat_client):
+        AzureProvider(api_key="should-be-ignored", api_base=custom_endpoint, credential=mock_credential)
+
+        mock_chat_client.assert_called_once_with(
+            endpoint=custom_endpoint,
+            credential=mock_credential,
+        )
+
+
+def test_azure_no_api_key_no_credential_allowed() -> None:
+    """Test that the provider can be created without an API key (for Entra ID use cases)."""
+    custom_endpoint = "https://test.eu.models.ai.azure.com"
+
+    with mock_azure_provider() as (_, _, mock_chat_client):
+        with patch("any_llm.providers.azure.azure.AzureKeyCredential") as mock_azure_key_credential:
+            AzureProvider(api_base=custom_endpoint)
+
+            mock_azure_key_credential.assert_called_once_with("")
+            mock_chat_client.assert_called_once()


### PR DESCRIPTION
## Description

Improves the `azure` provider with Microsoft Foundry alignment:

1. **Entra ID authentication**: Adds support for `AsyncTokenCredential`-based auth (e.g. `DefaultAzureCredential`) via a new `credential` kwarg. This is the recommended authentication method for Microsoft Foundry deployments. When a `credential` is provided, `api_key` is ignored.

2. **Documentation URL update**: Updates `PROVIDER_DOCUMENTATION_URL` from the old Azure AI Services page to the current Foundry Models documentation.

3. **README update**: Mentions Azure / Microsoft Foundry in the provider list.

### Usage example (Entra ID)

```python
from azure.identity.aio import DefaultAzureCredential
from any_llm import AnyLLM

llm = AnyLLM.create(
    "azure",
    api_base="https://my-resource.services.ai.azure.com",
    credential=DefaultAzureCredential(),
)
```

## PR Type

- 🆕 New Feature
- 📚 Documentation

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.6
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Investigation of Microsoft Foundry and implementation of recommended enhancements.

- [x] I am an AI Agent filling out this form (check box if true)