### PR TITLE
fix(types): serialize Reasoning as a plain string for OpenAI wire compatibility

### DIFF
--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -22,14 +22,37 @@ from openai.types.completion_usage import CompletionUsage as OpenAICompletionUsa
 from openai.types.completion_usage import PromptTokensDetails as OpenAIPromptTokensDetails
 from openai.types.create_embedding_response import Usage as OpenAIUsage
 from openai.types.embedding import Embedding as OpenAIEmbedding
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_serializer, model_validator
 
 # See https://github.com/mozilla-ai/any-llm/issues/95:
 # OpenAI Completion API doesn't include reasoning information, so we need to extend the openai type
 
 
 class Reasoning(BaseModel):
+    """Reasoning content emitted by a model.
+
+    Serializes as a plain JSON string so that responses are compatible with
+    OpenAI-style clients that expect ``delta.reasoning`` / ``message.reasoning``
+    to be a string. The Python attribute ``content`` remains available for
+    typed access (e.g. ``message.reasoning.content``).
+    """
+
     content: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_input(cls, value: Any) -> Any:
+        """Accept either a plain string or the ``{"content": str}`` object form."""
+        if isinstance(value, str):
+            return {"content": value}
+        if isinstance(value, dict) and "content" in value and value["content"] is not None:
+            return {"content": str(value["content"])}
+        return value
+
+    @model_serializer
+    def _serialize(self) -> str:
+        """Serialize as a plain string for OpenAI-compatible wire format."""
+        return self.content
 
 
 class ChatCompletionMessage(OpenAIChatCompletionMessage):

--- a/tests/unit/test_reasoning_type.py
+++ b/tests/unit/test_reasoning_type.py
@@ -164,10 +164,17 @@ def test_reasoning_rejects_dict_with_none_content() -> None:
         Reasoning.model_validate({"content": None})
 
 
-def test_reasoning_rejects_non_string_non_dict_input() -> None:
-    """An int or other non-string/non-dict input falls through and fails standard validation."""
+@pytest.mark.parametrize("invalid_input", [123, None, [], 1.5, ("tuple",)])
+def test_reasoning_rejects_non_string_non_dict_input(invalid_input: Any) -> None:
+    """Non-string, non-dict inputs fall through and fail standard validation."""
     with pytest.raises(ValidationError):
-        Reasoning.model_validate(123)
+        Reasoning.model_validate(invalid_input)
+
+
+def test_reasoning_accepts_empty_string() -> None:
+    """An empty string is valid reasoning content."""
+    reasoning = Reasoning.model_validate("")
+    assert reasoning.content == ""
 
 
 def test_reasoning_coerces_non_string_content_in_dict() -> None:

--- a/tests/unit/test_reasoning_type.py
+++ b/tests/unit/test_reasoning_type.py
@@ -8,6 +8,9 @@ expect ``delta.reasoning`` / ``message.reasoning`` to be a string.
 import json
 from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -147,6 +150,30 @@ def test_chat_completion_message_accepts_string_reasoning_on_input() -> None:
     message = completion.choices[0].message
     assert message.reasoning is not None
     assert message.reasoning.content == "plain reasoning"
+
+
+def test_reasoning_rejects_dict_without_content_key() -> None:
+    """A dict that lacks the ``content`` key falls through and fails standard validation."""
+    with pytest.raises(ValidationError):
+        Reasoning.model_validate({"other_field": "value"})
+
+
+def test_reasoning_rejects_dict_with_none_content() -> None:
+    """A dict where ``content`` is None falls through and fails standard validation."""
+    with pytest.raises(ValidationError):
+        Reasoning.model_validate({"content": None})
+
+
+def test_reasoning_rejects_non_string_non_dict_input() -> None:
+    """An int or other non-string/non-dict input falls through and fails standard validation."""
+    with pytest.raises(ValidationError):
+        Reasoning.model_validate(123)
+
+
+def test_reasoning_coerces_non_string_content_in_dict() -> None:
+    """A dict whose ``content`` value is not a string is coerced via ``str()``."""
+    reasoning = Reasoning.model_validate({"content": 42})
+    assert reasoning.content == "42"
 
 
 def test_reasoning_roundtrip_through_json() -> None:

--- a/tests/unit/test_reasoning_type.py
+++ b/tests/unit/test_reasoning_type.py
@@ -1,0 +1,172 @@
+"""Tests for the Reasoning type's wire format and validation.
+
+The Reasoning model wraps a string ``content`` field but serializes as a plain
+string so that responses are wire-compatible with OpenAI-style clients that
+expect ``delta.reasoning`` / ``message.reasoning`` to be a string.
+"""
+
+import json
+from typing import Any
+
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChoiceDelta,
+    Reasoning,
+)
+
+
+def test_reasoning_serializes_as_plain_string() -> None:
+    """A Reasoning model dumps as a string, not an object."""
+    reasoning = Reasoning(content="thinking through the problem")
+    # The serializer returns a string; mypy infers dict[str, Any] from BaseModel.model_dump,
+    # so cast through Any to verify the runtime value.
+    dumped: Any = reasoning.model_dump()
+    assert dumped == "thinking through the problem"
+
+
+def test_reasoning_json_dump_is_quoted_string() -> None:
+    """model_dump_json produces a JSON string literal, not an object."""
+    reasoning = Reasoning(content="hello")
+    assert reasoning.model_dump_json() == '"hello"'
+
+
+def test_reasoning_validates_from_plain_string() -> None:
+    """Validation accepts a bare string (the wire format)."""
+    reasoning = Reasoning.model_validate("a bare string")
+    assert reasoning.content == "a bare string"
+
+
+def test_reasoning_validates_from_object_form() -> None:
+    """Validation still accepts the legacy ``{"content": str}`` object form."""
+    reasoning = Reasoning.model_validate({"content": "object form"})
+    assert reasoning.content == "object form"
+
+
+def test_reasoning_attribute_access_preserved() -> None:
+    """Typed attribute access remains the public Python API."""
+    reasoning = Reasoning(content="abc")
+    assert reasoning.content == "abc"
+
+
+def test_choice_delta_reasoning_dumps_string() -> None:
+    """The streaming delta serializes reasoning as a plain string."""
+    delta = ChoiceDelta(reasoning=Reasoning(content="step one"))
+    dumped = delta.model_dump()
+    assert dumped["reasoning"] == "step one"
+
+
+def test_chat_completion_chunk_reasoning_wire_format() -> None:
+    """A full chunk dumps with delta.reasoning as a string, matching OpenAI."""
+    chunk = ChatCompletionChunk.model_validate(
+        {
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"reasoning": {"content": "intermediate"}},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+    payload = json.loads(chunk.model_dump_json())
+    assert payload["choices"][0]["delta"]["reasoning"] == "intermediate"
+
+
+def test_chat_completion_chunk_accepts_string_reasoning_on_input() -> None:
+    """Validation accepts ``delta.reasoning`` as a plain string (OpenAI wire form)."""
+    chunk = ChatCompletionChunk.model_validate(
+        {
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"reasoning": "string form"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+    assert chunk.choices[0].delta.reasoning is not None
+    assert chunk.choices[0].delta.reasoning.content == "string form"
+
+
+def test_chat_completion_message_reasoning_wire_format() -> None:
+    """Non-streaming completion dumps message.reasoning as a string."""
+    completion = ChatCompletion.model_validate(
+        {
+            "id": "id",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "answer",
+                        "reasoning": {"content": "because"},
+                    },
+                }
+            ],
+        }
+    )
+    payload = json.loads(completion.model_dump_json())
+    assert payload["choices"][0]["message"]["reasoning"] == "because"
+
+
+def test_chat_completion_message_accepts_string_reasoning_on_input() -> None:
+    """Non-streaming validation accepts a bare string for message.reasoning."""
+    completion = ChatCompletion.model_validate(
+        {
+            "id": "id",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "answer",
+                        "reasoning": "plain reasoning",
+                    },
+                }
+            ],
+        }
+    )
+    message = completion.choices[0].message
+    assert message.reasoning is not None
+    assert message.reasoning.content == "plain reasoning"
+
+
+def test_reasoning_roundtrip_through_json() -> None:
+    """A chunk can be serialized to JSON and re-validated back to a Reasoning object."""
+    original = ChatCompletionChunk.model_validate(
+        {
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"reasoning": {"content": "loop"}},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+    serialized = original.model_dump_json()
+    revived = ChatCompletionChunk.model_validate_json(serialized)
+    assert revived.choices[0].delta.reasoning is not None
+    assert revived.choices[0].delta.reasoning.content == "loop"


### PR DESCRIPTION
## Description

The `any-llm` `Reasoning` model previously serialized as `{"content": "..."}` on the wire (e.g. inside `delta.reasoning` and `message.reasoning`). This broke OpenAI-compatible clients that strictly validate streaming chunks against a schema expecting `delta.reasoning` to be a plain `string`.

Concretely, OpenCode (using Zod) rejected `mzai` provider streaming responses with:

```
"path": ["choices", 0, "delta", "reasoning"]
"message": "Invalid input: expected string, received object"
```

This PR fixes the wire format while preserving the typed Python attribute API:

- Add a `@model_serializer` on `Reasoning` that returns `self.content` (plain string).
- Add a `@model_validator(mode="before")` that accepts both a plain string and the legacy `{"content": str}` object form on input.

Typed Python access remains unchanged: `message.reasoning.content`, `delta.reasoning.content`, and `Reasoning(content="...")` construction all continue to work across every provider and across every internal consumer (`utils/messages_compat.py`, provider `_convert_*` helpers, xml-reasoning extraction, etc.).

The only observable change is the JSON shape produced by `model_dump()` / `model_dump_json()` for objects containing a `Reasoning` field: a plain string instead of `{"content": str}`.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Surfaced via OpenCode + the `mzai` provider; see commit message for details.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.7
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Used to scope the fix, implement the Pydantic serializer/validator changes, and write unit tests. All decisions were reviewed and approved by the human author before commit.

- [ ] I am an AI Agent filling out this form (check box if true)

## Notes for reviewers

### Behavior change (mild breaking)

`model_dump()` / `model_dump_json()` of any object containing a `Reasoning` field now emits a string for that field instead of `{"content": str}`. Any downstream code that re-parses the dumped JSON shape (e.g. reads `payload["choices"][0]["delta"]["reasoning"]["content"]`) must be updated to read the string directly. Validation accepts both shapes, so deserializing previously-dumped payloads still works.

### Test coverage

Added `tests/unit/test_reasoning_type.py` covering:

- `Reasoning` serializes to a plain string (`model_dump` and `model_dump_json`).
- Validation accepts both string and object forms.
- Attribute access (`reasoning.content`) is preserved.
- `ChoiceDelta.reasoning` and `ChatCompletionMessage.reasoning` dump as strings.
- Full `ChatCompletionChunk` / `ChatCompletion` round-trip through JSON.
- Wire-format input as a plain string still validates into a typed `Reasoning`.

All 1292 existing unit tests pass; `uv run pre-commit run --all-files` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning now accepts either a raw string or a structured object and automatically normalises inputs; it serialises as a plain string for improved OpenAI-compatible payloads.

* **Tests**
  * Added comprehensive tests for validation, coercion, serialisation to/from JSON, error cases for invalid inputs, and end-to-end JSON round-trip behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->