### PR TITLE
fix(otari): unwrap union responses via to_dict (tool_calls + non-streaming messages)

### DIFF
--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -86,11 +86,17 @@ def _as_plain_dict(response: Any) -> Any:
     """Normalize an otari-native pydantic response into a plain dict.
 
     otari 0.1.0's async client returns its own typed pydantic models rather than
-    OpenAI types. Dumping them to a dict lets any-llm's own response types validate
-    the payload (extra keys like ``additional_properties`` are ignored/allowed).
-    Non-model inputs (e.g. dicts in unit tests) are returned unchanged.
+    OpenAI types. The generated models use oneOf/anyOf unions for some fields (e.g.
+    ``tool_calls`` and Messages content blocks); their ``to_dict()`` unwraps each union
+    to the actual instance, whereas Pydantic's ``model_dump()`` leaks the union wrapper
+    (``actual_instance`` / ``anyof_schema_*``) and fails any-llm's validation. Prefer
+    ``to_dict()``, falling back to ``model_dump()`` for plain pydantic models. Non-model
+    inputs (e.g. dicts in unit tests) are returned unchanged.
     """
     if isinstance(response, BaseModel):
+        to_dict = getattr(response, "to_dict", None)
+        if callable(to_dict):
+            return to_dict()
         return response.model_dump()
     return response
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -51,11 +51,6 @@ _OTARI_SKIPPED_TESTS: dict[str, str] = {
     "test_retrieve_batch_results_with_api_function": "batch needs provider_name + gateway batch support",
     "test_completion_with_image": "gateway returns 502 on multimodal image content",
     "test_completion_with_pdf": "gateway returns 502 on multimodal pdf content",
-    # any-llm otari provider deserialization bugs
-    "test_agent_loop_parallel_tool_calls": "tool_calls deserialization bug (any-llm#1126)",
-    "test_agent_loop_sequential_tool_calls": "tool_calls deserialization bug (any-llm#1126)",
-    "test_messages_non_streaming": "non-streaming Messages deserialization bug (any-llm#1126)",
-    "test_messages_with_system_prompt": "non-streaming Messages deserialization bug (any-llm#1126)",
 }
 
 

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -67,6 +67,22 @@ def test_as_plain_dict_normalizes_models_and_passes_through() -> None:
     assert _as_plain_dict(passthrough) is passthrough
 
 
+def test_as_plain_dict_prefers_to_dict_over_model_dump() -> None:
+    """otari's generated models leak oneOf/anyOf union wrappers via model_dump (breaking
+    tool_calls and Messages content); their to_dict unwraps to the actual instance, so
+    _as_plain_dict must prefer to_dict."""
+    from pydantic import BaseModel
+
+    class _OtariLike(BaseModel):
+        value: int
+
+        def to_dict(self) -> dict[str, int]:
+            return {"unwrapped": self.value}
+
+    # model_dump would return {"value": 7}; the fix must use to_dict's unwrapped form.
+    assert _as_plain_dict(_OtariLike(value=7)) == {"unwrapped": 7}
+
+
 def test_extract_model_from_requests_none_when_missing() -> None:
     assert _extract_model_from_requests([]) is None
     assert _extract_model_from_requests([{"custom_id": "1", "body": {}}]) is None


### PR DESCRIPTION
## Description

Fixes the otari provider response-deserialization failures found by the otari e2e tests: tool calls and non-streaming Messages.

**Root cause:** otari 0.1.0's generated client models some fields (`tool_calls`, Messages content blocks) as oneOf/anyOf unions. `_as_plain_dict` used pydantic's `model_dump()`, which leaks the union wrapper (`actual_instance` / `anyof_schema_*`) instead of the inner instance, so any-llm's `ChatCompletion` / `MessageResponse` validation failed:
- tool calls: `Field required` for `tool_calls.0.id/function/type` (the value was the union wrapper).
- Messages: `37 validation errors for MessageResponse`.

**Fix:** the generated models' `to_dict()` unwraps each union to its actual instance and yields OpenAI-compatible dicts. `_as_plain_dict` now prefers `to_dict()`, falling back to `model_dump()` for plain pydantic models. This is a single normalization fix at the SDK boundary, not per-field special-casing.

Also drops the four corresponding skips in the otari e2e (agent_loop x2, messages x2), which now pass.

### Verified live (api.otari.ai)
otari e2e went from **6 passed / 19 skipped** to **10 passed / 15 skipped, 0 failed**. Unit: 53 otari+gateway tests pass; `ruff` + `mypy` clean.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1126

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Root-caused and verified against the live otari.ai endpoint. Drafted via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced otari provider to correctly handle version 0.1.0 pydantic model serialisation, improving data validation accuracy, reliability and compatibility.

* **Tests**
  * Added comprehensive unit tests for provider serialisation handling to verify proper data processing and model compatibility.
  * Updated integration test coverage for otari provider to ensure reliable functionality across different capabilities and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->