### PR TITLE
fix(anthropic): map xhigh to Anthropic xhigh and expose max effort

### DIFF
--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1508,7 +1508,7 @@ def generate_types_completion_page() -> str:
             "**Import:** `from any_llm.types.completion import ReasoningEffort`",
             "",
             """```
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "auto"]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "auto"]
 ```""",
             "",
             'The value `"auto"` (the default) maps to each provider\'s own default reasoning level.',

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -47,7 +47,8 @@ REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
     "low": "low",
     "medium": "medium",
     "high": "high",
-    "xhigh": "max",
+    "xhigh": "xhigh",
+    "max": "max",
 }
 
 

--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -28,7 +28,14 @@ from any_llm.types.completion import (
 
 INFERENCE_PARAMETERS = ["maxTokens", "temperature", "topP", "stopSequences"]
 
-REASONING_EFFORT_TO_THINKING_BUDGETS = {"minimal": 1024, "low": 2048, "medium": 8192, "high": 24576, "xhigh": 32768}
+REASONING_EFFORT_TO_THINKING_BUDGETS = {
+    "minimal": 1024,
+    "low": 2048,
+    "medium": 8192,
+    "high": 24576,
+    "xhigh": 32768,
+    "max": 32768,
+}
 
 
 def _convert_params(params: CompletionParams, kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -38,6 +38,7 @@ REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "medium": 8192,
     "high": 24576,
     "xhigh": 32768,
+    "max": 32768,
 }
 
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -59,7 +59,14 @@ if TYPE_CHECKING:
         OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
     )
 
-REASONING_EFFORT_TO_THINKING_BUDGETS = {"minimal": 256, "low": 1024, "medium": 8192, "high": 24576, "xhigh": 32768}
+REASONING_EFFORT_TO_THINKING_BUDGETS = {
+    "minimal": 256,
+    "low": 1024,
+    "medium": 8192,
+    "high": 24576,
+    "xhigh": 32768,
+    "max": 32768,
+}
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
 
 

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -98,7 +98,7 @@ Usage = OpenAIUsage
 ChoiceDeltaToolCall = OpenAIChoiceDeltaToolCall
 ChoiceDeltaToolCallFunction = OpenAIChoiceDeltaToolCallFunction
 
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "auto"]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "auto"]
 
 
 class CompletionParams(BaseModel):

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -288,6 +288,39 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
             assert call_kwargs["output_config"] == {"effort": REASONING_EFFORT_TO_ANTHROPIC_EFFORT[reasoning_effort]}
 
 
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_effort"),
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+        ("max", "max"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_reasoning_effort_maps_to_distinct_anthropic_effort(
+    reasoning_effort: ReasoningEffort, expected_effort: str
+) -> None:
+    """Guard against mapping canonical xhigh onto Anthropic's max (see issue #1107).
+
+    Anthropic exposes low < medium < high < xhigh < max as distinct levels, so each
+    canonical effort must map to its intended Anthropic level rather than silently
+    escalating xhigh to max.
+    """
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_anthropic_provider() as mock_anthropic:
+        provider = AnthropicProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(model_id="model-id", messages=messages, reasoning_effort=reasoning_effort)
+        )
+
+        call_kwargs = mock_anthropic.return_value.messages.create.call_args[1]
+        assert call_kwargs["output_config"] == {"effort": expected_effort}
+
+
 @pytest.mark.asyncio
 async def test_completion_with_images() -> None:
     api_key = "test-api-key"

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -218,6 +218,7 @@ def test_preprocess_response_format_unsupported_raises() -> None:
         ("medium", {"type": "enabled", "token_budget": 8192}),
         ("high", {"type": "enabled", "token_budget": 24576}),
         ("xhigh", {"type": "enabled", "token_budget": 32768}),
+        ("max", {"type": "enabled", "token_budget": 32768}),
     ],
 )
 async def test_reasoning_effort_mapped_to_thinking(


### PR DESCRIPTION
## Description

Anthropic exposes five distinct reasoning effort levels (`low < medium < high < xhigh < max`), but any-llm mapped the canonical `xhigh` onto Anthropic's `max`. This had three consequences (reported in #1107):

1. Requesting `xhigh` silently produced a higher level (`max`) than asked, meaning more thinking tokens and cost than intended.
2. Anthropic's real `xhigh` level was unreachable.
3. Anthropic's `max` was only reachable by accident (by sending `xhigh`), and `"max"` was not a valid `ReasoningEffort` input value.

This PR:

- Adds `"max"` to the canonical `ReasoningEffort` literal so it is addressable on purpose.
- Fixes the Anthropic mapping: `xhigh -> xhigh` and adds `max -> max`.
- Adds a `max` entry to the budget-dict providers (`gemini`, `bedrock`, `cohere`) reusing their top budget (`32768`) so a `max` request does not raise a `KeyError`. These providers have no higher tier than `xhigh`, so mapping `max` to the same top budget is the closest faithful behavior.
- Leaves OpenAI-style passthrough providers unchanged (they pass `reasoning_effort` straight through, same as today's behavior for `xhigh`).
- Regenerates the doc literal in `scripts/generate_api_docs.py`.

### Notes for reviewers

- Anthropic gates `xhigh`/`max` availability by model (Opus 4.7/4.8). any-llm does not gate effort by model today; this PR preserves that passthrough behavior and does not add model gating.
- For `gemini`/`bedrock`/`cohere`, there is no true tier above `xhigh`; mapping `max` to the same top budget is a pragmatic choice. Happy to adjust if you prefer a different value.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1107

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Plan reviewed and approved by the human before implementation.

- [x] I am an AI Agent filling out this form (check box if true)