### PR TITLE
feat(lmstudio): use native lmstudio-python SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ sagemaker = [
   "boto3",
 ]
 
+lmstudio = [
+  "lmstudio>=1.5.0",
+]
 
 # These providers don't require any additional dependencies, but are included for completeness.
 azureopenai = []
@@ -121,7 +124,6 @@ inception = []
 llama = []
 llamacpp = []
 llamafile = []
-lmstudio = []
 moonshot = []
 nebius = []
 openai = []

--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -1,22 +1,259 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any, cast
+
 from typing_extensions import override
 
-from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.any_llm import AnyLLM
+from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
-# LM Studio has a python sdk, but per their docs they are compliant with OpenAI spec
-# https://lmstudio.ai/docs/app/api/endpoints/openai
-# So until its clear why the python sdk should be used, we'll default to inheriting from OpenAI SDK.
+MISSING_PACKAGES_ERROR = None
+try:
+    from lmstudio import AsyncClient, Chat
+
+    from .utils import (
+        convert_models_list,
+        create_chunk_from_fragment,
+        create_completion_from_prediction,
+        create_embedding_response,
+        create_final_chunk,
+    )
+except ImportError as e:
+    MISSING_PACKAGES_ERROR = e
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from any_llm.types.completion import (
+        ChatCompletion,
+        ChatCompletionChunk,
+        CompletionParams,
+        CreateEmbeddingResponse,
+    )
+    from any_llm.types.model import Model
 
 
-class LmstudioProvider(BaseOpenAIProvider):
-    API_BASE = "http://localhost:1234/v1"
+class LmstudioProvider(AnyLLM):
+    """LM Studio provider backed by the native `lmstudio-python` SDK.
+
+    Unlike the OpenAI-compatible REST endpoint, the native SDK speaks LM Studio's
+    websocket protocol. Its async client requires structured concurrency
+    (`async with AsyncClient() as client: ...`), so a fresh client is opened for
+    the duration of each request rather than being reused across calls.
+
+    Read more here - https://lmstudio.ai/docs/python
+    """
+
+    PROVIDER_NAME = "lmstudio"
+    PROVIDER_DOCUMENTATION_URL = "https://lmstudio.ai/docs/python"
     ENV_API_KEY_NAME = "LM_STUDIO_API_KEY"
     ENV_API_BASE_NAME = "LM_STUDIO_API_BASE"
-    PROVIDER_NAME = "lmstudio"
-    PROVIDER_DOCUMENTATION_URL = "https://lmstudio.ai/"
+    API_BASE = "localhost:1234"
 
+    SUPPORTS_COMPLETION = True
+    SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_RESPONSES = True
+    SUPPORTS_COMPLETION_IMAGE = False
+    SUPPORTS_COMPLETION_PDF = False
+    SUPPORTS_EMBEDDING = True
+    SUPPORTS_LIST_MODELS = True
+    SUPPORTS_RESPONSES = False
+    SUPPORTS_MODERATION = False
+    SUPPORTS_BATCH = False
+    SUPPORTS_RERANK = False
+
+    MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
+
+    api_host: str
+
+    @staticmethod
+    def _normalize_api_host(api_base: str | None) -> str | None:
+        """Reduce an OpenAI-style base URL to the `host:port` the SDK expects.
+
+        Accepts values such as `http://localhost:1234/v1` (the legacy default) and
+        returns `localhost:1234`. Returns None when no usable host is provided.
+        """
+        if not api_base:
+            return None
+        host = api_base.strip()
+        for scheme in ("http://", "https://", "ws://", "wss://"):
+            if host.startswith(scheme):
+                host = host[len(scheme) :]
+                break
+        host = host.rstrip("/")
+        host = host.removesuffix("/v1")
+        return host.rstrip("/") or None
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        return "no-key-required"
+        # LM Studio runs locally and does not require an API key.
+        return api_key
+
+    @override
+    def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
+        self.api_host = self._normalize_api_host(api_base) or self.API_BASE
+
+    def _build_chat(self, messages: list[dict[str, Any]]) -> Chat:
+        """Convert OpenAI-style messages into an LM Studio `Chat` history."""
+        chat = Chat()
+        for message in messages:
+            role = message.get("role")
+            content = self._extract_text_content(message.get("content"))
+            if role == "system":
+                chat.add_system_prompt(content)
+            elif role == "assistant":
+                chat.add_assistant_response(content)
+            else:
+                # Map user (and any unsupported roles such as tool) to a user turn
+                # so prior context is preserved even though tool calling is unsupported.
+                chat.add_user_message(content)
+        return chat
+
+    @staticmethod
+    def _extract_text_content(content: Any) -> str:
+        """Flatten message content into plain text (images/files are not supported)."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts = [
+                part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            return " ".join(text_parts)
+        return str(content)
+
+    @staticmethod
+    @override
+    def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
+        """Build an LM Studio prediction config dict from the shared CompletionParams."""
+        config: dict[str, Any] = {}
+        if params.temperature is not None:
+            config["temperature"] = params.temperature
+        max_tokens = params.max_completion_tokens or params.max_tokens
+        if max_tokens is not None:
+            config["maxTokens"] = max_tokens
+        if params.top_p is not None:
+            config["topPSampling"] = params.top_p
+        if params.stop is not None:
+            config["stopStrings"] = [params.stop] if isinstance(params.stop, str) else params.stop
+        config.update(kwargs)
+        return config
+
+    @staticmethod
+    def _resolve_response_format(params: CompletionParams) -> dict[str, Any] | None:
+        """Translate response_format into a JSON schema the SDK can enforce."""
+        if params.response_format is None:
+            return None
+        if is_structured_output_type(params.response_format):
+            return get_json_schema(params.response_format)
+        if isinstance(params.response_format, dict):
+            return params.response_format
+        return None
+
+    @staticmethod
+    @override
+    def _convert_completion_response(response: Any) -> ChatCompletion:
+        """Convert an LM Studio PredictionResult to an OpenAI-compatible ChatCompletion."""
+        return create_completion_from_prediction(response, response.model_info.model_key)
+
+    @staticmethod
+    @override
+    def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
+        """Convert an LM Studio prediction fragment to an OpenAI-compatible chunk."""
+        model = kwargs.get("model", "unknown")
+        response_id = kwargs.get("response_id", f"chatcmpl-{uuid.uuid4()}")
+        return create_chunk_from_fragment(response, model, response_id)
+
+    @staticmethod
+    @override
+    def _convert_embedding_params(params: Any, **kwargs: Any) -> dict[str, Any]:
+        converted_params = {"input": params}
+        converted_params.update(kwargs)
+        return converted_params
+
+    @staticmethod
+    @override
+    def _convert_embedding_response(response: Any) -> CreateEmbeddingResponse:
+        """Convert normalized embedding output ({"model", "vectors"}) to OpenAI format."""
+        return create_embedding_response(response["model"], response["vectors"])
+
+    @staticmethod
+    @override
+    def _convert_list_models_response(response: Any) -> Sequence[Model]:
+        return convert_models_list(response)
+
+    async def _stream_completion(
+        self,
+        params: CompletionParams,
+        config: dict[str, Any],
+        response_format: dict[str, Any] | None,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        chat = self._build_chat(params.messages)
+        response_id = f"chatcmpl-{uuid.uuid4()}"
+
+        async with AsyncClient(api_host=self.api_host) as client:
+            model = await client.llm.model(params.model_id)
+            prediction_stream = await model.respond_stream(
+                chat,
+                config=cast("Any", config or None),
+                response_format=response_format,
+            )
+            async for fragment in prediction_stream:
+                yield create_chunk_from_fragment(fragment, params.model_id, response_id)
+            result = prediction_stream.result()
+            yield create_final_chunk(result, params.model_id, response_id)
+
+    @override
+    async def _acompletion(
+        self,
+        params: CompletionParams,
+        **kwargs: Any,
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if params.tools:
+            msg = (
+                "The LM Studio provider uses the native lmstudio-python SDK, which does not support "
+                "OpenAI-style tool calling (returning tool calls without executing them). "
+                "Tool use is only available via the SDK's agentic `.act()` API, which is not exposed here."
+            )
+            raise NotImplementedError(msg)
+
+        config = self._convert_completion_params(params, **kwargs)
+        response_format = self._resolve_response_format(params)
+
+        if params.stream:
+            return self._stream_completion(params, config, response_format)
+
+        chat = self._build_chat(params.messages)
+        async with AsyncClient(api_host=self.api_host) as client:
+            model = await client.llm.model(params.model_id)
+            result = await model.respond(
+                chat,
+                config=cast("Any", config or None),
+                response_format=response_format,
+            )
+        return create_completion_from_prediction(result, params.model_id)
+
+    @override
+    async def _aembedding(
+        self,
+        model: str,
+        inputs: str | list[str],
+        **kwargs: Any,
+    ) -> CreateEmbeddingResponse:
+        async with AsyncClient(api_host=self.api_host) as client:
+            embedding_model = await client.embedding.model(model)
+            result = await embedding_model.embed(inputs)
+
+        if isinstance(inputs, str):
+            vectors = [list(cast("Sequence[float]", result))]
+        else:
+            vectors = [list(vector) for vector in cast("Sequence[Sequence[float]]", result)]
+        return create_embedding_response(model, vectors)
+
+    @override
+    async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
+        async with AsyncClient(api_host=self.api_host) as client:
+            downloaded = await client.list_downloaded_models()
+        return convert_models_list(downloaded)

--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -131,7 +131,7 @@ class LmstudioProvider(AnyLLM):
         config: dict[str, Any] = {}
         if params.temperature is not None:
             config["temperature"] = params.temperature
-        max_tokens = params.max_completion_tokens or params.max_tokens
+        max_tokens = params.max_completion_tokens if params.max_completion_tokens is not None else params.max_tokens
         if max_tokens is not None:
             config["maxTokens"] = max_tokens
         if params.top_p is not None:

--- a/src/any_llm/providers/lmstudio/utils.py
+++ b/src/any_llm/providers/lmstudio/utils.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
+    ChoiceDelta,
+    ChunkChoice,
+    CompletionUsage,
+    CreateEmbeddingResponse,
+    Embedding,
+    Reasoning,
+    Usage,
+)
+from any_llm.types.model import Model
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from lmstudio import (
+        AnyAsyncDownloadedModel,
+        LlmPredictionFragment,
+        LlmPredictionStats,
+        PredictionResult,
+    )
+
+OpenAIFinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
+
+# Map LM Studio stop reasons to the OpenAI-style finish reasons any-llm exposes.
+# https://lmstudio.ai/docs/python (LlmPredictionStopReason)
+_STOP_REASON_MAP: dict[str, OpenAIFinishReason] = {
+    "eosFound": "stop",
+    "stopStringFound": "stop",
+    "userStopped": "stop",
+    "modelUnloaded": "stop",
+    "failed": "stop",
+    "toolCalls": "tool_calls",
+    "maxPredictedTokensReached": "length",
+    "contextLengthReached": "length",
+}
+
+
+def _map_stop_reason(stop_reason: str | None) -> OpenAIFinishReason:
+    if stop_reason is None:
+        return "stop"
+    return _STOP_REASON_MAP.get(stop_reason, "stop")
+
+
+def _usage_from_stats(stats: LlmPredictionStats | None) -> CompletionUsage:
+    prompt_tokens = int(stats.prompt_tokens_count or 0) if stats else 0
+    completion_tokens = int(stats.predicted_tokens_count or 0) if stats else 0
+    total_tokens = int(stats.total_tokens_count or 0) if stats else 0
+    if not total_tokens:
+        total_tokens = prompt_tokens + completion_tokens
+    return CompletionUsage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _split_reasoning_from_content(content: str) -> tuple[str, str | None]:
+    """Extract reasoning wrapped in <think></think> tags from the content (if present)."""
+    if "<think>" in content and "</think>" in content:
+        reasoning = content.split("<think>", 1)[1].split("</think>", 1)[0]
+        remainder = content.split("</think>", 1)[1]
+        return remainder, reasoning
+    return content, None
+
+
+def create_completion_from_prediction(result: PredictionResult, model: str) -> ChatCompletion:
+    """Convert an LM Studio PredictionResult into an OpenAI-compatible ChatCompletion."""
+    content, reasoning_content = _split_reasoning_from_content(result.content)
+
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=content,
+        reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
+    )
+    choice = Choice(
+        index=0,
+        finish_reason=_map_stop_reason(result.stats.stop_reason if result.stats else None),
+        message=message,
+    )
+    return ChatCompletion(
+        id=f"chatcmpl-{uuid.uuid4()}",
+        model=model,
+        created=int(time.time()),
+        object="chat.completion",
+        choices=[choice],
+        usage=_usage_from_stats(result.stats),
+    )
+
+
+def create_chunk_from_fragment(
+    fragment: LlmPredictionFragment,
+    model: str,
+    response_id: str,
+) -> ChatCompletionChunk:
+    """Convert a streaming LM Studio prediction fragment into an OpenAI-compatible chunk."""
+    if fragment.reasoning_type == "reasoning":
+        delta = ChoiceDelta(role="assistant", reasoning=Reasoning(content=fragment.content))
+    elif fragment.reasoning_type in ("reasoningStartTag", "reasoningEndTag"):
+        # The tag delimiters carry no user-facing content of their own.
+        delta = ChoiceDelta(role="assistant")
+    else:
+        delta = ChoiceDelta(role="assistant", content=fragment.content)
+
+    return ChatCompletionChunk(
+        id=response_id,
+        choices=[ChunkChoice(index=0, delta=delta, finish_reason=None)],
+        created=int(time.time()),
+        model=model,
+        object="chat.completion.chunk",
+    )
+
+
+def create_final_chunk(result: PredictionResult, model: str, response_id: str) -> ChatCompletionChunk:
+    """Emit a terminal chunk carrying the finish reason and usage statistics."""
+    return ChatCompletionChunk(
+        id=response_id,
+        choices=[
+            ChunkChoice(
+                index=0,
+                delta=ChoiceDelta(),
+                finish_reason=_map_stop_reason(result.stats.stop_reason if result.stats else None),
+            )
+        ],
+        created=int(time.time()),
+        model=model,
+        object="chat.completion.chunk",
+        usage=_usage_from_stats(result.stats),
+    )
+
+
+def create_embedding_response(model: str, vectors: list[list[float]]) -> CreateEmbeddingResponse:
+    """Convert LM Studio embedding vectors into an OpenAI-compatible CreateEmbeddingResponse."""
+    data = [Embedding(embedding=vector, index=index, object="embedding") for index, vector in enumerate(vectors)]
+    return CreateEmbeddingResponse(
+        data=data,
+        model=model,
+        object="list",
+        usage=Usage(prompt_tokens=0, total_tokens=0),
+    )
+
+
+def convert_models_list(downloaded_models: Sequence[AnyAsyncDownloadedModel]) -> list[Model]:
+    """Convert LM Studio downloaded-model listings into OpenAI-compatible Model entries."""
+    return [
+        Model(
+            id=cast("Any", model).model_key,
+            object="model",
+            created=0,
+            owned_by="lmstudio",
+        )
+        for model in downloaded_models
+    ]

--- a/src/any_llm/providers/lmstudio/utils.py
+++ b/src/any_llm/providers/lmstudio/utils.py
@@ -65,11 +65,15 @@ def _usage_from_stats(stats: LlmPredictionStats | None) -> CompletionUsage:
 
 
 def _split_reasoning_from_content(content: str) -> tuple[str, str | None]:
-    """Extract reasoning wrapped in <think></think> tags from the content (if present)."""
+    """Extract reasoning wrapped in <think></think> tags from the content (if present).
+
+    Any text before the opening tag or after the closing tag is preserved as content,
+    so a model that emits a preface before its reasoning block does not lose output.
+    """
     if "<think>" in content and "</think>" in content:
-        reasoning = content.split("<think>", 1)[1].split("</think>", 1)[0]
-        remainder = content.split("</think>", 1)[1]
-        return remainder, reasoning
+        before, after_open = content.split("<think>", 1)
+        reasoning, after_close = after_open.split("</think>", 1)
+        return before + after_close, reasoning
     return content, None
 
 

--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -307,7 +307,7 @@ async def test_acompletion_with_tools_raises() -> None:
             CompletionParams(
                 model_id="m",
                 messages=[{"role": "user", "content": "weather?"}],
-                tools=[{"type": "function", "function": {"name": "get_weather"}}],
+                tools=[get_weather],
             )
         )
 
@@ -382,3 +382,15 @@ def test_convert_models_list_helper() -> None:
 )
 def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
     assert utils._map_stop_reason(stop_reason) == expected
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_content", "expected_reasoning"),
+    [
+        ("<think>because</think>final", "final", "because"),
+        ("preface <think>because</think> final", "preface  final", "because"),
+        ("no tags here", "no tags here", None),
+    ],
+)
+def test_split_reasoning_from_content(content: str, expected_content: str, expected_reasoning: str | None) -> None:
+    assert utils._split_reasoning_from_content(content) == (expected_content, expected_reasoning)

--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -1,22 +1,108 @@
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
 from any_llm import AnyLLM
+from any_llm.providers.lmstudio import utils
 from any_llm.providers.lmstudio.lmstudio import LmstudioProvider
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    CompletionParams,
+    CreateEmbeddingResponse,
+)
+
+
+def _make_stats(
+    *,
+    prompt: int = 10,
+    predicted: int = 5,
+    total: int = 15,
+    stop_reason: str = "eosFound",
+) -> Mock:
+    stats = Mock()
+    stats.prompt_tokens_count = prompt
+    stats.predicted_tokens_count = predicted
+    stats.total_tokens_count = total
+    stats.stop_reason = stop_reason
+    return stats
+
+
+def _make_prediction_result(content: str = "Hello there", model_key: str = "qwen3-0.6b") -> Mock:
+    result = Mock()
+    result.content = content
+    result.stats = _make_stats()
+    result.model_info = Mock()
+    result.model_info.model_key = model_key
+    return result
+
+
+class _FakeStream:
+    """Minimal async-iterable stand-in for lmstudio's AsyncPredictionStream."""
+
+    def __init__(self, fragments: list[Mock], result: Mock) -> None:
+        self._fragments = fragments
+        self._result = result
+
+    async def __aiter__(self) -> AsyncIterator[Mock]:
+        for fragment in self._fragments:
+            yield fragment
+
+    def result(self) -> Mock:
+        return self._result
+
+
+def _patch_async_client(inner_client: Mock) -> Any:
+    """Patch AsyncClient so `async with AsyncClient(...)` yields ``inner_client``."""
+    client_cm = Mock()
+    client_cm.__aenter__ = AsyncMock(return_value=inner_client)
+    client_cm.__aexit__ = AsyncMock(return_value=None)
+    return patch(
+        "any_llm.providers.lmstudio.lmstudio.AsyncClient",
+        return_value=client_cm,
+    )
 
 
 def test_provider_basics() -> None:
     """Test provider instantiation and basic attributes."""
-    p = LmstudioProvider(api_key="sk-test")
+    p = LmstudioProvider()
     assert p.PROVIDER_NAME == "lmstudio"
-    assert p.API_BASE == "http://localhost:1234/v1"
+    assert p.api_host == "localhost:1234"
     assert p.SUPPORTS_COMPLETION is True
     assert p.SUPPORTS_COMPLETION_STREAMING is True
     assert p.SUPPORTS_COMPLETION_REASONING is True
-    assert p.SUPPORTS_RESPONSES is True
+    assert p.SUPPORTS_EMBEDDING is True
+    assert p.SUPPORTS_LIST_MODELS is True
+    assert p.SUPPORTS_RESPONSES is False
 
 
 def test_api_key_not_required() -> None:
     """Test that LM Studio does not require an API key."""
     p = LmstudioProvider()
     assert p.PROVIDER_NAME == "lmstudio"
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        ("http://localhost:1234/v1", "localhost:1234"),
+        ("https://example.com:4321/v1", "example.com:4321"),
+        ("ws://10.0.0.2:9999", "10.0.0.2:9999"),
+        ("192.168.0.5:5000", "192.168.0.5:5000"),
+        ("http://localhost:1234/", "localhost:1234"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_normalize_api_host(api_base: str | None, expected: str | None) -> None:
+    assert LmstudioProvider._normalize_api_host(api_base) == expected
+
+
+def test_api_base_override_sets_host() -> None:
+    p = LmstudioProvider(api_base="http://10.0.0.2:9999/v1")
+    assert p.api_host == "10.0.0.2:9999"
 
 
 def test_factory_integration() -> None:
@@ -41,7 +127,258 @@ def test_provider_metadata() -> None:
     metadata = LmstudioProvider.get_provider_metadata()
     assert metadata.name == "lmstudio"
     assert metadata.env_key == "LM_STUDIO_API_KEY"
-    assert metadata.doc_url == "https://lmstudio.ai/"
+    assert metadata.doc_url == "https://lmstudio.ai/docs/python"
     assert metadata.completion is True
     assert metadata.streaming is True
-    assert metadata.responses is True
+    assert metadata.responses is False
+
+
+def test_build_chat_maps_roles() -> None:
+    p = LmstudioProvider()
+    chat = p._build_chat(
+        [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "ignored"}},
+                ],
+            },
+        ]
+    )
+    # 1 system + 3 conversation turns
+    assert len(chat._messages) == 4
+
+
+def test_extract_text_content_variants() -> None:
+    assert LmstudioProvider._extract_text_content(None) == ""
+    assert LmstudioProvider._extract_text_content("plain") == "plain"
+    assert (
+        LmstudioProvider._extract_text_content([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a b"
+    )
+
+
+def test_convert_completion_params_maps_known_fields() -> None:
+    params = CompletionParams(
+        model_id="qwen3-0.6b",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.5,
+        max_tokens=50,
+        top_p=0.9,
+        stop="STOP",
+    )
+    config = LmstudioProvider._convert_completion_params(params)
+    assert config["temperature"] == 0.5
+    assert config["maxTokens"] == 50
+    assert config["topPSampling"] == 0.9
+    assert config["stopStrings"] == ["STOP"]
+
+
+def test_convert_completion_params_stop_list_and_extra_kwargs() -> None:
+    params = CompletionParams(
+        model_id="qwen3-0.6b",
+        messages=[{"role": "user", "content": "hi"}],
+        stop=["a", "b"],
+    )
+    config = LmstudioProvider._convert_completion_params(params, topKSampling=40)
+    assert config["stopStrings"] == ["a", "b"]
+    assert config["topKSampling"] == 40
+
+
+def test_resolve_response_format_dict_passthrough() -> None:
+    params = CompletionParams(
+        model_id="qwen3-0.6b",
+        messages=[{"role": "user", "content": "hi"}],
+        response_format={"type": "json_object"},
+    )
+    assert LmstudioProvider._resolve_response_format(params) == {"type": "json_object"}
+
+
+def test_resolve_response_format_pydantic() -> None:
+    from pydantic import BaseModel
+
+    class Out(BaseModel):
+        name: str
+
+    params = CompletionParams(
+        model_id="qwen3-0.6b",
+        messages=[{"role": "user", "content": "hi"}],
+        response_format=Out,
+    )
+    schema = LmstudioProvider._resolve_response_format(params)
+    assert isinstance(schema, dict)
+    assert "properties" in schema
+    assert "name" in schema["properties"]
+
+
+def test_resolve_response_format_none() -> None:
+    params = CompletionParams(model_id="m", messages=[{"role": "user", "content": "hi"}])
+    assert LmstudioProvider._resolve_response_format(params) is None
+
+
+@pytest.mark.asyncio
+async def test_acompletion_non_stream() -> None:
+    provider = LmstudioProvider()
+
+    model_handle = Mock()
+    model_handle.respond = AsyncMock(return_value=_make_prediction_result())
+    inner_client = Mock()
+    inner_client.llm.model = AsyncMock(return_value=model_handle)
+
+    with _patch_async_client(inner_client):
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="qwen3-0.6b",
+                messages=[{"role": "user", "content": "Hello"}],
+                temperature=0.2,
+            )
+        )
+
+    assert isinstance(result, ChatCompletion)
+    assert result.choices[0].message.content == "Hello there"
+    inner_client.llm.model.assert_awaited_once_with("qwen3-0.6b")
+    call_kwargs = model_handle.respond.call_args.kwargs
+    assert call_kwargs["config"] == {"temperature": 0.2}
+
+
+@pytest.mark.asyncio
+async def test_acompletion_extracts_reasoning() -> None:
+    provider = LmstudioProvider()
+
+    model_handle = Mock()
+    model_handle.respond = AsyncMock(return_value=_make_prediction_result(content="<think>because</think>final"))
+    inner_client = Mock()
+    inner_client.llm.model = AsyncMock(return_value=model_handle)
+
+    with _patch_async_client(inner_client):
+        result = await provider._acompletion(
+            CompletionParams(model_id="m", messages=[{"role": "user", "content": "Hello"}])
+        )
+
+    assert isinstance(result, ChatCompletion)
+    assert result.choices[0].message.content == "final"
+    assert result.choices[0].message.reasoning is not None
+    assert result.choices[0].message.reasoning.content == "because"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming() -> None:
+    provider = LmstudioProvider()
+
+    frag_reasoning = Mock(reasoning_type="reasoning", content="thinking")
+    frag_content = Mock(reasoning_type="none", content="hello")
+    stream = _FakeStream([frag_reasoning, frag_content], _make_prediction_result())
+
+    model_handle = Mock()
+    model_handle.respond_stream = AsyncMock(return_value=stream)
+    inner_client = Mock()
+    inner_client.llm.model = AsyncMock(return_value=model_handle)
+
+    with _patch_async_client(inner_client):
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="m",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+            )
+        )
+        chunks = [chunk async for chunk in result]  # type: ignore[union-attr]
+
+    assert all(isinstance(chunk, ChatCompletionChunk) for chunk in chunks)
+    # reasoning fragment + content fragment + final chunk
+    assert len(chunks) == 3
+    assert chunks[0].choices[0].delta.reasoning is not None
+    assert chunks[1].choices[0].delta.content == "hello"
+    assert chunks[2].choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_tools_raises() -> None:
+    provider = LmstudioProvider()
+
+    def get_weather(location: str) -> str:
+        return "sunny"
+
+    with pytest.raises(NotImplementedError, match="tool calling"):
+        await provider._acompletion(
+            CompletionParams(
+                model_id="m",
+                messages=[{"role": "user", "content": "weather?"}],
+                tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_aembedding_single_string() -> None:
+    provider = LmstudioProvider()
+
+    embedding_handle = Mock()
+    embedding_handle.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    inner_client = Mock()
+    inner_client.embedding.model = AsyncMock(return_value=embedding_handle)
+
+    with _patch_async_client(inner_client):
+        response = await provider._aembedding("nomic-embed", "hello")
+
+    assert isinstance(response, CreateEmbeddingResponse)
+    assert len(response.data) == 1
+    assert response.data[0].embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_aembedding_list_input() -> None:
+    provider = LmstudioProvider()
+
+    embedding_handle = Mock()
+    embedding_handle.embed = AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
+    inner_client = Mock()
+    inner_client.embedding.model = AsyncMock(return_value=embedding_handle)
+
+    with _patch_async_client(inner_client):
+        response = await provider._aembedding("nomic-embed", ["a", "b"])
+
+    assert len(response.data) == 2
+    assert response.data[1].index == 1
+    assert response.data[1].embedding == [0.3, 0.4]
+
+
+@pytest.mark.asyncio
+async def test_alist_models() -> None:
+    provider = LmstudioProvider()
+
+    inner_client = Mock()
+    inner_client.list_downloaded_models = AsyncMock(
+        return_value=[Mock(model_key="qwen3-0.6b"), Mock(model_key="nomic-embed")]
+    )
+
+    with _patch_async_client(inner_client):
+        models = await provider._alist_models()
+
+    assert [m.id for m in models] == ["qwen3-0.6b", "nomic-embed"]
+    assert all(m.owned_by == "lmstudio" for m in models)
+
+
+def test_convert_models_list_helper() -> None:
+    models = utils.convert_models_list([Mock(model_key="a"), Mock(model_key="b")])
+    assert [m.id for m in models] == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("eosFound", "stop"),
+        ("stopStringFound", "stop"),
+        ("userStopped", "stop"),
+        ("maxPredictedTokensReached", "length"),
+        ("contextLengthReached", "length"),
+        ("toolCalls", "tool_calls"),
+        ("unknown-reason", "stop"),
+        (None, "stop"),
+    ],
+)
+def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
+    assert utils._map_stop_reason(stop_reason) == expected


### PR DESCRIPTION
## Description

Backs the `LMSTUDIO` provider with the native [`lmstudio-python`](https://lmstudio.ai/docs/python) SDK instead of inheriting from the OpenAI-compatible base provider.

The provider now subclasses `AnyLLM` directly and talks LM Studio's websocket protocol via `lmstudio.AsyncClient`. Because the async client requires structured concurrency (`async with AsyncClient(...)` opens websocket sessions eagerly and forbids implicit lazy connection), a fresh client is opened for the duration of each request rather than reused across calls.

**Supported capabilities**
- Completion (non-streaming + streaming)
- Reasoning, separated from content via the fragment `reasoning_type` and `<think>` extraction
- Structured output (`response_format`)
- Embeddings
- Listing downloaded models (an improvement over the REST `/v1/models`, which only lists *loaded* models)

**Consequences of moving to the native SDK** (vs. the OpenAI REST endpoint)
- **OpenAI-style tool calling is no longer supported.** The SDK only exposes the agentic `.act()` API (which *executes* tools in a loop); it cannot return tool-call requests without executing them. Passing `tools` now raises `NotImplementedError` rather than silently misbehaving.
- The **Responses API**, **moderation**, and **batch** are no longer advertised (`SUPPORTS_RESPONSES`/`SUPPORTS_MODERATION`/`SUPPORTS_BATCH = False`).
- Image/PDF input are disabled for now (text-only message conversion); these could be added later via the SDK's `prepare_image` file handles.
- `LM_STUDIO_API_BASE` URLs are normalized to a bare `host:port` (e.g. `http://localhost:1234/v1` -> `localhost:1234`).

Adds `lmstudio>=1.5.0` as the `lmstudio` extra dependency (1.5.0 is the first release with full async API support).

## PR Type

- 🆕 New Feature

## Relevant issues

Closes #443

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

### Testing notes
- `uv run pytest tests/unit` passes (1277 passed, 64 skipped); the rewritten `tests/unit/providers/test_lmstudio_provider.py` (36 tests) mocks `AsyncClient` to cover message/Chat conversion, config mapping, response + reasoning conversion, streaming, embeddings, list-models, and the tools-not-supported path.
- `uv run pre-commit run --all-files` passes (ruff, ruff-format, mypy strict, codespell) across all 242 source files.
- Integration tests (`tests/integration`) require a running LM Studio server and were **not** executed in this environment; a maintainer run against a live server is recommended before merge. Existing integration tests already skip LMSTUDIO for tools/agent-loop, image/PDF, and exempt it from the embedding token-count assertion, and `test_responses.py` skips it now that `SUPPORTS_RESPONSES` is `False`.

## AI Usage Information

- AI Model used: claude-opus-4-8
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: SDK behavior (field names, async client lifecycle, tool-calling limits) was verified by introspecting the installed `lmstudio` 1.5.0 package and reading its async source.

- [x] I am an AI Agent filling out this form (check box if true)
