### PR TITLE
test(otari): re-enable reasoning e2e tests with gpt-oss-120b (blocked on otari SDK release)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,10 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.ANTHROPIC: "claude-sonnet-4-6",
         LLMProvider.GEMINI: "gemini-2.5-flash",
         LLMProvider.GATEWAY: "gpt-5-nano",
-        # anthropic via otari completes but does not surface reasoning content; use a reasoning
-        # model (needs the otari SDK reasoning-string fix, mozilla-ai/otari#145, to deserialize).
+        # No anthropic model via otari surfaces reasoning content (tested haiku/sonnet/opus, even
+        # with reasoning_effort set: OpenAI reasoning_effort is not mapped to Anthropic extended
+        # thinking). gpt-oss-120b does emit reasoning, which needs the otari SDK reasoning-string
+        # fix (mozilla-ai/otari#145) to deserialize.
         LLMProvider.OTARI: "mzai:openai/gpt-oss-120b",
         LLMProvider.VERTEXAI: "gemini-2.5-flash",
         LLMProvider.GITHUB: "openai/gpt-4.1-nano",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,9 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.ANTHROPIC: "claude-sonnet-4-6",
         LLMProvider.GEMINI: "gemini-2.5-flash",
         LLMProvider.GATEWAY: "gpt-5-nano",
-        LLMProvider.OTARI: "anthropic:claude-haiku-4-5",
+        # anthropic via otari completes but does not surface reasoning content; use a reasoning
+        # model (needs the otari SDK reasoning-string fix, mozilla-ai/otari#145, to deserialize).
+        LLMProvider.OTARI: "mzai:openai/gpt-oss-120b",
         LLMProvider.VERTEXAI: "gemini-2.5-flash",
         LLMProvider.GITHUB: "openai/gpt-4.1-nano",
         LLMProvider.GROQ: "openai/gpt-oss-20b",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,8 +43,6 @@ _OTARI_SKIPPED_TESTS: dict[str, str] = {
     "test_responses_async": "no Responses-API upstream on the test account (otari-ai#907)",
     "test_responses_format_basemodel": "no Responses-API upstream on the test account (otari-ai#907)",
     "test_responses_format_dataclass": "no Responses-API upstream on the test account (otari-ai#907)",
-    "test_completion_reasoning": "reasoning content not surfaced by the gateway",
-    "test_completion_reasoning_streaming": "reasoning content not surfaced by the gateway",
     "test_create_and_retrieve_batch": "batch needs provider_name + gateway batch support",
     "test_list_batches": "batch needs provider_name + gateway batch support",
     "test_retrieve_batch_results_not_complete": "batch needs provider_name + gateway batch support",


### PR DESCRIPTION
## Description

Re-enables the otari reasoning e2e tests, which were skipped because the test account's reliably-routable model (`anthropic:claude-haiku-4-5`) does not surface reasoning content, and the otari Python SDK could not deserialize reasoning from models that do emit it (the CCReasoning string-vs-object schema bug, mozilla-ai/otari#143).

mozilla-ai/otari#145 fixes that (types the SDK response schemas in serialization mode so `message.reasoning` is a string). This PR:
- Switches `provider_reasoning_model_map[OTARI]` to `mzai:openai/gpt-oss-120b` (a reasoning-emitting model).
- Removes the `test_completion_reasoning` and `test_completion_reasoning_streaming` entries from `_OTARI_SKIPPED_TESTS`.

> ✅ **Validated and ready.** otari `0.1.1` (with mozilla-ai/otari#145) is published to PyPI. The `filter=otari` integration run on this branch installed otari `0.1.1` and reported **12 passed, 13 skipped, 0 failed** — the otari e2e went from 10 to 12. It was also validated against the tagged source (`otari-0.1.1`) before publish.

## PR Type

- 🚦 Infrastructure

## Relevant issues

Closes #1130
Depends on mozilla-ai/otari#145 (published as otari 0.1.1)

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Validated against the live otari.ai endpoint with otari 0.1.1, both from the tagged source pre-publish and via the CI integration run post-publish. Drafted via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use an improved reasoning model for a third‑party provider to enhance test reliability.
  * Refined skip‑reason mappings to streamline and stabilise integration test coverage across image, batch and document scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->