### PR TITLE
feat(cohere): map reasoning_effort to thinking token_budget

### DIFF
--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
     from any_llm.types.rerank import RerankResponse
 
 
+REASONING_EFFORT_TO_THINKING_BUDGETS = {
+    "minimal": 256,
+    "low": 1024,
+    "medium": 8192,
+    "high": 24576,
+    "xhigh": 32768,
+}
+
+
 class CohereProvider(AnyLLM):
     """Cohere Provider using the new response conversion utilities."""
 
@@ -59,12 +68,18 @@ class CohereProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for Cohere API."""
-        # Cohere does not support providing reasoning effort
         converted_params = params.model_dump(
-            exclude_none=True, exclude={"model_id", "messages", "response_format", "stream", "stream_options"}
+            exclude_none=True,
+            exclude={"model_id", "messages", "response_format", "stream", "stream_options", "reasoning_effort"},
         )
-        if converted_params.get("reasoning_effort") in ("auto", "none"):
-            converted_params.pop("reasoning_effort")
+        if params.reasoning_effort != "auto":
+            if params.reasoning_effort is None or params.reasoning_effort == "none":
+                converted_params["thinking"] = {"type": "disabled"}
+            else:
+                converted_params["thinking"] = {
+                    "type": "enabled",
+                    "token_budget": REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort],
+                }
         converted_params.update(kwargs)
         return converted_params
 

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -11,7 +11,7 @@ from any_llm.providers.cohere.utils import (
     _create_openai_chunk_from_cohere_chunk,
     _patch_messages,
 )
-from any_llm.types.completion import CompletionParams, CreateEmbeddingResponse
+from any_llm.types.completion import CompletionParams, CreateEmbeddingResponse, ReasoningEffort
 
 
 def _mk_provider() -> Any:
@@ -207,9 +207,23 @@ def test_preprocess_response_format_unsupported_raises() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("reasoning_effort", ["auto", "none"])
-async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
-    """Test that reasoning_effort 'auto' and 'none' are filtered from Cohere API calls."""
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_thinking"),
+    [
+        ("auto", None),
+        ("none", {"type": "disabled"}),
+        (None, {"type": "disabled"}),
+        ("minimal", {"type": "enabled", "token_budget": 256}),
+        ("low", {"type": "enabled", "token_budget": 1024}),
+        ("medium", {"type": "enabled", "token_budget": 8192}),
+        ("high", {"type": "enabled", "token_budget": 24576}),
+        ("xhigh", {"type": "enabled", "token_budget": 32768}),
+    ],
+)
+async def test_reasoning_effort_mapped_to_thinking(
+    reasoning_effort: ReasoningEffort | None, expected_thinking: dict[str, Any] | None
+) -> None:
+    """Test reasoning_effort maps to Cohere thinking config like Gemini."""
     pytest.importorskip("cohere")
     from any_llm.providers.cohere.cohere import CohereProvider
 
@@ -224,12 +238,16 @@ async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
                 CompletionParams(
                     model_id="command-r-plus",
                     messages=[{"role": "user", "content": "Hello"}],
-                    reasoning_effort=reasoning_effort,  # type: ignore[arg-type]
+                    reasoning_effort=reasoning_effort,
                 ),
             )
 
             call_kwargs = mock_client.chat.call_args[1]
             assert "reasoning_effort" not in call_kwargs
+            if expected_thinking is None:
+                assert "thinking" not in call_kwargs
+            else:
+                assert call_kwargs["thinking"] == expected_thinking
 
 
 def _mock_tool_call(tool_id: str, name: str, arguments: str) -> Mock:


### PR DESCRIPTION
## Description
Map reasoning_effort for the Cohere provider to Cohere v2 thinking config, mirroring Gemini behavior.

This change:
- Converts explicit effort levels (minimal, low, medium, high, xhigh) to thinking.token_budget values
- Maps none and None to thinking.type=disabled
- Keeps auto as provider default by omitting thinking
- Prevents raw reasoning_effort from being forwarded to Cohere
- Expands unit tests to cover all supported effort values and expected thinking payloads

## PR Type
- 🆕 New Feature

## Relevant issues
Fixes #546

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines: https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: GPT-5.3 Codex (openai/gpt-5.3-codex)
- AI Developer Tool used: OpenCode CLI agent
- Any other info you'd like to share: Implemented per existing provider patterns and validated with targeted pytest run.

- [x] I am an AI Agent filling out this form (check box if true)

## Testing
- uv run pytest -v tests/unit/providers/test_cohere_provider.py