### PR TITLE
fix(bedrock): coerce empty tool description to non-empty string

### DIFF
--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -88,7 +88,7 @@ def _convert_tool_spec(tools: list[dict[str, Any]], tool_choice: str | dict[str,
             {
                 "toolSpec": {
                     "name": tool["function"]["name"],
-                    "description": tool["function"].get("description", " "),
+                    "description": tool["function"].get("description") or " ",
                     "inputSchema": {"json": tool["function"].get("parameters") or {"type": "object", "properties": {}}},
                 }
             }

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -768,3 +768,25 @@ def test_convert_tool_spec_with_parameters() -> None:
         tool_choice=None,
     )
     assert tool_config["tools"][0]["toolSpec"]["inputSchema"]["json"] == params
+
+
+def test_convert_tool_spec_empty_description() -> None:
+    """Regression: an empty description ("") must be coerced to a non-empty string.
+
+    Bedrock's Converse API requires toolSpec.description to have a minimum length of 1.
+    LangChain serializes tools without a docstring as ``"description": ""``; ``.get(default)``
+    only fires when the key is missing, so the empty string must be coerced explicitly.
+    """
+    # (a) description present but empty -> coerced to " "
+    tool_config = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "ping", "description": "", "parameters": None}}],
+        tool_choice=None,
+    )
+    assert tool_config["tools"][0]["toolSpec"]["description"] == " "
+
+    # (b) description key missing -> existing behaviour preserved
+    tool_config = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "ping", "parameters": None}}],
+        tool_choice=None,
+    )
+    assert tool_config["tools"][0]["toolSpec"]["description"] == " "


### PR DESCRIPTION
## Description

Closes #1101.

Binding a tool with an empty description string (`""`) to the AWS Bedrock provider raises `botocore.exceptions.ParamValidationError`:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter toolConfig.tools[0].toolSpec.description, value: 0, valid min length: 1
```

This is the default shape for LangChain tools without a docstring — `convert_to_openai_tool` serializes them with `"description": ""` (key present, value empty).

### Root cause

In `src/any_llm/providers/bedrock/utils.py`, `_convert_tool_spec` used:

```python
"description": tool["function"].get("description", " "),
```

`dict.get(key, default)` only returns the default when the key is **absent**. LangChain includes the `description` key with an empty string, so the existing `" "` fallback never fired and `""` passed straight through to boto3. Bedrock's Converse API requires `toolSpec.description` to have a minimum length of 1.

### Fix

```python
"description": tool["function"].get("description") or " ",
```

One line. `or " "` coerces both a missing key **and** an empty string to `" "`, completing the non-empty-description sanitisation the original `" "` default already intended.

**Bedrock-only by design.** The other providers (`anthropic`, `gemini`, `azure`, `xai`) intentionally default to `""` because their APIs accept empty/missing descriptions — Bedrock is the only one requiring length ≥ 1, which is why it is the only provider with a `" "` default. The other converters are left untouched.

### Testing

- New unit test `test_convert_tool_spec_empty_description` in `tests/unit/providers/test_aws_provider.py`, following the existing `test_convert_tool_spec_*` style. Covers both the empty-string case (the bug) and the missing-key case (regression guard). No AWS calls.
- Verified the bug reproduces and the fix resolves it **client-side** via botocore parameter validation (which validates before signing/sending), using fake credentials — the exact `ParamValidationError` above is raised without the fix and the request passes parameter validation with it. **No live Bedrock round-trip was performed** (no AWS credentials available in this environment).
- `ruff format --check`, `ruff check`, `mypy` all clean on both changed files.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1101

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Anthropic)
- AI Developer Tool used: Claude Code. The fix and regression test were written by Claude Code under interactive, edit-by-edit human review (no autonomous commits). Issue triage, root-cause analysis, the client-side botocore reproduction, and the provider-consistency decision (Bedrock-only) were directed and verified by me. I understand and stand behind every line submitted.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
