### PR TITLE
test: suppress spurious "Event loop is closed" asyncio teardown noise

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,33 @@
+import logging
 import os
 from collections import defaultdict
 from collections.abc import Generator
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from any_llm.constants import LLMProvider
 from tests.constants import CI_EXCLUDED_PROVIDERS, INCLUDE_LOCAL_PROVIDERS, INCLUDE_NON_LOCAL_PROVIDERS, LOCAL_PROVIDERS
+
+
+class _IgnoreEventLoopClosedFilter(logging.Filter):
+    """Drop the noisy ``Event loop is closed`` records asyncio logs during teardown.
+
+    pytest-asyncio uses a function-scoped event loop, so the loop is closed at the end of
+    each async test. httpx ``AsyncClient`` instances held by providers are finalized
+    afterwards and schedule ``aclose()`` on the already-closed loop, which asyncio reports
+    through its logger as ``RuntimeError: Event loop is closed``. These are teardown
+    artifacts, not real failures; every other asyncio record passes through untouched.
+    """
+
+    @override
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "Event loop is closed" not in record.getMessage()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    logging.getLogger("asyncio").addFilter(_IgnoreEventLoopClosedFilter())
 
 
 @pytest.fixture

--- a/tests/unit/test_async_teardown_logging.py
+++ b/tests/unit/test_async_teardown_logging.py
@@ -1,0 +1,30 @@
+import logging
+
+from tests.conftest import _IgnoreEventLoopClosedFilter
+
+
+def _make_record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="asyncio",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_filter_suppresses_event_loop_closed_records() -> None:
+    log_filter = _IgnoreEventLoopClosedFilter()
+    record = _make_record(
+        "Task exception was never retrieved\n"
+        "future: <Task finished coro=<AsyncClient.aclose()> exception=RuntimeError('Event loop is closed')>"
+    )
+    assert log_filter.filter(record) is False
+
+
+def test_filter_passes_unrelated_asyncio_records() -> None:
+    log_filter = _IgnoreEventLoopClosedFilter()
+    record = _make_record("Some unrelated asyncio error")
+    assert log_filter.filter(record) is True


### PR DESCRIPTION
## Description

Integration and unit test logs are polluted with repeated `RuntimeError: Event loop is closed` tracebacks, which GitHub Actions renders as `##[error]` annotations that look like failures.

Root cause: `pytest-asyncio` uses a function-scoped event loop, so the loop is closed at the end of each async test. httpx `AsyncClient` instances held by providers (via `AsyncOpenAI`, and now `AsyncOtariClient._http`) are finalized afterwards and schedule `aclose()` on the already-closed loop. asyncio reports this through its logger (`default_exception_handler` to the `asyncio` logger), which is what shows up in CI output.

This change registers a `logging.Filter` on the `asyncio` logger (via `pytest_configure` in `tests/conftest.py`) that drops only records containing the phrase `Event loop is closed`. Every other asyncio record passes through untouched, so genuine errors still surface.

The issue suggested a `pytest_unraisableexception` hook, but pytest 9 replaced that returnable hook with an internal collector, and the actual emission is via the asyncio logger, so the filter targets the real source.

Scope note: this removes the misleading log noise. It does not turn the integration job green on its own, which is red due to unrelated live-API provider failures.

## PR Type

- 🚦 Infrastructure

## Relevant issues

Fixes #1118

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Authored by Claude via back-and-forth with @njbrake. The root-cause investigation (reproducing the asyncio emission path and adapting away from the pytest 9 hook change) and the scope decisions are his; the implementation and prose are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite logging by suppressing spurious "Event loop is closed" messages during test teardown, reducing unnecessary noise in test output.
  * Added comprehensive unit tests to verify the logging filter correctly suppresses the unwanted message whilst allowing other asyncio logging records to pass through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->