### PR TITLE
feat(together): support list_models

### DIFF
--- a/src/any_llm/providers/together/together.py
+++ b/src/any_llm/providers/together/together.py
@@ -12,6 +12,7 @@ try:
     import together
 
     from .utils import (
+        _convert_models_list,
         _convert_together_response_to_chat_completion,
         _create_openai_chunk_from_together_chunk,
     )
@@ -50,7 +51,7 @@ class TogetherProvider(AnyLLM):
     SUPPORTS_COMPLETION_IMAGE = True
     SUPPORTS_COMPLETION_PDF = False
     SUPPORTS_EMBEDDING = False
-    SUPPORTS_LIST_MODELS = False
+    SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = False
     SUPPORTS_RERANK = False
 
@@ -122,8 +123,7 @@ class TogetherProvider(AnyLLM):
     @override
     def _convert_list_models_response(response: Any) -> Sequence[Model]:
         """Convert Together list models response to OpenAI format."""
-        msg = "Together does not support listing models"
-        raise NotImplementedError(msg)
+        return _convert_models_list(response)
 
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
@@ -181,3 +181,8 @@ class TogetherProvider(AnyLLM):
         )
 
         return self._convert_completion_response(response.model_dump())
+
+    @override
+    async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
+        models_list = await self.client.models.list(**kwargs)
+        return self._convert_list_models_response(models_list)

--- a/src/any_llm/providers/together/utils.py
+++ b/src/any_llm/providers/together/utils.py
@@ -17,6 +17,7 @@ from any_llm.types.completion import (
     CompletionUsage,
     Reasoning,
 )
+from any_llm.types.model import Model
 from any_llm.utils.reasoning import normalize_reasoning_from_provider_fields_and_xml_tags
 
 
@@ -141,3 +142,21 @@ def _convert_together_response_to_chat_completion(response_data: dict[str, Any],
         choices=choices_out,
         usage=usage,
     )
+
+
+def _convert_models_list(response: Any) -> list[Model]:
+    """Convert Together model listing response to OpenAI-compatible Model objects."""
+    raw_models = response.data if hasattr(response, "data") else response
+    converted_models: list[Model] = []
+
+    for model in raw_models:
+        data = model.model_dump() if hasattr(model, "model_dump") else dict(vars(model))
+        if data.get("object") is None:
+            data["object"] = "model"
+        if data.get("created") is None:
+            data["created"] = 0
+        if data.get("owned_by") is None:
+            data["owned_by"] = data.get("organization") or "together"
+        converted_models.append(Model.model_validate(data))
+
+    return converted_models

--- a/tests/unit/providers/test_together_provider.py
+++ b/tests/unit/providers/test_together_provider.py
@@ -1,12 +1,14 @@
 from datetime import datetime
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from together.types import ChatCompletionChunk as TogetherChatCompletionChunk
 
 from any_llm.providers.together.utils import _create_openai_chunk_from_together_chunk
 from any_llm.types.completion import ChatCompletionChunk, CompletionParams
+from any_llm.types.model import Model
 
 
 def make_together_chunk(
@@ -337,3 +339,69 @@ def test_convert_completion_params_without_response_format() -> None:
     result = TogetherProvider._convert_completion_params(params)
 
     assert "response_format" not in result
+
+
+def test_together_convert_models_list_maps_to_openai_model() -> None:
+    from any_llm.providers.together.together import TogetherProvider
+
+    response = [
+        SimpleNamespace(
+            id="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            object="model",
+            created=1735689600,
+            organization="meta-llama",
+            type="chat",
+            context_length=131072,
+        )
+    ]
+
+    result = TogetherProvider._convert_list_models_response(response)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Model)
+    assert result[0].id == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+    assert result[0].object == "model"
+    assert result[0].created == 1735689600
+    assert result[0].owned_by == "meta-llama"
+    assert result[0].model_extra is not None
+    assert result[0].model_extra["type"] == "chat"
+    assert result[0].model_extra["context_length"] == 131072
+
+
+def test_together_convert_models_list_fills_missing_fields() -> None:
+    from any_llm.providers.together.together import TogetherProvider
+
+    response = [SimpleNamespace(id="deepseek-ai/DeepSeek-V3", created=None, object=None, organization=None)]
+
+    result = TogetherProvider._convert_list_models_response(response)
+
+    assert len(result) == 1
+    assert result[0].id == "deepseek-ai/DeepSeek-V3"
+    assert result[0].object == "model"
+    assert result[0].created == 0
+    assert result[0].owned_by == "together"
+
+
+@patch("any_llm.providers.together.together.together.AsyncTogether")
+def test_together_list_models_calls_client_and_passes_kwargs(mock_together_class: MagicMock) -> None:
+    from any_llm.providers.together.together import TogetherProvider
+
+    mock_client = AsyncMock()
+    mock_client.models.list.return_value = [
+        SimpleNamespace(
+            id="Qwen/Qwen2.5-72B-Instruct-Turbo",
+            object="model",
+            created=1735689600,
+            organization="Qwen",
+        )
+    ]
+    mock_together_class.return_value = mock_client
+
+    provider = TogetherProvider(api_key="test-api-key")
+    result = provider.list_models(dedicated=True)
+
+    mock_client.models.list.assert_called_once_with(dedicated=True)
+    assert len(result) == 1
+    assert isinstance(result[0], Model)
+    assert result[0].id == "Qwen/Qwen2.5-72B-Instruct-Turbo"
+    assert result[0].owned_by == "Qwen"


### PR DESCRIPTION
## Description
Adds `list_models` support for the Together provider by implementing provider-level listing and converting Together model payloads into OpenAI-compatible `Model` objects with required field defaults.

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #517

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: gpt-5.3-codex
- AI Developer Tool used: OpenCode
- Any other info you would like to share: Implemented from issue requirements, with targeted provider and unit test validation.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)