### PR TITLE
test: skip otari/gateway integration tests when no endpoint is configured

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,8 +168,9 @@ def provider_client_config() -> dict[LLMProvider, dict[str, Any]]:
         LLMProvider.BEDROCK: {"region_name": "us-east-1"},
         LLMProvider.CEREBRAS: {"timeout": 10},
         LLMProvider.COHERE: {"timeout": 10},
-        LLMProvider.GATEWAY: {"api_base": "http://127.0.0.1:3000", "timeout": 1},
-        LLMProvider.OTARI: {"api_base": "http://127.0.0.1:3000", "timeout": 1},
+        # otari/gateway intentionally omit a default api_base: they resolve the endpoint from
+        # OTARI_API_BASE / GATEWAY_API_BASE and are skipped when that is unset (see
+        # tests/integration/conftest.py), so no localhost placeholder is needed here.
         LLMProvider.GROQ: {"timeout": 10},
         LLMProvider.LLAMACPP: {"api_base": "http://127.0.0.1:8090/v1"},
         LLMProvider.VLLM: {"api_base": "http://127.0.0.1:8080/v1"},

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -18,7 +18,11 @@ CI_EXCLUDED_PROVIDERS = [
     LLMProvider.VLLM,
 ]
 
-EXPECTED_PROVIDERS = os.environ.get("EXPECTED_PROVIDERS", "").split(",")
+# Strip whitespace and drop empties so values like "anthropic, otari" or an unset env var
+# (which would otherwise yield [""]) compare cleanly in `provider in EXPECTED_PROVIDERS` checks.
+EXPECTED_PROVIDERS = [
+    provider.strip() for provider in os.environ.get("EXPECTED_PROVIDERS", "").split(",") if provider.strip()
+]
 
 INCLUDE_LOCAL_PROVIDERS = os.getenv("INCLUDE_LOCAL_PROVIDERS", "true").lower() in ("true", "1", "t")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+
+from any_llm.constants import LLMProvider
+from tests.constants import EXPECTED_PROVIDERS
+
+# The otari/gateway gateway has no server started in CI (unlike ollama, llamacpp, lmstudio and
+# llamafile, which the local integration job boots up). Its integration tests can therefore
+# only run against a real endpoint configured via these env vars, for example the dedicated
+# otari e2e job. When the endpoint is not configured we skip rather than fail: otari 0.1.0's
+# SDK is urllib3-based, so an unreachable placeholder host raises errors the per-test skip
+# clauses do not catch, and some requests fail during client-side validation before any
+# network call. Listing the provider in EXPECTED_PROVIDERS forces a run so a misconfigured
+# e2e job fails loudly instead of skipping silently.
+_GATEWAY_PROVIDER_ENV_VARS: dict[LLMProvider, tuple[str, ...]] = {
+    LLMProvider.OTARI: ("OTARI_API_BASE",),
+    LLMProvider.GATEWAY: ("GATEWAY_API_BASE", "OTARI_API_BASE"),
+}
+
+
+@pytest.fixture(autouse=True)
+def _skip_unconfigured_gateway_providers(request: pytest.FixtureRequest) -> None:
+    """Skip otari/gateway integration tests when no real endpoint is configured."""
+    callspec = getattr(request.node, "callspec", None)
+    if callspec is None:
+        return
+    provider = callspec.params.get("provider")
+    if not isinstance(provider, LLMProvider) or provider in EXPECTED_PROVIDERS:
+        return
+    env_vars = _GATEWAY_PROVIDER_ENV_VARS.get(provider)
+    if env_vars and not any(os.getenv(var) for var in env_vars):
+        pytest.skip(f"{provider.value} endpoint not configured (set {' or '.join(env_vars)}), skipping")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,8 +5,8 @@ import pytest
 from any_llm.constants import LLMProvider
 from tests.constants import EXPECTED_PROVIDERS
 
-# The otari/gateway gateway has no server started in CI (unlike ollama, llamacpp, lmstudio and
-# llamafile, which the local integration job boots up). Its integration tests can therefore
+# The otari and gateway providers have no server started in CI (unlike ollama, llamacpp,
+# lmstudio and llamafile, which the local integration job boots up). Their integration tests can
 # only run against a real endpoint configured via these env vars, for example the dedicated
 # otari e2e job. When the endpoint is not configured we skip rather than fail: otari 0.1.0's
 # SDK is urllib3-based, so an unreachable placeholder host raises errors the per-test skip


### PR DESCRIPTION
## Description

The `run-local-integration-tests` job has been failing on `main` for the `otari` and `gateway` providers (36 tests, 18 each; no other provider affected). These providers point at a `http://127.0.0.1:3000` placeholder and have no server started in CI, so they were always meant to skip. They relied on a per-test `except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError)` clause to skip when the host is unreachable. Since the otari SDK 0.1.0 adoption (#1116) the client is `urllib3`-based, so an unreachable host raises `urllib3.exceptions.MaxRetryError`, which those clauses do not catch, turning intended skips into failures.

This PR restores the pre-0.1.0 behavior (otari/gateway always skip in CI when no endpoint is configured) by adding an integration-only autouse fixture that skips them when `OTARI_API_BASE` / `GATEWAY_API_BASE` are unset and the provider is not listed in `EXPECTED_PROVIDERS`. It also drops the now-dead localhost placeholders from `provider_client_config` so a real endpoint is no longer overridden.

This intentionally does not fix the genuine otari incompatibilities (batch `provider_name`, structured-output conversion) that fail during client-side validation before any network call; those need a real endpoint to validate and are tracked in #1123 for the otari e2e work (#1120).

### Changes
- `tests/integration/conftest.py` (new): autouse fixture skipping otari/gateway when no endpoint is configured. Guards tests that are not provider-parametrized (e.g. `test_cached_tokens`).
- `tests/conftest.py`: remove the otari/gateway `http://127.0.0.1:3000` entries from `provider_client_config`.

### Verification
- otari/gateway integration set: 50 skipped, 0 failures (was 36 failures), with clear skip reasons.
- With `OTARI_API_BASE` set, otari runs instead of skipping (the gate opens for the e2e job).
- Unit `test_client_args[otari/gateway]` still pass (the integration-only fixture does not affect unit tests).
- `ruff check`, `ruff format`, and `mypy --strict` pass on the changed files.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Part of #1123

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: This is a CI-only test-skip change, so no new unit tests were added; verification was done by running the previously failing otari/gateway integration set and confirming they now skip cleanly. The change was driven via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration tests now automatically skip provider-specific tests when required environment variables are not set, reducing false failures.
  * Test fixtures adjusted to avoid assuming default provider endpoints, improving environment-aware behaviour.
  * Parsing of the EXPECTED_PROVIDERS environment variable hardened to trim whitespace and ignore empty entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->