### PR TITLE
ci: add otari e2e integration test job against the hosted endpoint

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -134,6 +134,47 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  run-otari-e2e-tests:
+    # End-to-end tests against the hosted otari endpoint. The otari URL and API key live in
+    # GitHub secrets (OTARI_API_BASE / OTARI_API_KEY) so they stay out of the codebase. Runs on
+    # merge to main and on manual dispatch; skipped on pull_request_target since the secrets are
+    # not exposed to untrusted forks.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: 3.13
+          activate-environment: true
+
+      - name: Install dependencies
+        run: |
+          uv sync --group tests --extra all
+
+      - name: Run Otari e2e integration tests
+        env:
+          OTARI_API_BASE: ${{ secrets.OTARI_API_BASE }}
+          OTARI_API_KEY: ${{ secrets.OTARI_API_KEY }}
+          # Mark otari as expected so missing credentials or connection errors fail the job
+          # instead of silently skipping (see tests/integration/conftest.py).
+          EXPECTED_PROVIDERS: otari
+          INCLUDE_LOCAL_PROVIDERS: "true"
+          INCLUDE_NON_LOCAL_PROVIDERS: "false"
+        run: |
+          pytest tests/integration -v -k otari --cov --cov-report=xml || [ $? -eq 5 ]
+
+      - name: Upload coverage reports to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   run-local-integration-tests:
     needs: [expected-providers, determine-jobs-to-run]
     if: needs.determine-jobs-to-run.outputs.should_run_local == 'true'


### PR DESCRIPTION
## Description

Adds a `run-otari-e2e-tests` job that exercises the otari provider end to end against the real hosted otari endpoint, on merge to `main` and on manual dispatch. The endpoint URL and API key are read from GitHub secrets (`OTARI_API_BASE` / `OTARI_API_KEY`) so they stay out of the codebase, and the job is skipped on `pull_request_target` since secrets are not exposed to untrusted forks.

The job sets `EXPECTED_PROVIDERS=otari` so missing credentials or connection errors fail loudly rather than skipping silently, and runs `pytest tests/integration -k otari`.

> **Draft / stacked PR.** This is stacked on #1124 (base branch `fix/skip-unconfigured-otari-gateway-tests`); GitHub will retarget it to `main` once #1124 merges. It relies on #1124's skip-when-unconfigured gate so otari runs only when `OTARI_API_BASE` is set.

### Blockers before this can merge / go green
1. **Secrets must be configured** by a repo admin: `OTARI_API_BASE` and `OTARI_API_KEY`. Until then, merging this would make the push-to-main job red, because `EXPECTED_PROVIDERS=otari` forces otari to run.
2. **Genuine otari incompatibilities must be fixed first** (tracked in #1123). `pytest -k otari` runs the full otari set, and a few tests currently fail against a real endpoint during client-side request building:
   - `test_response_format`: the provider passes a Pydantic model straight to the otari SDK's `ChatCompletionRequest` (Pydantic `dict_type` error).
   - `test_list_batches` and the batch retrieve/cancel steps: the otari provider requires a `provider_name` the generic tests do not pass.

   These either need provider fixes or the e2e selection narrowed before the job is green.

## PR Type

- 🆕 New Feature
- 🚦 Infrastructure

## Relevant issues

Fixes #1120
Depends on #1124
Related: #1123

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: CI-only change (a new workflow job). It cannot be fully exercised without the otari secrets, so it is opened as a draft with the prerequisites documented above. Drafted via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)
