### PR TITLE
revert: pre-commit autoupdate (#1096)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         exclude: (\.md|\.ambr)$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.15"
+    rev: "v0.15.12"
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
## Description
Reverts commit 893ed49 (`pre-commit autoupdate (#1096)`) to unblock failing CI.

The autoupdate moved `ruff-pre-commit` to a release that requires `ruff==0.15.15`, but our workflow's `exclude-newer` cutoff filtered that version out, making `run-linter` unsatisfiable.

## PR Type
- 🐛 Bug Fix

## Relevant issues
N/A

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: openai/gpt-5.3-codex
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Revert-only change; validated with `uv run pre-commit run --all-files --verbose`.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)