### PR TITLE
fix(docs): stop gitbook publish from ignoring cookbook pages

### DIFF
--- a/scripts/convert_to_gitbook.py
+++ b/scripts/convert_to_gitbook.py
@@ -18,7 +18,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent
 DOCS_SRC = Path("docs")
 SITE_DIR = Path("site")
-SITE_IGNORE_PATTERNS = ("*.ipynb",)
+SITE_IGNORE_PATTERNS = ("*.ipynb", ".gitignore")
 
 
 def run_generator(script_name: str) -> None:

--- a/tests/unit/test_convert_to_gitbook.py
+++ b/tests/unit/test_convert_to_gitbook.py
@@ -59,6 +59,7 @@ def test_main_writes_dynamic_cookbook_summary(monkeypatch: pytest.MonkeyPatch, t
         target = docs_dir / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("# Placeholder\n", encoding="utf-8")
+    (docs_dir / ".gitignore").write_text("cookbooks/*.md\n", encoding="utf-8")
 
     _write_notebook(
         cookbooks_dir / "browser_use_with_any_llm.ipynb",
@@ -76,6 +77,7 @@ def test_main_writes_dynamic_cookbook_summary(monkeypatch: pytest.MonkeyPatch, t
     assert "* [Browser-Use with Any-LLM](cookbooks/browser-use-with-any-llm.md)" in summary
     assert (site_dir / "cookbooks" / "browser-use-with-any-llm.md").exists()
     assert not (site_dir / "cookbooks" / "browser_use_with_any_llm.ipynb").exists()
+    assert not (site_dir / ".gitignore").exists()
 
 
 def test_build_summary_falls_back_when_no_cookbooks(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
Fixes the GitBook publish artifact so generated cookbook pages are not dropped from the gitbook-docs branch.

## PR Type

- 🐛 Bug Fix
- 📚 Documentation


## Checklist
- [X] I understand the code I am submitting.
- [X] I have added unit tests that prove my fix/feature works
- [X] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [X] Documentation was updated where necessary
- [X] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [X] **AI Usage:**
    - [ ] No AI was used.
    - [X] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
