### PR TITLE
fix(gemini): route JSON Schema with $defs/$ref through parameters_json_schema

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -29,6 +29,22 @@ from any_llm.types.model import Model
 _INLINE_SIZE_LIMIT = 20 * 1024 * 1024
 
 
+def _has_json_schema_refs(schema: Any) -> bool:
+    """Return True if *schema* contains a ``$defs`` block or any ``$ref`` reference.
+
+    ``google.genai.types.Schema`` does not accept ``$ref``/``$defs``. When present,
+    the schema must be routed through ``FunctionDeclaration.parameters_json_schema``
+    instead, which the SDK forwards to the server as raw JSON Schema.
+    """
+    if isinstance(schema, dict):
+        if "$defs" in schema or "$ref" in schema:
+            return True
+        return any(_has_json_schema_refs(v) for v in schema.values())
+    if isinstance(schema, list):
+        return any(_has_json_schema_refs(v) for v in schema)
+    return False
+
+
 def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
     converted_tools = []
     function_declarations = []
@@ -43,6 +59,17 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
 
         function = tool["function"]
         params: dict[str, Any] = function.get("parameters") or {}
+
+        if _has_json_schema_refs(params):
+            function_declarations.append(
+                types.FunctionDeclaration(
+                    name=function["name"],
+                    description=function.get("description", ""),
+                    parameters_json_schema=params,
+                )
+            )
+            continue
+
         properties: dict[str, dict[str, Any]] = {}
         for param_name, param_info in (params.get("properties") or {}).items():
             prop: dict[str, Any] = {

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -660,6 +660,115 @@ def test_convert_tool_spec_parameters_missing_properties() -> None:
     assert decl.parameters.properties == {}  # type: ignore[union-attr]
 
 
+def test_convert_tool_spec_json_schema_with_defs_and_refs() -> None:
+    """Regression for #1094: JSON Schema with $defs/$ref must route through parameters_json_schema.
+
+    google.genai.types.Schema rejects $ref/$defs (Pydantic extra_forbidden). The SDK exposes
+    FunctionDeclaration.parameters_json_schema for raw JSON Schema input; ref-bearing schemas
+    must use that field instead of the reshaped `parameters=types.Schema(...)` path.
+    """
+    raw_params = {
+        "$defs": {
+            "Param": {
+                "properties": {
+                    "content": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "description": "A content.",
+                        "title": "Content",
+                    },
+                    "content2": {"description": "An other content", "title": "Content2", "type": "string"},
+                },
+                "required": ["content", "content2"],
+                "title": "Param",
+                "type": "object",
+                "additionalProperties": False,
+            }
+        },
+        "properties": {
+            "param": {
+                "description": "A mock param.",
+                "items": {"$ref": "#/$defs/Param"},
+                "type": "array",
+            }
+        },
+        "required": ["param"],
+        "type": "object",
+        "additionalProperties": False,
+    }
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "json_schema_tool_ex",
+                "description": "An example tool that uses a JSON schema to define the input structure.",
+                "parameters": raw_params,
+            },
+        }
+    ]
+
+    tools = _convert_tool_spec(openai_tools)
+
+    assert len(tools) == 1
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.name == "json_schema_tool_ex"
+    assert decl.parameters is None
+    assert decl.parameters_json_schema == raw_params
+
+
+def test_convert_tool_spec_nested_ref_only() -> None:
+    """A $ref nested deep inside an item schema (no top-level $defs) must still trigger routing."""
+    raw_params = {
+        "type": "object",
+        "properties": {
+            "outer": {
+                "type": "object",
+                "properties": {"inner": {"$ref": "#/components/schemas/Thing"}},
+            }
+        },
+    }
+    tools = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "nested", "parameters": raw_params}}]
+    )
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.parameters is None
+    assert decl.parameters_json_schema == raw_params
+
+
+def test_convert_tool_spec_mixed_ref_and_plain_tools() -> None:
+    """Ref-bearing and plain tools in the same call should each take the appropriate path."""
+    tools = _convert_tool_spec(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "with_ref",
+                    "parameters": {
+                        "$defs": {"X": {"type": "string"}},
+                        "type": "object",
+                        "properties": {"x": {"$ref": "#/$defs/X"}},
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "plain",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            },
+        ]
+    )
+    assert len(tools) == 1
+    decls = tools[0].function_declarations  # type: ignore[union-attr]
+    assert len(decls) == 2
+    assert decls[0].name == "with_ref"
+    assert decls[0].parameters is None
+    assert decls[0].parameters_json_schema is not None
+    assert decls[1].name == "plain"
+    assert decls[1].parameters_json_schema is None
+    assert decls[1].parameters.type == "OBJECT"  # type: ignore[union-attr]
+
+
 @pytest.mark.asyncio
 async def test_gemini_with_built_in_tools() -> None:
     """Test that built-in tools are added correctly when specified."""

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -726,9 +726,7 @@ def test_convert_tool_spec_nested_ref_only() -> None:
             }
         },
     }
-    tools = _convert_tool_spec(
-        [{"type": "function", "function": {"name": "nested", "parameters": raw_params}}]
-    )
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "nested", "parameters": raw_params}}])
     decl = tools[0].function_declarations[0]  # type: ignore[index]
     assert decl.parameters is None
     assert decl.parameters_json_schema == raw_params
@@ -759,14 +757,16 @@ def test_convert_tool_spec_mixed_ref_and_plain_tools() -> None:
         ]
     )
     assert len(tools) == 1
-    decls = tools[0].function_declarations  # type: ignore[union-attr]
+    decls = tools[0].function_declarations
+    assert decls is not None
     assert len(decls) == 2
     assert decls[0].name == "with_ref"
     assert decls[0].parameters is None
     assert decls[0].parameters_json_schema is not None
     assert decls[1].name == "plain"
     assert decls[1].parameters_json_schema is None
-    assert decls[1].parameters.type == "OBJECT"  # type: ignore[union-attr]
+    assert decls[1].parameters is not None
+    assert decls[1].parameters.type == "OBJECT"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Closes #1094.

`_convert_tool_spec` in `src/any_llm/providers/gemini/utils.py` builds `types.FunctionDeclaration(parameters=types.Schema(**parameters_dict))` for every tool. `google.genai.types.Schema` is a Pydantic model that rejects `$ref` and `$defs` (`extra_forbidden`), so any OpenAI-format tool whose `parameters` is a JSON Schema with `$defs`/`$ref` — e.g. anything derived from a nested Pydantic model — crashes with the validation error in #1094.

`FunctionDeclaration` exposes a second, mutually-exclusive parameter field, `parameters_json_schema`, which the SDK forwards to the server as raw JSON Schema (the server resolves `$ref`/`$defs` itself). The fix routes ref-bearing schemas through that field and leaves the existing reshaping path unchanged for everything else.

### Changes

- **`src/any_llm/providers/gemini/utils.py`** — new `_has_json_schema_refs()` helper (recursive `$defs`/`$ref` detection); `_convert_tool_spec` routes ref-bearing schemas to `parameters_json_schema=params` instead of `parameters=types.Schema(...)`.
- **`tests/unit/providers/test_gemini_provider.py`** — 3 regression tests: the exact issue repro, a deeply-nested `$ref` without top-level `$defs`, and mixed ref+plain tools in a single call.

### Verification

- `pytest tests/unit/providers/test_gemini_provider.py` — 78 passed (3 new).
- Live round-trip against `gemini-2.5-flash` with the issue's exact tool definition: Gemini accepted the schema and produced a valid tool call (`{"param": [{"content": "hello", "content2": "world"}, {"content": null, "content2": "only-second"}]}`).

The three regression tests cover the conversion logic offline (CI); the live round-trip was a manual end-to-end check against the real Gemini API.

### Notes

- `any-llm` declares `google-genai` without a version floor; `parameters_json_schema` has existed on every published version of `google-genai` (0.1.0+), so no floor bump is required.
- Pure addition: schemas without `$defs`/`$ref` continue through the existing `types.Schema(...)` path with no behavior change.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1094

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Anthropic)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Diff and tests were drafted by Claude under interactive human review (edit-by-edit approval, no autonomous commits). Live Gemini round-trip and decision to route via \`parameters_json_schema\` over a \`\$ref\` resolver were author-driven.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)