### PR TITLE
fix(gateway): preserve extra chat completion fields

### DIFF
--- a/src/any_llm/gateway/api/routes/chat.py
+++ b/src/any_llm/gateway/api/routes/chat.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -36,6 +36,8 @@ def rate_limit_headers(info: RateLimitInfo) -> dict[str, str]:
 
 class ChatCompletionRequest(BaseModel):
     """OpenAI-compatible chat completion request."""
+
+    model_config = ConfigDict(extra="allow")
 
     model: str
     messages: list[dict[str, Any]] = Field(min_length=1)

--- a/tests/gateway/test_stream_options_injection.py
+++ b/tests/gateway/test_stream_options_injection.py
@@ -98,3 +98,27 @@ def test_preserves_client_stream_options() -> None:
         }
     )
     assert kwargs["stream_options"] == custom
+
+
+def test_preserves_extra_request_fields() -> None:
+    """Unknown OpenAI-compatible fields should pass through to acompletion kwargs."""
+    kwargs = _build_completion_kwargs(
+        {
+            "model": "openai:gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "custom_request_field": {"enabled": True},
+        }
+    )
+    assert kwargs["custom_request_field"] == {"enabled": True}
+
+
+def test_preserves_provider_specific_extra_fields() -> None:
+    """Provider-specific request fields should pass through to acompletion kwargs."""
+    kwargs = _build_completion_kwargs(
+        {
+            "model": "openrouter:anthropic/claude-sonnet-4.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "provider": {"only": ["Anthropic"], "allow_fallbacks": False},
+        }
+    )
+    assert kwargs["provider"] == {"only": ["Anthropic"], "allow_fallbacks": False}


### PR DESCRIPTION
## Description

The gateway's OpenAI-compatible `/v1/chat/completions` request model now allows extra request fields instead of dropping everything outside the explicitly modeled parameters.

This is needed for provider-specific and OpenAI-compatible request options that any-llm can already accept via `acompletion(**kwargs)`, but which the gateway currently strips during Pydantic request parsing. One concrete case is Gemini's OpenAI-compatible chat completions API, where Google documents explicit context cache usage via nested `extra_body`:

```python
stream = client.chat.completions.create(
    model="gemini-3.5-flash",
    n=1,
    messages=[{"role": "user", "content": "Summarize the video"}],
    stream=True,
    stream_options={"include_usage": True},
    extra_body={
        "extra_body": {
            "google": {
                "cached_content": "cachedContents/0000aaaa1111bbbb2222cccc3333dddd4444eeee"
            }
        }
    },
)
```

Source: [Gemini OpenAI compatibility docs](https://ai.google.dev/gemini-api/docs/openai#enable-gemini-features-with-extra_body).

Other providers have their own request-shaping needs as well, so the fix keeps passthrough generic instead of adding Gemini- or cache-specific fields to the gateway schema.

The existing stream-options tests now cover both arbitrary extra request fields and provider-specific fields, so future request-model changes do not accidentally narrow the passthrough behavior again.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: Implementation and regression tests were drafted by Codex under interactive human direction and review.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
