### PR TITLE
fix(otari): preserve cache_control via native /messages pass-through

### DIFF
--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -274,8 +274,8 @@ class OtariProvider(BaseOpenAIProvider):
         SDK's ``message()`` to preserve them.
         """
         api_kwargs = params.model_dump(exclude_none=True)
-        api_kwargs.pop("stream", None)
         api_kwargs.update(kwargs)
+        api_kwargs.pop("stream", None)
 
         if params.stream:
             return self._stream_messages_async(**api_kwargs)

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -13,6 +13,15 @@ from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.providers.openai.utils import _convert_moderation_response_from_openai
 from any_llm.types.batch import Batch, BatchResult, BatchResultError, BatchResultItem
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    MessageDeltaEvent,
+    MessageResponse,
+    MessageStartEvent,
+    MessageStopEvent,
+)
 from any_llm.types.model import Model
 from any_llm.types.rerank import RerankResponse
 from any_llm.utils.structured_output import build_responses_text_format, is_structured_output_type
@@ -24,6 +33,7 @@ if TYPE_CHECKING:
 
     from any_llm.types.audio import AudioSpeechParams, AudioTranscriptionParams, Transcription
     from any_llm.types.image import ImageGenerationParams, ImagesResponse
+    from any_llm.types.messages import MessagesParams, MessageStreamEvent
     from any_llm.types.moderation import ModerationResponse
     from any_llm.types.responses import Response, ResponsesParams, ResponseStreamEvent
 
@@ -96,6 +106,31 @@ def _extract_model_from_requests(requests: list[dict[str, Any]]) -> str | None:
         model: Any = requests[0]["body"].get("model")
         return str(model) if model is not None else None
     return None
+
+
+# otari's /messages stream yields raw Anthropic SSE event dicts (the SDK has no
+# single typed model for them). Map each by its ``type`` field to the matching
+# any-llm event model; unknown types (e.g. ``ping``) are skipped.
+_MESSAGE_STREAM_EVENT_TYPES: dict[str, type[BaseModel]] = {
+    "message_start": MessageStartEvent,
+    "message_delta": MessageDeltaEvent,
+    "message_stop": MessageStopEvent,
+    "content_block_start": ContentBlockStartEvent,
+    "content_block_delta": ContentBlockDeltaEvent,
+    "content_block_stop": ContentBlockStopEvent,
+}
+
+
+def _message_stream_event_from_dict(event: dict[str, Any]) -> MessageStreamEvent | None:
+    """Validate a raw otari message SSE event dict into a typed MessageStreamEvent.
+
+    Returns ``None`` for event types any-llm does not surface (e.g. ``ping``).
+    """
+    event_type = event.get("type")
+    model = _MESSAGE_STREAM_EVENT_TYPES.get(event_type) if isinstance(event_type, str) else None
+    if model is None:
+        return None
+    return cast("MessageStreamEvent", model.model_validate(event))
 
 
 class OtariProvider(BaseOpenAIProvider):
@@ -226,6 +261,35 @@ class OtariProvider(BaseOpenAIProvider):
 
             return _chunk_iterator()
         return self._convert_completion_response(_as_plain_dict(response))
+
+    @override
+    async def _amessages(
+        self, params: MessagesParams, **kwargs: Any
+    ) -> MessageResponse | AsyncIterator[MessageStreamEvent]:
+        """Native Anthropic Messages API pass-through via otari's /messages endpoint.
+
+        The base implementation converts Messages to Chat Completions, which silently
+        drops Anthropic-only features (``cache_control`` on system blocks, ``thinking``
+        config). otari's gateway serves /messages natively, so delegate to the otari
+        SDK's ``message()`` to preserve them.
+        """
+        api_kwargs = params.model_dump(exclude_none=True)
+        api_kwargs.pop("stream", None)
+        api_kwargs.update(kwargs)
+
+        if params.stream:
+            return self._stream_messages_async(**api_kwargs)
+
+        response = await self.otari_client.message(**api_kwargs)
+        return MessageResponse.model_validate(_as_plain_dict(response))
+
+    async def _stream_messages_async(self, **api_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        """Stream otari's /messages endpoint, yielding typed any-llm event models."""
+        stream = await self.otari_client.message(stream=True, **api_kwargs)
+        async for event in stream:
+            converted = _message_stream_event_from_dict(_as_plain_dict(event))
+            if converted is not None:
+                yield converted
 
     @override
     async def _aresponses(

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -21,7 +21,17 @@ from any_llm.providers.otari.otari import (
     OtariProvider,
     _as_plain_dict,
     _extract_model_from_requests,
+    _message_stream_event_from_dict,
     _parse_jsonl_to_requests,
+)
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    MessageResponse,
+    MessagesParams,
+    MessageStartEvent,
+    MessageStopEvent,
+    TextBlock,
 )
 
 
@@ -34,6 +44,7 @@ def _mock_otari_client() -> MagicMock:
     client = MagicMock()
     client.platform_mode = False
     client.completion = AsyncMock()
+    client.message = AsyncMock()
     client.embedding = AsyncMock()
     client.moderation = AsyncMock()
     client.rerank = AsyncMock()
@@ -451,3 +462,123 @@ async def test_otari_aresponses_without_response_format() -> None:
 
     # No structured response_format -> no text.format injected.
     assert "text" not in client.response.call_args.kwargs
+
+
+def _message_response_payload() -> dict[str, Any]:
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+        # otari-native models carry extra keys; MessageResponse should ignore them.
+        "additional_properties": {"served_by": "otari"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic_fields() -> None:
+    client = _mock_otari_client()
+    client.message.return_value = _message_response_payload()
+    provider = _build_provider(client)
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        system=[{"type": "text", "text": "You are helpful.", "cache_control": {"type": "ephemeral"}}],
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    )
+
+    result = await provider._amessages(params, metadata={"user_id": "u1"})
+
+    assert isinstance(result, MessageResponse)
+    assert result.id == "msg_1"
+    block = result.content[0]
+    assert isinstance(block, TextBlock)
+    assert block.text == "hi"
+
+    call_kwargs = client.message.call_args.kwargs
+    assert call_kwargs["model"] == "claude-sonnet-4-5"
+    assert call_kwargs["max_tokens"] == 100
+    # cache_control on the system block and thinking config survive the pass-through.
+    assert call_kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+    # Extra kwargs are forwarded; stream is not set for non-streaming calls.
+    assert call_kwargs["metadata"] == {"user_id": "u1"}
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_excludes_none_valued_optional_params() -> None:
+    client = _mock_otari_client()
+    client.message.return_value = _message_response_payload()
+    provider = _build_provider(client)
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    await provider._amessages(params)
+
+    call_kwargs = client.message.call_args.kwargs
+    # Unset optionals (temperature, tools, ...) are dropped, not sent as None.
+    assert "temperature" not in call_kwargs
+    assert "tools" not in call_kwargs
+    assert "system" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_streaming_yields_typed_events_and_skips_unknown() -> None:
+    raw_events = [
+        {"type": "message_start", "message": _message_response_payload()},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "ping"},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 5},
+        },
+        {"type": "message_stop"},
+    ]
+
+    async def _aiter() -> Any:
+        for event in raw_events:
+            yield event
+
+    client = _mock_otari_client()
+    client.message.return_value = _aiter()
+    provider = _build_provider(client)
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+
+    result = await provider._amessages(params)
+
+    assert not isinstance(result, MessageResponse)
+    collected = [event async for event in result]
+
+    # The unknown "ping" event is skipped; everything else is yielded in order.
+    assert isinstance(collected[0], MessageStartEvent)
+    assert isinstance(collected[1], ContentBlockStartEvent)
+    assert isinstance(collected[2], ContentBlockDeltaEvent)
+    assert isinstance(collected[-1], MessageStopEvent)
+    assert len(collected) == len(raw_events) - 1
+    assert client.message.call_args.kwargs["stream"] is True
+
+
+def test_message_stream_event_from_dict_returns_none_for_unknown_type() -> None:
+    assert _message_stream_event_from_dict({"type": "ping"}) is None
+    assert _message_stream_event_from_dict({"no_type": True}) is None
+    assert isinstance(_message_stream_event_from_dict({"type": "message_stop"}), MessageStopEvent)


### PR DESCRIPTION
## Description

`OtariProvider` inherited the base `_amessages()`, which converts Anthropic Messages to Chat Completions and silently drops Anthropic-only features (`cache_control` on system blocks, `thinking` config). For applications relying on Anthropic prompt caching, this meant every request through otari lost caching, raising latency and cost.

otari's gateway serves `/messages` natively, and otari SDK 0.1.0 now exposes `AsyncOtariClient.message()`. This PR overrides `_amessages()` to delegate to `otari_client.message()`, mirroring how `_acompletion()` delegates to `otari_client.completion()`. The transport (auth, URL, SSE parsing) stays inside the otari SDK where it belongs.

- Non-streaming results validate into `MessageResponse`.
- Streaming raw event dicts from otari's `/messages` SSE stream are mapped to typed `MessageStreamEvent` models; unknown event types (e.g. `ping`) are skipped.
- The deprecated `GatewayProvider` subclass inherits the fix via the shared client.

This supersedes the raw-httpx approach in #1111 (closed) by keeping transport in the SDK rather than reimplementing it in any-llm.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1110

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Authored by Claude via back-and-forth with @njbrake. The reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native support for Anthropic-style messaging, including streaming responses and typed event delivery.
  * Anthropic-specific settings (e.g. system controls and thinking behaviour) are preserved for native message operations.

* **Tests**
  * New unit tests covering native messaging, streaming event ordering and filtering, and preservation of request fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->