### PR TITLE
feat(responses): support structured outputs via response_format

### DIFF
--- a/src/any_llm/__init__.py
+++ b/src/any_llm/__init__.py
@@ -53,6 +53,7 @@ from any_llm.exceptions import (
 from any_llm.types.audio import AudioSpeechParams, AudioTranscriptionParams, Transcription, TranscriptionVerbose
 from any_llm.types.batch import Batch, BatchRequestCounts, BatchResult, BatchResultError, BatchResultItem
 from any_llm.types.completion import ParsedChatCompletion, ParsedChatCompletionMessage, ParsedChoice
+from any_llm.types.responses import ParsedResponse
 
 try:
     __version__ = version("any-llm-sdk")
@@ -83,6 +84,7 @@ __all__ = [
     "ParsedChatCompletion",
     "ParsedChatCompletionMessage",
     "ParsedChoice",
+    "ParsedResponse",
     "ProviderError",
     "RateLimitError",
     "Transcription",

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -38,10 +38,20 @@ from any_llm.types.messages import (
     MessageStreamEvent,
 )
 from any_llm.types.provider import ProviderMetadata
-from any_llm.types.responses import Response, ResponseInputParam, ResponsesParams, ResponseStreamEvent
+from any_llm.types.responses import (
+    ParsedResponse,
+    Response,
+    ResponseInputParam,
+    ResponsesParams,
+    ResponseStreamEvent,
+)
 from any_llm.utils.aio import async_coro_to_sync_iter, async_iter_to_sync_iter, run_async_in_sync
 from any_llm.utils.exception_handler import handle_exceptions
-from any_llm.utils.structured_output import is_structured_output_type, parse_json_content
+from any_llm.utils.structured_output import (
+    is_structured_output_type,
+    parse_json_content,
+    parse_responses_output,
+)
 
 ResponseFormatT = TypeVar("ResponseFormatT", bound=BaseModel)
 
@@ -777,7 +787,53 @@ class AnyLLM(ABC):
 
         return convert_stream()
 
-    def responses(self, **kwargs: Any) -> ResponseResource | Response | Iterator[ResponseStreamEvent]:
+    # Overloads let type checkers narrow the return type based on response_format and stream.
+    @overload
+    def responses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: type[ResponseFormatT],
+        stream: Literal[False] | None = ...,
+        **kwargs: Any,
+    ) -> ParsedResponse[ResponseFormatT]: ...
+
+    @overload
+    def responses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        stream: Literal[True],
+        **kwargs: Any,
+    ) -> Iterator[ResponseStreamEvent]: ...
+
+    @overload
+    def responses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: dict[str, Any] | None = ...,
+        stream: Literal[False] | None = ...,
+        **kwargs: Any,
+    ) -> ResponseResource | Response: ...
+
+    @overload
+    def responses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: dict[str, Any] | type | None = ...,
+        stream: bool | None = ...,
+        **kwargs: Any,
+    ) -> ResponseResource | Response | Iterator[ResponseStreamEvent] | ParsedResponse[Any]: ...
+
+    def responses(
+        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+    ) -> ResponseResource | Response | Iterator[ResponseStreamEvent] | ParsedResponse[Any]:
         """Create a response synchronously.
 
         See [AnyLLM.aresponses][any_llm.any_llm.AnyLLM.aresponses]
@@ -785,14 +841,63 @@ class AnyLLM(ABC):
         allow_running_loop = kwargs.pop("allow_running_loop", INSIDE_NOTEBOOK)
         if kwargs.get("stream"):
             return async_coro_to_sync_iter(
-                cast("Coroutine[Any, Any, AsyncIterator[ResponseStreamEvent]]", self.aresponses(**kwargs)),
+                cast(
+                    "Coroutine[Any, Any, AsyncIterator[ResponseStreamEvent]]",
+                    self.aresponses(model, input_data, **kwargs),
+                ),
                 allow_running_loop=allow_running_loop,
             )
 
-        response = run_async_in_sync(self.aresponses(**kwargs), allow_running_loop=allow_running_loop)
+        response = run_async_in_sync(
+            self.aresponses(model, input_data, **kwargs), allow_running_loop=allow_running_loop
+        )
         if isinstance(response, (ResponseResource, Response)):
             return response
         return async_iter_to_sync_iter(response, allow_running_loop=allow_running_loop)
+
+    # Overloads let type checkers narrow the return type based on response_format and stream.
+    @overload
+    async def aresponses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: type[ResponseFormatT],
+        stream: Literal[False] | None = ...,
+        **kwargs: Any,
+    ) -> ParsedResponse[ResponseFormatT]: ...
+
+    @overload
+    async def aresponses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        stream: Literal[True],
+        **kwargs: Any,
+    ) -> AsyncIterator[ResponseStreamEvent]: ...
+
+    @overload
+    async def aresponses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: dict[str, Any] | None = ...,
+        stream: Literal[False] | None = ...,
+        **kwargs: Any,
+    ) -> ResponseResource | Response: ...
+
+    @overload
+    async def aresponses(
+        self,
+        model: str,
+        input_data: str | ResponseInputParam,
+        *,
+        response_format: dict[str, Any] | type | None = ...,
+        stream: bool | None = ...,
+        **kwargs: Any,
+    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent] | ParsedResponse[Any]: ...
 
     @handle_exceptions(wrap_streaming=True)
     async def aresponses(
@@ -811,6 +916,7 @@ class AnyLLM(ABC):
         parallel_tool_calls: bool | None = None,
         reasoning: Any | None = None,
         text: Any | None = None,
+        response_format: dict[str, Any] | type | None = None,
         presence_penalty: float | None = None,
         frequency_penalty: float | None = None,
         truncation: str | None = None,
@@ -826,7 +932,7 @@ class AnyLLM(ABC):
         prompt_cache_retention: str | None = None,
         conversation: str | dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent] | ParsedResponse[Any]:
         """Create a response using the OpenResponses API.
 
         This implements the OpenResponses specification and returns either
@@ -850,6 +956,10 @@ class AnyLLM(ABC):
             parallel_tool_calls: Whether to allow the model to run tool calls in parallel.
             reasoning: Configuration options for reasoning models.
             text: Configuration options for a text response from the model. Can be plain text or structured JSON data.
+            response_format: Structured-output type. When a Pydantic ``BaseModel`` or dataclass is passed, the
+                response is parsed and returned as a ``ParsedResponse`` whose ``output_parsed`` holds the typed
+                object (the Responses-API analogue of ``client.responses.parse``). A raw OpenAI ``text.format``
+                dict is also accepted and passed through unparsed.
             presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
             frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
             truncation: Controls how the service truncates input when it exceeds the model context window.
@@ -868,13 +978,19 @@ class AnyLLM(ABC):
 
         Returns:
             Either a `ResponseResource` object (OpenResponses-compliant providers),
-            a `Response` object (non-compliant providers), or an iterator of
+            a `Response` object (non-compliant providers), a `ParsedResponse` (when a
+            structured `response_format` type is given), or an iterator of
             `ResponseStreamEvent` (streaming).
 
         Raises:
             NotImplementedError: If the selected provider does not support the Responses API.
+            ValueError: If a structured `response_format` is combined with `stream=True`.
 
         """
+        if is_structured_output_type(response_format) and stream:
+            msg = "stream is not supported for response_format"
+            raise ValueError(msg)
+
         prepared_tools = None
         if tools:
             prepared_tools = prepare_tools(tools, built_in_tools=self.BUILT_IN_TOOLS)
@@ -893,6 +1009,7 @@ class AnyLLM(ABC):
             parallel_tool_calls=parallel_tool_calls,
             reasoning=reasoning,
             text=text,
+            response_format=response_format,
             presence_penalty=presence_penalty,
             frequency_penalty=frequency_penalty,
             truncation=truncation,
@@ -910,7 +1027,19 @@ class AnyLLM(ABC):
             **kwargs,
         )
 
-        return await self._aresponses(params)
+        result = await self._aresponses(params)
+
+        if is_structured_output_type(response_format):
+            # OpenAI-SDK providers return a ParsedResponse directly (via responses.parse);
+            # other providers return a raw Response/ResponseResource that we parse here.
+            if isinstance(result, ParsedResponse):
+                return result
+            if isinstance(result, (Response, ResponseResource)):
+                parsed = parse_responses_output(result, response_format)
+                if parsed is not None:
+                    return parsed
+
+        return result
 
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -851,6 +851,7 @@ class AnyLLM(ABC):
         response = run_async_in_sync(
             self.aresponses(model, input_data, **kwargs), allow_running_loop=allow_running_loop
         )
+        # ParsedResponse (structured output) is a subclass of Response, so it is covered here.
         if isinstance(response, (ResponseResource, Response)):
             return response
         return async_iter_to_sync_iter(response, allow_running_loop=allow_running_loop)
@@ -1043,7 +1044,7 @@ class AnyLLM(ABC):
 
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any
-    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+    ) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
         if not self.SUPPORTS_RESPONSES:
             msg = "Provider doesn't support responses."
             raise NotImplementedError(msg)

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -19,7 +19,7 @@ from any_llm.types.messages import MessageResponse, MessageStreamEvent
 from any_llm.types.model import Model
 from any_llm.types.moderation import ModerationResponse
 from any_llm.types.rerank import RerankResponse
-from any_llm.types.responses import Response, ResponseInputParam, ResponseStreamEvent
+from any_llm.types.responses import ParsedResponse, Response, ResponseInputParam, ResponseStreamEvent
 
 
 def completion(
@@ -258,6 +258,7 @@ def responses(
     parallel_tool_calls: bool | None = None,
     reasoning: Any | None = None,
     text: Any | None = None,
+    response_format: dict[str, Any] | type | None = None,
     presence_penalty: float | None = None,
     frequency_penalty: float | None = None,
     truncation: str | None = None,
@@ -274,12 +275,13 @@ def responses(
     conversation: str | dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
-) -> ResponseResource | Response | Iterator[ResponseStreamEvent]:
+) -> ResponseResource | Response | ParsedResponse[Any] | Iterator[ResponseStreamEvent]:
     """Create a response using the OpenResponses API.
 
     This implements the OpenResponses specification and returns either
     `openresponses_types.ResponseResource` (for OpenResponses-compliant providers)
     or `openai.types.responses.Response` (for providers using OpenAI's native API).
+    If a structured `response_format` type is given, a `ParsedResponse` (with `output_parsed`) is returned.
     If `stream=True`, an iterator of `any_llm.types.responses.ResponseStreamEvent` items is returned.
 
     Args:
@@ -304,6 +306,9 @@ def responses(
         parallel_tool_calls: Whether to allow the model to run tool calls in parallel.
         reasoning: Configuration options for reasoning models.
         text: Configuration options for a text response from the model. Can be plain text or structured JSON data.
+        response_format: Structured-output type. A Pydantic ``BaseModel`` or dataclass returns a ``ParsedResponse``
+            with the parsed object in ``output_parsed`` (the analogue of ``client.responses.parse``); a raw
+            ``text.format`` dict is passed through unparsed.
         presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
         frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
         truncation: Controls how the service truncates input when it exceeds the model context window.
@@ -356,6 +361,7 @@ def responses(
         parallel_tool_calls=parallel_tool_calls,
         reasoning=reasoning,
         text=text,
+        response_format=response_format,
         presence_penalty=presence_penalty,
         frequency_penalty=frequency_penalty,
         truncation=truncation,
@@ -392,6 +398,7 @@ async def aresponses(
     parallel_tool_calls: bool | None = None,
     reasoning: Any | None = None,
     text: Any | None = None,
+    response_format: dict[str, Any] | type | None = None,
     presence_penalty: float | None = None,
     frequency_penalty: float | None = None,
     truncation: str | None = None,
@@ -408,12 +415,13 @@ async def aresponses(
     conversation: str | dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
-) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
     """Create a response using the OpenResponses API.
 
     This implements the OpenResponses specification and returns either
     `openresponses_types.ResponseResource` (for OpenResponses-compliant providers)
     or `openai.types.responses.Response` (for providers using OpenAI's native API).
+    If a structured `response_format` type is given, a `ParsedResponse` (with `output_parsed`) is returned.
     If `stream=True`, an iterator of `any_llm.types.responses.ResponseStreamEvent` items is returned.
 
     Args:
@@ -438,6 +446,9 @@ async def aresponses(
         parallel_tool_calls: Whether to allow the model to run tool calls in parallel.
         reasoning: Configuration options for reasoning models.
         text: Configuration options for a text response from the model. Can be plain text or structured JSON data.
+        response_format: Structured-output type. A Pydantic ``BaseModel`` or dataclass returns a ``ParsedResponse``
+            with the parsed object in ``output_parsed`` (the analogue of ``client.responses.parse``); a raw
+            ``text.format`` dict is passed through unparsed.
         presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
         frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
         truncation: Controls how the service truncates input when it exceeds the model context window.
@@ -490,6 +501,7 @@ async def aresponses(
         parallel_tool_calls=parallel_tool_calls,
         reasoning=reasoning,
         text=text,
+        response_format=response_format,
         presence_penalty=presence_penalty,
         frequency_penalty=frequency_penalty,
         truncation=truncation,

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -328,8 +328,9 @@ def responses(
 
     Returns:
         Either a `ResponseResource` object (OpenResponses-compliant providers),
-        a `Response` object (non-compliant providers), or an iterator of
-        `ResponseStreamEvent` (streaming).
+        a `Response` object (non-compliant providers), a `ParsedResponse` (with
+        `output_parsed`) when a structured `response_format` type is given, or an
+        iterator of `ResponseStreamEvent` (streaming).
 
     Raises:
         NotImplementedError: If the selected provider does not support the Responses API.
@@ -468,8 +469,9 @@ async def aresponses(
 
     Returns:
         Either a `ResponseResource` object (OpenResponses-compliant providers),
-        a `Response` object (non-compliant providers), or an iterator of
-        `ResponseStreamEvent` (streaming).
+        a `Response` object (non-compliant providers), a `ParsedResponse` (with
+        `output_parsed`) when a structured `response_format` type is given, or an
+        iterator of `ResponseStreamEvent` (streaming).
 
     Raises:
         NotImplementedError: If the selected provider does not support the Responses API.

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from openai import AsyncOpenAI, AsyncStream
+from pydantic import BaseModel
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
-from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
+from any_llm.utils.structured_output import (
+    build_responses_text_format,
+    get_json_schema,
+    is_structured_output_type,
+)
 
 if TYPE_CHECKING:
     from openresponses_types import ResponseResource
@@ -179,7 +184,18 @@ class GroqProvider(AnyLLM):
             **self.kwargs,
         )
 
-        response = await client.responses.create(**params.model_dump(exclude_none=True), **kwargs)
+        response_format = params.response_format
+        create_kwargs = params.model_dump(exclude_none=True, exclude={"response_format"})
+
+        if is_structured_output_type(response_format):
+            create_kwargs.pop("text", None)
+            if issubclass(response_format, BaseModel):
+                return await client.responses.parse(text_format=response_format, **create_kwargs, **kwargs)
+            create_kwargs["text"] = build_responses_text_format(response_format)
+        elif isinstance(response_format, dict):
+            create_kwargs["text"] = {"format": response_format}
+
+        response = await client.responses.create(**create_kwargs, **kwargs)
 
         if not isinstance(response, Response | AsyncStream):
             msg = f"Responses API returned an unexpected type: {type(response)}"

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
+from any_llm.types.responses import ParsedResponse, Response, ResponsesParams, ResponseStreamEvent
 from any_llm.utils.structured_output import (
     build_responses_text_format,
     get_json_schema,
@@ -170,7 +170,7 @@ class GroqProvider(AnyLLM):
     @override
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any
-    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+    ) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
         """Call Groq Responses API and normalize into ChatCompletion/Chunks."""
         # Python SDK doesn't yet support it: https://community.groq.com/feature-requests-6/groq-python-sdk-support-for-responses-api-262
 

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     )
 
     from any_llm.types.model import Model
-    from any_llm.types.responses import Response, ResponsesParams
+    from any_llm.types.responses import ParsedResponse, Response, ResponsesParams
 
 
 class HuggingfaceProvider(AnyLLM):
@@ -213,7 +213,7 @@ class HuggingfaceProvider(AnyLLM):
     @override
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any
-    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+    ) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
         """Call OpenResponses API via HuggingFace router.
 
         See: https://huggingface.co/docs/inference-providers/guides/responses-api

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -7,6 +7,7 @@ from openai._streaming import AsyncStream
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import ResponseStreamEvent
 from openresponses_types import ResponseResource
+from pydantic import BaseModel
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
@@ -20,6 +21,7 @@ from any_llm.types.completion import (
     CreateEmbeddingResponse,
     Reasoning,
 )
+from any_llm.utils.structured_output import build_responses_text_format, is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
 try:
@@ -216,11 +218,29 @@ class HuggingfaceProvider(AnyLLM):
 
         See: https://huggingface.co/docs/inference-providers/guides/responses-api
         """
+        response_format = params.response_format
+        create_kwargs = params.model_dump(exclude_none=True, exclude={"response_format"})
+
+        if is_structured_output_type(response_format):
+            create_kwargs.pop("text", None)
+            if issubclass(response_format, BaseModel):
+                return await self.responses_client.responses.parse(
+                    text_format=response_format,
+                    **create_kwargs,
+                    **kwargs,
+                )
+            create_kwargs["text"] = build_responses_text_format(response_format)
+        elif isinstance(response_format, dict):
+            create_kwargs["text"] = {"format": response_format}
+
         response: Response | AsyncStream[ResponseStreamEvent] = await self.responses_client.responses.create(
-            **params.model_dump(exclude_none=True), **kwargs
+            **create_kwargs, **kwargs
         )
 
         if isinstance(response, OpenAIResponse):
+            # Structured output: return the raw Response so the base layer parses it into a ParsedResponse.
+            if is_structured_output_type(response_format):
+                return response
             return ResponseResource.model_validate(response.model_dump(warnings=False))
 
         if isinstance(response, AsyncStream):

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -36,7 +36,7 @@ from any_llm.types.completion import (
 from any_llm.types.image import ImageGenerationParams, ImagesResponse
 from any_llm.types.model import Model
 from any_llm.types.moderation import ModerationResponse
-from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
+from any_llm.types.responses import ParsedResponse, Response, ResponsesParams, ResponseStreamEvent
 from any_llm.utils.structured_output import (
     build_responses_text_format,
     get_json_schema,
@@ -227,7 +227,7 @@ class BaseOpenAIProvider(AnyLLM):
     @override
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any
-    ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
+    ) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
         """Call OpenAI Responses API"""
         response_format = params.response_format
         create_kwargs = params.model_dump(exclude_none=True, exclude={"response_format"})

--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -37,7 +37,11 @@ from any_llm.types.image import ImageGenerationParams, ImagesResponse
 from any_llm.types.model import Model
 from any_llm.types.moderation import ModerationResponse
 from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
-from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
+from any_llm.utils.structured_output import (
+    build_responses_text_format,
+    get_json_schema,
+    is_structured_output_type,
+)
 
 
 class BaseOpenAIProvider(AnyLLM):
@@ -225,11 +229,32 @@ class BaseOpenAIProvider(AnyLLM):
         self, params: ResponsesParams, **kwargs: Any
     ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
         """Call OpenAI Responses API"""
-        response = await self.client.responses.create(**params.model_dump(exclude_none=True), **kwargs)
+        response_format = params.response_format
+        create_kwargs = params.model_dump(exclude_none=True, exclude={"response_format"})
+
+        if is_structured_output_type(response_format):
+            # Pydantic models use the native parse() helper (mirrors chat.completions.parse);
+            # dataclasses request schema-conformant JSON via text.format and are parsed by the base layer.
+            create_kwargs.pop("text", None)
+            if issubclass(response_format, BaseModel):
+                return await self.client.responses.parse(
+                    text_format=response_format,
+                    **create_kwargs,
+                    **kwargs,
+                )
+            create_kwargs["text"] = build_responses_text_format(response_format)
+        elif isinstance(response_format, dict):
+            create_kwargs["text"] = {"format": response_format}
+
+        response = await self.client.responses.create(**create_kwargs, **kwargs)
 
         if not isinstance(response, Response | AsyncStream):
             msg = f"Responses API returned an unexpected type: {type(response)}"
             raise ValueError(msg)
+        # When a structured response_format was requested, return the raw Response so the base
+        # layer can parse it into a ParsedResponse (do not collapse it to a ResponseResource).
+        if is_structured_output_type(response_format):
+            return response
         # if it's a Response, try to convert it to a ResponseResource. If that fails, return the Response
         if isinstance(response, Response):
             try:

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -14,6 +14,7 @@ from any_llm.types.batch import Batch, BatchResult, BatchResultError, BatchResul
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
 from any_llm.types.model import Model
 from any_llm.types.rerank import RerankResponse
+from any_llm.utils.structured_output import build_responses_text_format, is_structured_output_type
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
@@ -192,7 +193,14 @@ class OtariProvider(BaseOpenAIProvider):
     async def _aresponses(
         self, params: ResponsesParams, **kwargs: Any
     ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent]:
-        response_kwargs = params.model_dump(exclude_none=True, exclude={"model", "input"})
+        response_format = params.response_format
+        response_kwargs = params.model_dump(exclude_none=True, exclude={"model", "input", "response_format"})
+        # Otari has no parse() helper: request schema-conformant JSON via text.format and let the
+        # base layer parse the result into a ParsedResponse.
+        if is_structured_output_type(response_format):
+            response_kwargs["text"] = build_responses_text_format(response_format)
+        elif isinstance(response_format, dict):
+            response_kwargs["text"] = {"format": response_format}
         response_kwargs.update(kwargs)
         result = await self.otari_client.response(model=params.model, input=params.input, **response_kwargs)
         return cast("ResponseResource | Response | AsyncIterator[ResponseStreamEvent]", result)

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from openai.types.responses import ParsedResponse as OpenAIParsedResponse
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import ResponseInputParam as OpenAIResponseInputParam
 from openai.types.responses import ResponseOutputMessage as OpenAIResponseOutputMessage
@@ -7,6 +8,7 @@ from openai.types.responses import ResponseStreamEvent as OpenAIResponseStreamEv
 from pydantic import BaseModel, ConfigDict
 
 Response = OpenAIResponse
+ParsedResponse = OpenAIParsedResponse
 ResponseStreamEvent = OpenAIResponseStreamEvent
 ResponseOutputMessage = OpenAIResponseOutputMessage
 ResponseInputParam = OpenAIResponseInputParam
@@ -52,8 +54,12 @@ class ResponsesParams(BaseModel):
     max_output_tokens: int | None = None
     """Maximum number of tokens to generate"""
 
-    response_format: dict[str, Any] | type[BaseModel] | None = None
-    """Format specification for the response"""
+    response_format: dict[str, Any] | type | None = None
+    """Structured-output format for the response.
+
+    Accepts a Pydantic ``BaseModel`` subclass or a dataclass type (parsed into
+    ``ParsedResponse.output_parsed``), or a raw OpenAI ``text.format`` dict.
+    """
 
     stream: bool | None = None
     """Whether to stream the response"""

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -79,7 +79,7 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
     try:
         parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(warnings=False))
     except ValidationError:
-        if isinstance(response, Response):
+        if isinstance(response, Response):  # pragma: no cover - a valid Response always validates as ParsedResponse
             raise
         logger.warning(
             "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, TypeGuard
+from typing import TYPE_CHECKING, Any, TypeGuard
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from any_llm.logging import logger
+
+if TYPE_CHECKING:
+    from any_llm.types.responses import ParsedResponse
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:
@@ -38,3 +43,54 @@ def parse_json_content(response_format: type, content: str) -> Any:
     if issubclass(response_format, BaseModel):
         return response_format.model_validate_json(content)
     return TypeAdapter(response_format).validate_json(content)
+
+
+def build_responses_text_format(response_format: type) -> dict[str, Any]:
+    """Build the Responses API ``text`` config that requests schema-conformant JSON.
+
+    Used by providers that cannot call ``client.responses.parse()`` (e.g. the
+    OpenResponses providers) so the model still emits JSON matching the schema.
+    Works with both Pydantic BaseModel subclasses and dataclass types.
+    """
+    return {
+        "format": {
+            "type": "json_schema",
+            "name": response_format.__name__,
+            "schema": get_json_schema(response_format),
+        }
+    }
+
+
+def parse_responses_output(response: Any, response_format: type) -> ParsedResponse[Any] | None:
+    """Normalize a raw Responses result into a ``ParsedResponse`` with ``output_parsed``.
+
+    Takes an OpenAI ``Response`` (what every provider yields on the structured-output
+    path) and returns an OpenAI ``ParsedResponse`` whose ``output_parsed`` holds the
+    typed object. Works with both Pydantic BaseModel subclasses and dataclass types.
+
+    Returns ``None`` (after logging a warning) if ``response`` cannot be normalized into
+    a ``ParsedResponse`` (e.g. an OpenResponses ``ResponseResource`` whose schema diverges
+    from OpenAI's), so callers can fall back to the original object.
+    """
+    from openai.types.responses import ParsedResponseOutputMessage, ParsedResponseOutputText
+
+    from any_llm.types.responses import ParsedResponse, Response
+
+    try:
+        parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(warnings=False))
+    except ValidationError:
+        if isinstance(response, Response):
+            raise
+        logger.warning(
+            "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
+            type(response).__name__,
+        )
+        return None
+
+    for output in parsed.output:
+        if not isinstance(output, ParsedResponseOutputMessage):
+            continue
+        for content in output.content:
+            if isinstance(content, ParsedResponseOutputText) and content.text and content.parsed is None:
+                content.parsed = parse_json_content(response_format, content.text)
+    return parsed

--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -1,13 +1,15 @@
+import dataclasses
 from typing import Any
 
 import httpx
 import pytest
 from openai import APIConnectionError
 from openresponses_types import ResponseResource
+from pydantic import BaseModel
 
 from any_llm import AnyLLM, LLMProvider
-from any_llm.exceptions import MissingApiKeyError
-from any_llm.types.responses import Response
+from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
+from any_llm.types.responses import ParsedResponse, Response
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 
@@ -37,3 +39,78 @@ async def test_responses_async(
             pytest.skip("Local Model host is not set up, skipping")
         raise
     assert isinstance(result, (ResponseResource, Response))
+
+
+@pytest.mark.asyncio
+async def test_responses_format_basemodel(
+    provider: LLMProvider,
+    provider_model_map: dict[LLMProvider, str],
+    provider_client_config: dict[LLMProvider, dict[str, Any]],
+) -> None:
+    """Structured output via the Responses API returns a ParsedResponse with output_parsed."""
+
+    class CityResponse(BaseModel):
+        city_name: str
+
+    try:
+        llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
+        if not llm.SUPPORTS_RESPONSES:
+            pytest.skip(f"{provider.value} does not support responses, skipping")
+        model_id = provider_model_map[provider]
+        result = await llm.aresponses(
+            model_id,
+            input_data="What is the capital of France?",
+            response_format=CityResponse,
+        )
+    except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
+        pytest.skip(f"{provider.value} API key not provided, skipping")
+    except UnsupportedParameterError:
+        pytest.skip(f"{provider.value} does not support structured responses, skipping")
+    except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
+        if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
+            pytest.skip("Local Model host is not set up, skipping")
+        raise
+
+    assert isinstance(result, ParsedResponse)
+    assert isinstance(result.output_parsed, CityResponse)
+    assert "paris" in result.output_parsed.city_name.lower()
+
+
+@pytest.mark.asyncio
+async def test_responses_format_dataclass(
+    provider: LLMProvider,
+    provider_model_map: dict[LLMProvider, str],
+    provider_client_config: dict[LLMProvider, dict[str, Any]],
+) -> None:
+    """Structured output via the Responses API also works with a dataclass type."""
+
+    @dataclasses.dataclass
+    class CityResponse:
+        city_name: str
+
+    try:
+        llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
+        if not llm.SUPPORTS_RESPONSES:
+            pytest.skip(f"{provider.value} does not support responses, skipping")
+        model_id = provider_model_map[provider]
+        result = await llm.aresponses(
+            model_id,
+            input_data="What is the capital of France?",
+            response_format=CityResponse,
+        )
+    except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
+        pytest.skip(f"{provider.value} API key not provided, skipping")
+    except UnsupportedParameterError:
+        pytest.skip(f"{provider.value} does not support structured responses, skipping")
+    except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
+        if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
+            pytest.skip("Local Model host is not set up, skipping")
+        raise
+
+    assert isinstance(result, ParsedResponse)
+    assert isinstance(result.output_parsed, CityResponse)
+    assert "paris" in result.output_parsed.city_name.lower()

--- a/tests/unit/providers/test_groq_provider.py
+++ b/tests/unit/providers/test_groq_provider.py
@@ -251,3 +251,121 @@ def test_streaming_chunk_extracts_cached_tokens() -> None:
     assert result.usage.prompt_tokens == 4641
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 4608
+
+
+def _make_openai_response(text: str):  # type: ignore[no-untyped-def]
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    from any_llm.types.responses import Response
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.groq.groq.AsyncOpenAI")
+async def test_groq_aresponses_basemodel_uses_parse(mock_openai_class: Mock) -> None:
+    from any_llm.providers.groq.groq import GroqProvider
+    from any_llm.types.responses import ParsedResponse
+    from any_llm.utils.structured_output import parse_responses_output
+
+    class City(BaseModel):
+        city_name: str
+
+    parsed = parse_responses_output(_make_openai_response('{"city_name": "Paris"}'), City)
+
+    client = AsyncMock()
+    client.responses.parse = AsyncMock(return_value=parsed)
+    client.responses.create = AsyncMock()
+    mock_openai_class.return_value = client
+
+    provider = GroqProvider(api_key="test-api-key")
+    result = await provider.aresponses("openai/gpt-oss-20b", "capital of France?", response_format=City)
+
+    client.responses.parse.assert_awaited_once()
+    assert client.responses.parse.call_args.kwargs["text_format"] is City
+    client.responses.create.assert_not_called()
+    assert isinstance(result, ParsedResponse)
+    assert result.output_parsed is not None
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.groq.groq.AsyncOpenAI")
+async def test_groq_aresponses_dataclass_uses_create_and_is_parsed(mock_openai_class: Mock) -> None:
+    import dataclasses
+
+    from any_llm.providers.groq.groq import GroqProvider
+    from any_llm.types.responses import ParsedResponse
+
+    @dataclasses.dataclass
+    class City:
+        city_name: str
+
+    client = AsyncMock()
+    client.responses.create = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+    client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = client
+
+    provider = GroqProvider(api_key="test-api-key")
+    result = await provider.aresponses("openai/gpt-oss-20b", "capital of France?", response_format=City)
+
+    client.responses.parse.assert_not_called()
+    assert client.responses.create.call_args.kwargs["text"]["format"]["type"] == "json_schema"
+    assert isinstance(result, ParsedResponse)
+    assert result.output_parsed is not None
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.groq.groq.AsyncOpenAI")
+async def test_groq_aresponses_dict_response_format_sets_text_format(mock_openai_class: Mock) -> None:
+    from any_llm.providers.groq.groq import GroqProvider
+    from any_llm.types.responses import ParsedResponse
+
+    client = AsyncMock()
+    client.responses.create = AsyncMock(return_value=_make_openai_response("{}"))
+    client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = client
+
+    response_format = {"type": "json_schema", "name": "City", "schema": {"type": "object"}}
+
+    provider = GroqProvider(api_key="test-api-key")
+    result = await provider.aresponses("openai/gpt-oss-20b", "hi", response_format=response_format)
+
+    client.responses.parse.assert_not_called()
+    assert client.responses.create.call_args.kwargs["text"] == {"format": response_format}
+    # A raw dict response_format is passed through unparsed.
+    assert not isinstance(result, ParsedResponse)
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.groq.groq.AsyncOpenAI")
+async def test_groq_aresponses_without_response_format(mock_openai_class: Mock) -> None:
+    from any_llm.providers.groq.groq import GroqProvider
+
+    client = AsyncMock()
+    client.responses.create = AsyncMock(return_value=_make_openai_response("{}"))
+    client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = client
+
+    provider = GroqProvider(api_key="test-api-key")
+    await provider.aresponses("openai/gpt-oss-20b", "hi")
+
+    client.responses.parse.assert_not_called()
+    assert "text" not in client.responses.create.call_args.kwargs

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -290,3 +290,129 @@ def test_create_openai_chunk_without_usage() -> None:
 
     assert result.usage is None
     assert result.choices[0].delta.content == "Hello"
+
+
+def _make_openai_response(text: str):  # type: ignore[no-untyped-def]
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    from any_llm.types.responses import Response
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_huggingface_aresponses_basemodel_uses_parse() -> None:
+    from pydantic import BaseModel
+
+    from any_llm.types.responses import ParsedResponse
+    from any_llm.utils.structured_output import parse_responses_output
+
+    class City(BaseModel):
+        city_name: str
+
+    parsed = parse_responses_output(_make_openai_response('{"city_name": "Paris"}'), City)
+
+    with (
+        patch("any_llm.providers.huggingface.huggingface.AsyncInferenceClient"),
+        patch("any_llm.providers.huggingface.huggingface.AsyncOpenAI") as mock_openai,
+    ):
+        client = AsyncMock()
+        client.responses.parse = AsyncMock(return_value=parsed)
+        client.responses.create = AsyncMock()
+        mock_openai.return_value = client
+
+        provider = HuggingfaceProvider(api_key="test-api-key")
+        result = await provider.aresponses("model", "capital of France?", response_format=City)
+
+    client.responses.parse.assert_awaited_once()
+    assert client.responses.parse.call_args.kwargs["text_format"] is City
+    client.responses.create.assert_not_called()
+    assert isinstance(result, ParsedResponse)
+    assert result.output_parsed is not None
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+async def test_huggingface_aresponses_dataclass_uses_create_and_is_parsed() -> None:
+    import dataclasses
+
+    from any_llm.types.responses import ParsedResponse
+
+    @dataclasses.dataclass
+    class City:
+        city_name: str
+
+    with (
+        patch("any_llm.providers.huggingface.huggingface.AsyncInferenceClient"),
+        patch("any_llm.providers.huggingface.huggingface.AsyncOpenAI") as mock_openai,
+    ):
+        client = AsyncMock()
+        client.responses.create = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+        client.responses.parse = AsyncMock()
+        mock_openai.return_value = client
+
+        provider = HuggingfaceProvider(api_key="test-api-key")
+        result = await provider.aresponses("model", "capital of France?", response_format=City)
+
+    client.responses.parse.assert_not_called()
+    assert client.responses.create.call_args.kwargs["text"]["format"]["type"] == "json_schema"
+    assert isinstance(result, ParsedResponse)
+    assert result.output_parsed is not None
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+async def test_huggingface_aresponses_dict_passthrough_sets_text_format() -> None:
+    with (
+        patch("any_llm.providers.huggingface.huggingface.AsyncInferenceClient"),
+        patch("any_llm.providers.huggingface.huggingface.AsyncOpenAI") as mock_openai,
+        patch("any_llm.providers.huggingface.huggingface.ResponseResource") as mock_resource,
+    ):
+        client = AsyncMock()
+        client.responses.create = AsyncMock(return_value=_make_openai_response("{}"))
+        mock_openai.return_value = client
+        sentinel = object()
+        mock_resource.model_validate.return_value = sentinel
+
+        provider = HuggingfaceProvider(api_key="test-api-key")
+        response_format = {"type": "json_schema", "name": "City", "schema": {"type": "object"}}
+        result = await provider.aresponses("model", "hi", response_format=response_format)
+
+    assert client.responses.create.call_args.kwargs["text"] == {"format": response_format}
+    # Non-structured dict path converts the OpenAI Response into a ResponseResource.
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_huggingface_aresponses_without_response_format() -> None:
+    with (
+        patch("any_llm.providers.huggingface.huggingface.AsyncInferenceClient"),
+        patch("any_llm.providers.huggingface.huggingface.AsyncOpenAI") as mock_openai,
+        patch("any_llm.providers.huggingface.huggingface.ResponseResource") as mock_resource,
+    ):
+        client = AsyncMock()
+        client.responses.create = AsyncMock(return_value=_make_openai_response("{}"))
+        mock_openai.return_value = client
+        mock_resource.model_validate.return_value = object()
+
+        provider = HuggingfaceProvider(api_key="test-api-key")
+        await provider.aresponses("model", "hi")
+
+    client.responses.parse.assert_not_called()
+    assert "text" not in client.responses.create.call_args.kwargs

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -120,6 +120,24 @@ async def test_aresponses_stream_with_response_format_raises(mock_openai_class: 
         await provider.aresponses(model="gpt-4o", input_data="hi", response_format=_City, stream=True)
 
 
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_without_response_format_returns_response(mock_openai_class: MagicMock) -> None:
+    """No response_format: neither parse nor text.format is used, and the raw Response is returned."""
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+    mock_client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    result = await provider.aresponses(model="gpt-4o", input_data="hi")
+
+    mock_client.responses.parse.assert_not_called()
+    assert "text" not in mock_client.responses.create.call_args.kwargs
+    assert isinstance(result, Response)
+    assert not isinstance(result, ParsedResponse)
+
+
 @patch("any_llm.providers.openai.base.AsyncOpenAI")
 def test_responses_sync_basemodel_returns_parsed(mock_openai_class: MagicMock) -> None:
     """The synchronous wrapper must return the ParsedResponse (a Response subclass), not iterate it."""

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -1,11 +1,123 @@
+import dataclasses
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from pydantic import BaseModel
 
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import CompletionParams
 from any_llm.types.model import Model
+from any_llm.types.responses import ParsedResponse, Response
+from any_llm.utils.structured_output import parse_responses_output
+
+
+class _City(BaseModel):
+    city_name: str
+
+
+@dataclasses.dataclass
+class _CityDataclass:
+    city_name: str
+
+
+class _ResponsesProvider(BaseOpenAIProvider):
+    SUPPORTS_RESPONSES = True
+    PROVIDER_NAME = "ResponsesProvider"
+    ENV_API_KEY_NAME = "TEST_API_KEY"
+    PROVIDER_DOCUMENTATION_URL = "https://example.com"
+    API_BASE = "https://api.example.com/v1"
+
+
+def _make_openai_response(text: str) -> Response:
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_basemodel_uses_parse(mock_openai_class: MagicMock) -> None:
+    parsed = parse_responses_output(_make_openai_response('{"city_name": "Paris"}'), _City)
+
+    mock_client = AsyncMock()
+    mock_client.responses.parse = AsyncMock(return_value=parsed)
+    mock_client.responses.create = AsyncMock()
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    result = await provider.aresponses(model="gpt-4o", input_data="capital of France?", response_format=_City)
+
+    mock_client.responses.parse.assert_awaited_once()
+    assert mock_client.responses.parse.call_args.kwargs["text_format"] is _City
+    mock_client.responses.create.assert_not_called()
+    assert isinstance(result, ParsedResponse)
+    assert isinstance(result.output_parsed, _City)
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_dataclass_uses_create_and_is_parsed(mock_openai_class: MagicMock) -> None:
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+    mock_client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    result = await provider.aresponses(model="gpt-4o", input_data="capital of France?", response_format=_CityDataclass)
+
+    mock_client.responses.parse.assert_not_called()
+    create_kwargs = mock_client.responses.create.call_args.kwargs
+    assert create_kwargs["text"]["format"]["type"] == "json_schema"
+    assert "response_format" not in create_kwargs
+    assert isinstance(result, ParsedResponse)
+    assert isinstance(result.output_parsed, _CityDataclass)
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_dict_response_format_is_passed_through_unparsed(mock_openai_class: MagicMock) -> None:
+    raw = _make_openai_response('{"city_name": "Paris"}')
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=raw)
+    mock_client.responses.parse = AsyncMock()
+    mock_openai_class.return_value = mock_client
+
+    response_format = {"type": "json_schema", "name": "City", "schema": {"type": "object"}}
+
+    provider = _ResponsesProvider(api_key="key")
+    result = await provider.aresponses(model="gpt-4o", input_data="hi", response_format=response_format)
+
+    mock_client.responses.parse.assert_not_called()
+    assert mock_client.responses.create.call_args.kwargs["text"] == {"format": response_format}
+    assert not isinstance(result, ParsedResponse)
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_stream_with_response_format_raises(mock_openai_class: MagicMock) -> None:
+    mock_openai_class.return_value = AsyncMock()
+    provider = _ResponsesProvider(api_key="key")
+
+    with pytest.raises(ValueError, match="stream is not supported for response_format"):
+        await provider.aresponses(model="gpt-4o", input_data="hi", response_format=_City, stream=True)
 
 
 @patch("any_llm.providers.openai.base.AsyncOpenAI")

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -121,6 +121,23 @@ async def test_aresponses_stream_with_response_format_raises(mock_openai_class: 
 
 
 @patch("any_llm.providers.openai.base.AsyncOpenAI")
+def test_responses_sync_basemodel_returns_parsed(mock_openai_class: MagicMock) -> None:
+    """The synchronous wrapper must return the ParsedResponse (a Response subclass), not iterate it."""
+    parsed = parse_responses_output(_make_openai_response('{"city_name": "Paris"}'), _City)
+
+    mock_client = AsyncMock()
+    mock_client.responses.parse = AsyncMock(return_value=parsed)
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    result = provider.responses(model="gpt-4o", input_data="capital of France?", response_format=_City)
+
+    assert isinstance(result, ParsedResponse)
+    assert isinstance(result.output_parsed, _City)
+    assert result.output_parsed.city_name == "Paris"
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
 def test_list_models_returns_model_list_when_supported(mock_openai_class: MagicMock) -> None:
     class ListModelsProvider(BaseOpenAIProvider):
         SUPPORTS_LIST_MODELS = True

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -329,3 +329,77 @@ async def test_otari_completion_uses_converted_params_with_max_tokens_remap() ->
     call_kwargs = mocked_client.completion.call_args.kwargs
     assert call_kwargs["max_completion_tokens"] == 42
     assert "max_tokens" not in call_kwargs
+
+
+def _make_openai_response(text: str):  # type: ignore[no-untyped-def]
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    from any_llm.types.responses import Response
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_otari_aresponses_basemodel_requests_schema_and_is_parsed() -> None:
+    from pydantic import BaseModel
+
+    from any_llm.types.responses import ParsedResponse
+
+    class City(BaseModel):
+        city_name: str
+
+    client = _mock_otari_client()
+    client.response = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+    provider = _build_provider(client)
+
+    result = await provider.aresponses("model", "capital of France?", response_format=City)
+
+    assert "response_format" not in client.response.call_args.kwargs
+    assert client.response.call_args.kwargs["text"]["format"]["type"] == "json_schema"
+    assert isinstance(result, ParsedResponse)
+    assert result.output_parsed is not None
+    assert result.output_parsed.city_name == "Paris"
+
+
+@pytest.mark.asyncio
+async def test_otari_aresponses_dict_response_format_sets_text_format() -> None:
+    from any_llm.types.responses import ParsedResponse
+
+    client = _mock_otari_client()
+    client.response = AsyncMock(return_value=_make_openai_response("{}"))
+    provider = _build_provider(client)
+
+    response_format = {"type": "json_schema", "name": "City", "schema": {"type": "object"}}
+    result = await provider.aresponses("model", "hi", response_format=response_format)
+
+    assert client.response.call_args.kwargs["text"] == {"format": response_format}
+    # A raw dict response_format is passed through unparsed (not a ParsedResponse).
+    assert not isinstance(result, ParsedResponse)
+
+
+@pytest.mark.asyncio
+async def test_otari_aresponses_without_response_format() -> None:
+    client = _mock_otari_client()
+    client.response = AsyncMock(return_value=_make_openai_response("{}"))
+    provider = _build_provider(client)
+
+    await provider.aresponses("model", "hi")
+
+    # No structured response_format -> no text.format injected.
+    assert "text" not in client.response.call_args.kwargs

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -149,3 +149,37 @@ def test_parse_responses_output_returns_none_when_not_normalizable() -> None:
 
     result = parse_responses_output(NotAResponse(), PydanticModel)
     assert result is None
+
+
+def test_parse_responses_output_skips_non_message_output() -> None:
+    """Non-message outputs and non-text content (e.g. tool calls, refusals) are skipped; the message is parsed."""
+    from openai.types.responses import ResponseFunctionToolCall, ResponseOutputRefusal
+
+    function_call = ResponseFunctionToolCall(
+        id="fc-1", type="function_call", call_id="call-1", name="do_thing", arguments="{}", status="completed"
+    )
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[
+            ResponseOutputRefusal(type="refusal", refusal="n/a"),
+            ResponseOutputText(type="output_text", text='{"name": "Alice", "age": 30}', annotations=[]),
+        ],
+    )
+    response = Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[function_call, message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    parsed = parse_responses_output(response, PydanticModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, PydanticModel)
+    assert parsed.output_parsed.name == "Alice"

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -1,9 +1,37 @@
 import dataclasses
 from typing import Any
 
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from pydantic import BaseModel
 
-from any_llm.utils.structured_output import get_json_schema, is_structured_output_type, parse_json_content
+from any_llm.types.responses import ParsedResponse, Response
+from any_llm.utils.structured_output import (
+    build_responses_text_format,
+    get_json_schema,
+    is_structured_output_type,
+    parse_json_content,
+    parse_responses_output,
+)
+
+
+def _make_response(text: str) -> Response:
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
 
 
 class PydanticModel(BaseModel):
@@ -85,3 +113,39 @@ def test_parse_json_content_dataclass_nested() -> None:
     assert result.name == "Alice"
     assert isinstance(result.address, Address)
     assert result.address.city == "Paris"
+
+
+def test_build_responses_text_format_basemodel() -> None:
+    text_config = build_responses_text_format(PydanticModel)
+    fmt = text_config["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["name"] == "PydanticModel"
+    assert "name" in fmt["schema"]["properties"]
+
+
+def test_build_responses_text_format_dataclass() -> None:
+    text_config = build_responses_text_format(DataclassModel)
+    assert text_config["format"]["name"] == "DataclassModel"
+    assert "age" in text_config["format"]["schema"]["properties"]
+
+
+def test_parse_responses_output_basemodel() -> None:
+    parsed = parse_responses_output(_make_response('{"name": "Alice", "age": 30}'), PydanticModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, PydanticModel)
+    assert parsed.output_parsed.name == "Alice"
+
+
+def test_parse_responses_output_dataclass() -> None:
+    parsed = parse_responses_output(_make_response('{"name": "Bob", "age": 7}'), DataclassModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, DataclassModel)
+    assert parsed.output_parsed.age == 7
+
+
+def test_parse_responses_output_returns_none_when_not_normalizable() -> None:
+    class NotAResponse(BaseModel):
+        output: list[Any] = []
+
+    result = parse_responses_output(NotAResponse(), PydanticModel)
+    assert result is None


### PR DESCRIPTION
## Description

Adds structured-output support to the Responses API — the analogue of OpenAI's `client.responses.parse(text_format=...)` — via a new `response_format` parameter on `responses()` / `aresponses()`, mirroring the existing `completion(response_format=...)` support.

Passing a Pydantic `BaseModel` or dataclass returns a `ParsedResponse` whose `output_parsed` holds the typed object:

```python
from pydantic import BaseModel
from any_llm import responses

class CalendarEvent(BaseModel):
    name: str
    date: str

r = responses(model="gpt-4o", provider="openai",
              input_data="Lunch on Friday", response_format=CalendarEvent)
r.output_parsed   # -> CalendarEvent(...)
```

- OpenAI-SDK providers (openai, azureopenai, lmstudio, fireworks, huggingface, groq) use the native `client.responses.parse(text_format=...)`.
- Other responses-capable providers (e.g. otari) request schema-conformant JSON via `text.format`; the base layer parses it into a `ParsedResponse`.
- Dataclasses are supported in addition to Pydantic models.
- A structured `response_format` combined with `stream=True` raises `ValueError`, mirroring `completion`.
- `ResponsesParams.response_format` (previously declared but unused) is now wired up.

## PR Type

- 🆕 New Feature

## Relevant issues

Closes #1100

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Implementation was AI-drafted under human direction and review; the contributor will respond to review discussion themselves.

- [x] I am an AI Agent filling out this form (check box if true)