### PR TITLE
fix(ollama): pass tools as top-level arg in streaming completions

### DIFF
--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -153,6 +153,7 @@ class OllamaProvider(AnyLLM):
         response: AsyncIterator[OllamaChatResponse] = await self.client.chat(
             model=model,
             messages=messages,
+            tools=kwargs.pop("tools", None),
             think=kwargs.pop("think", None),
             stream=True,
             options=kwargs,

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -87,6 +88,44 @@ async def test_completion_with_dict_response_format() -> None:
 
             call_kwargs = provider.client.chat.call_args[1]
             assert call_kwargs["format"] == response_format
+
+
+@pytest.mark.asyncio
+async def test_streaming_completion_passes_tools_top_level() -> None:
+    """Test that tools are passed as a top-level kwarg to client.chat(), not inside options."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {"location": {"type": "string"}}},
+            },
+        }
+    ]
+
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter())
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="llama3.1",
+                messages=[{"role": "user", "content": "What's the weather?"}],
+                tools=tools,
+                stream=True,
+            ),
+        )
+        async for _ in result:  # type: ignore[union-attr]
+            pass
+
+        call_kwargs = provider.client.chat.call_args[1]
+        assert call_kwargs["tools"] == tools
+        assert "tools" not in call_kwargs.get("options", {})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`OllamaProvider._stream_completion_async()` passes `tools` inside `options=kwargs` instead of as a top-level keyword argument to `self.client.chat()`. The ollama SDK ignores tools inside `options`, so the model receives no tool definitions during streaming requests.

The non-streaming path in `_acompletion()` correctly pops `tools` from kwargs and passes it as a top-level parameter. This fix applies the same pattern to the streaming path.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1113

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4 (Anthropic)
- AI Developer Tool used: VS Code with GitHub Copilot
- Any other info you'd like to share: AI assisted with identifying the bug, drafting the fix, and writing the unit test.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed streaming completions to properly forward tools to the underlying service call, ensuring tools functionality works correctly during streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->