### PR TITLE
fix(responses): strict schema + alias-safe round-trip for dataclass structured output

### DIFF
--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -45,6 +45,28 @@ def parse_json_content(response_format: type, content: str) -> Any:
     return TypeAdapter(response_format).validate_json(content)
 
 
+def _make_schema_strict(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively enforce ``additionalProperties: false`` and require every property.
+
+    Fallback used only if OpenAI's private strict-schema helper is unavailable; covers the
+    common object/array/$defs cases (it does not rewrite optional fields as nullable).
+    """
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            if obj.get("type") == "object" and "properties" in obj:
+                obj["additionalProperties"] = False
+                obj["required"] = list(obj["properties"].keys())
+            for value in obj.values():
+                _walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    _walk(schema)
+    return schema
+
+
 def get_strict_json_schema(response_format: type) -> dict[str, Any]:
     """Get a strict JSON schema (``additionalProperties: false``, all fields required).
 
@@ -52,9 +74,11 @@ def get_strict_json_schema(response_format: type) -> dict[str, Any]:
     so the manual dataclass path stays byte-for-byte compatible with the native BaseModel path.
     Works with both Pydantic BaseModel subclasses and dataclass types.
     """
-    from openai.lib._pydantic import _ensure_strict_json_schema
-
     schema = get_json_schema(response_format)
+    try:
+        from openai.lib._pydantic import _ensure_strict_json_schema
+    except ImportError:  # pragma: no cover - private SDK helper relocated/removed
+        return _make_schema_strict(schema)
     return _ensure_strict_json_schema(schema, path=(), root=schema)
 
 

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 from any_llm.logging import logger
 
 if TYPE_CHECKING:
-    from any_llm.types.responses import ParsedResponse
+    from any_llm.types.responses import ParsedResponse, Response
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:
@@ -123,13 +123,17 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
         # whose Python attribute is schema_) so the round-trip re-validates cleanly.
         parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(by_alias=True, warnings=False))
     except ValidationError:
-        if isinstance(response, Response):  # pragma: no cover - a valid Response always validates as ParsedResponse
-            raise
-        logger.warning(
-            "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
-            type(response).__name__,
-        )
-        return None
+        if isinstance(response, Response):
+            # Some providers return a valid Response whose shape does not satisfy the stricter
+            # ParsedResponse schema (e.g. Fireworks: usage.output_tokens_details=None). Build the
+            # ParsedResponse without re-validating the whole payload so output_parsed still works.
+            parsed = _parsed_response_from_raw(response)
+        else:
+            logger.warning(
+                "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
+                type(response).__name__,
+            )
+            return None
 
     for output in parsed.output:
         if not isinstance(output, ParsedResponseOutputMessage):
@@ -138,3 +142,42 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
             if isinstance(content, ParsedResponseOutputText) and content.text and content.parsed is None:
                 content.parsed = parse_json_content(response_format, content.text)
     return parsed
+
+
+def _parsed_response_from_raw(response: Response) -> ParsedResponse[Any]:
+    """Build a ``ParsedResponse`` from an already-validated ``Response`` without re-validation.
+
+    Used when a provider returns a valid ``Response`` that does not satisfy the stricter
+    ``ParsedResponse`` schema. Message text content is rebuilt as ``ParsedResponseOutputText``
+    (which carries ``parsed``) so the downstream parse loop and ``output_parsed`` keep working;
+    other fields are carried over verbatim via ``model_construct`` (no coercion).
+    """
+    from openai.types.responses import (
+        ParsedResponseOutputMessage,
+        ParsedResponseOutputText,
+        ResponseOutputMessage,
+        ResponseOutputText,
+    )
+
+    from any_llm.types.responses import ParsedResponse
+
+    parsed_output: list[Any] = []
+    for item in response.output:
+        if not isinstance(item, ResponseOutputMessage):
+            parsed_output.append(item)
+            continue
+        parsed_content: list[Any] = [
+            ParsedResponseOutputText.model_construct(**content.model_dump(by_alias=True, warnings=False))
+            if isinstance(content, ResponseOutputText)
+            else content
+            for content in item.content
+        ]
+        parsed_output.append(
+            ParsedResponseOutputMessage.model_construct(
+                **{**item.model_dump(by_alias=True, warnings=False), "content": parsed_content}
+            )
+        )
+
+    data = response.model_dump(by_alias=True, warnings=False)
+    data["output"] = parsed_output
+    return ParsedResponse.model_construct(**data)

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 from any_llm.logging import logger
 
 if TYPE_CHECKING:
-    from any_llm.types.responses import ParsedResponse, Response
+    from any_llm.types.responses import ParsedResponse
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:
@@ -123,17 +123,13 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
         # whose Python attribute is schema_) so the round-trip re-validates cleanly.
         parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(by_alias=True, warnings=False))
     except ValidationError:
-        if isinstance(response, Response):
-            # Some providers return a valid Response whose shape does not satisfy the stricter
-            # ParsedResponse schema (e.g. Fireworks: usage.output_tokens_details=None). Build the
-            # ParsedResponse without re-validating the whole payload so output_parsed still works.
-            parsed = _parsed_response_from_raw(response)
-        else:
-            logger.warning(
-                "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
-                type(response).__name__,
-            )
-            return None
+        if isinstance(response, Response):  # pragma: no cover - a valid Response always validates as ParsedResponse
+            raise
+        logger.warning(
+            "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
+            type(response).__name__,
+        )
+        return None
 
     for output in parsed.output:
         if not isinstance(output, ParsedResponseOutputMessage):
@@ -142,42 +138,3 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
             if isinstance(content, ParsedResponseOutputText) and content.text and content.parsed is None:
                 content.parsed = parse_json_content(response_format, content.text)
     return parsed
-
-
-def _parsed_response_from_raw(response: Response) -> ParsedResponse[Any]:
-    """Build a ``ParsedResponse`` from an already-validated ``Response`` without re-validation.
-
-    Used when a provider returns a valid ``Response`` that does not satisfy the stricter
-    ``ParsedResponse`` schema. Message text content is rebuilt as ``ParsedResponseOutputText``
-    (which carries ``parsed``) so the downstream parse loop and ``output_parsed`` keep working;
-    other fields are carried over verbatim via ``model_construct`` (no coercion).
-    """
-    from openai.types.responses import (
-        ParsedResponseOutputMessage,
-        ParsedResponseOutputText,
-        ResponseOutputMessage,
-        ResponseOutputText,
-    )
-
-    from any_llm.types.responses import ParsedResponse
-
-    parsed_output: list[Any] = []
-    for item in response.output:
-        if not isinstance(item, ResponseOutputMessage):
-            parsed_output.append(item)
-            continue
-        parsed_content: list[Any] = [
-            ParsedResponseOutputText.model_construct(**content.model_dump(by_alias=True, warnings=False))
-            if isinstance(content, ResponseOutputText)
-            else content
-            for content in item.content
-        ]
-        parsed_output.append(
-            ParsedResponseOutputMessage.model_construct(
-                **{**item.model_dump(by_alias=True, warnings=False), "content": parsed_content}
-            )
-        )
-
-    data = response.model_dump(by_alias=True, warnings=False)
-    data["output"] = parsed_output
-    return ParsedResponse.model_construct(**data)

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -45,18 +45,36 @@ def parse_json_content(response_format: type, content: str) -> Any:
     return TypeAdapter(response_format).validate_json(content)
 
 
+def get_strict_json_schema(response_format: type) -> dict[str, Any]:
+    """Get a strict JSON schema (``additionalProperties: false``, all fields required).
+
+    Mirrors the schema the OpenAI SDK emits for ``responses.parse()``/``chat.completions.parse()``
+    so the manual dataclass path stays byte-for-byte compatible with the native BaseModel path.
+    Works with both Pydantic BaseModel subclasses and dataclass types.
+    """
+    from openai.lib._pydantic import _ensure_strict_json_schema
+
+    schema = get_json_schema(response_format)
+    return _ensure_strict_json_schema(schema, path=(), root=schema)
+
+
 def build_responses_text_format(response_format: type) -> dict[str, Any]:
     """Build the Responses API ``text`` config that requests schema-conformant JSON.
 
     Used by providers that cannot call ``client.responses.parse()`` (e.g. the
     OpenResponses providers) so the model still emits JSON matching the schema.
-    Works with both Pydantic BaseModel subclasses and dataclass types.
+    The schema is made strict to match what ``responses.parse()`` sends for
+    BaseModel types: OpenAI requires ``additionalProperties: false``, and lenient
+    providers (Groq, HuggingFace) only echo back a complete ``text.format`` (with
+    the ``schema`` field) when ``strict`` is set. Works with both Pydantic
+    BaseModel subclasses and dataclass types.
     """
     return {
         "format": {
             "type": "json_schema",
+            "strict": True,
             "name": response_format.__name__,
-            "schema": get_json_schema(response_format),
+            "schema": get_strict_json_schema(response_format),
         }
     }
 
@@ -77,7 +95,9 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
     from any_llm.types.responses import ParsedResponse, Response
 
     try:
-        parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(warnings=False))
+        # by_alias=True preserves alias-only fields (e.g. ResponseFormatTextJSONSchemaConfig.schema,
+        # whose Python attribute is schema_) so the round-trip re-validates cleanly.
+        parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(by_alias=True, warnings=False))
     except ValidationError:
         if isinstance(response, Response):  # pragma: no cover - a valid Response always validates as ParsedResponse
             raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.LMSTUDIO: "google/gemma-3-4b",  # You must have LM Studio running and the server enabled
         LLMProvider.VLLM: "Qwen/Qwen2.5-0.5B-Instruct",
         LLMProvider.COHERE: "command-a-03-2025",
-        LLMProvider.CEREBRAS: "llama3.1-8b",
+        LLMProvider.CEREBRAS: "gpt-oss-120b",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",
         LLMProvider.BEDROCK: "amazon.nova-lite-v1:0",
         LLMProvider.SAGEMAKER: "<sagemaker_endpoint_name>",
@@ -124,7 +124,7 @@ def provider_image_model_map(provider_model_map: dict[LLMProvider, str]) -> dict
         **provider_model_map,
         LLMProvider.OPENAI: "gpt-5-mini",  # Slightly more powerful so that it doesn't get caught in a loop of logic
         LLMProvider.WATSONX: "meta-llama/llama-guard-3-11b-vision",
-        LLMProvider.SAMBANOVA: "Llama-4-Maverick-17B-128E-Instruct",
+        LLMProvider.SAMBANOVA: "gemma-4-31B-it",
         LLMProvider.NEBIUS: "Qwen/Qwen2.5-VL-72B-Instruct",
         LLMProvider.OPENROUTER: "google/gemini-2.5-flash-lite",
         LLMProvider.OLLAMA: "llava-phi3",  # Fast vision model compatible with OpenAI format

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -160,6 +160,7 @@ def test_parse_responses_output_roundtrips_json_schema_text_format() -> None:
 
     parsed = parse_responses_output(response, DataclassModel)
     assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, DataclassModel)
     assert parsed.output_parsed.age == 5
 
 

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -2,7 +2,6 @@ import dataclasses
 from typing import Any
 
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
-from openai.types.responses.response_usage import InputTokensDetails, ResponseUsage
 from pydantic import BaseModel
 
 from any_llm.types.responses import ParsedResponse, Response
@@ -181,28 +180,6 @@ def test_parse_responses_output_roundtrips_json_schema_text_format() -> None:
     assert isinstance(parsed, ParsedResponse)
     assert isinstance(parsed.output_parsed, DataclassModel)
     assert parsed.output_parsed.age == 5
-
-
-def test_parse_responses_output_non_conformant_response_falls_back() -> None:
-    """A valid Response that fails strict ParsedResponse validation still yields output_parsed.
-
-    Mirrors Fireworks, which returns usage.output_tokens_details=None (rejected by the stricter
-    ParsedResponse schema). The lenient fallback must still surface the parsed message text.
-    """
-    response = _make_response('{"name": "Dana", "age": 9}')
-    # output_tokens_details=None is what trips ParsedResponse validation.
-    response.usage = ResponseUsage.model_construct(
-        input_tokens=5,
-        output_tokens=3,
-        total_tokens=8,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
-        output_tokens_details=None,
-    )
-
-    parsed = parse_responses_output(response, DataclassModel)
-    assert isinstance(parsed, ParsedResponse)
-    assert isinstance(parsed.output_parsed, DataclassModel)
-    assert parsed.output_parsed.age == 9
 
 
 def test_parse_responses_output_basemodel() -> None:

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -137,6 +137,24 @@ def test_build_responses_text_format_is_strict() -> None:
         assert fmt["schema"]["additionalProperties"] is False
 
 
+def test_make_schema_strict_fallback() -> None:
+    """The fallback (used if OpenAI's private helper disappears) enforces strictness on nested objects."""
+    from any_llm.utils.structured_output import _make_schema_strict
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "nested": {"type": "object", "properties": {"x": {"type": "integer"}}},
+        },
+    }
+    strict = _make_schema_strict(schema)
+    assert strict["additionalProperties"] is False
+    assert strict["required"] == ["name", "nested"]
+    assert strict["properties"]["nested"]["additionalProperties"] is False
+    assert strict["properties"]["nested"]["required"] == ["x"]
+
+
 def test_parse_responses_output_roundtrips_json_schema_text_format() -> None:
     """Regression: a json_schema text.format must survive the model_dump round-trip.
 

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -129,6 +129,40 @@ def test_build_responses_text_format_dataclass() -> None:
     assert "age" in text_config["format"]["schema"]["properties"]
 
 
+def test_build_responses_text_format_is_strict() -> None:
+    """The text format must be strict so OpenAI accepts it and lenient providers echo the schema back."""
+    for model in (PydanticModel, DataclassModel):
+        fmt = build_responses_text_format(model)["format"]
+        assert fmt["strict"] is True
+        assert fmt["schema"]["additionalProperties"] is False
+
+
+def test_parse_responses_output_roundtrips_json_schema_text_format() -> None:
+    """Regression: a json_schema text.format must survive the model_dump round-trip.
+
+    The OpenAI type stores the schema under the Python attribute ``schema_`` with an alias of
+    ``schema``; dumping without ``by_alias=True`` drops it and re-validation fails.
+    """
+    from openai.types.responses import ResponseFormatTextJSONSchemaConfig
+    from openai.types.responses.response_text_config import ResponseTextConfig
+
+    response = _make_response('{"name": "Carol", "age": 5}')
+    response.text = ResponseTextConfig(
+        format=ResponseFormatTextJSONSchemaConfig.model_validate(
+            {
+                "name": "DataclassModel",
+                "schema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                "type": "json_schema",
+                "strict": True,
+            }
+        )
+    )
+
+    parsed = parse_responses_output(response, DataclassModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert parsed.output_parsed.age == 5
+
+
 def test_parse_responses_output_basemodel() -> None:
     parsed = parse_responses_output(_make_response('{"name": "Alice", "age": 30}'), PydanticModel)
     assert isinstance(parsed, ParsedResponse)

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -2,6 +2,7 @@ import dataclasses
 from typing import Any
 
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses.response_usage import InputTokensDetails, ResponseUsage
 from pydantic import BaseModel
 
 from any_llm.types.responses import ParsedResponse, Response
@@ -180,6 +181,28 @@ def test_parse_responses_output_roundtrips_json_schema_text_format() -> None:
     assert isinstance(parsed, ParsedResponse)
     assert isinstance(parsed.output_parsed, DataclassModel)
     assert parsed.output_parsed.age == 5
+
+
+def test_parse_responses_output_non_conformant_response_falls_back() -> None:
+    """A valid Response that fails strict ParsedResponse validation still yields output_parsed.
+
+    Mirrors Fireworks, which returns usage.output_tokens_details=None (rejected by the stricter
+    ParsedResponse schema). The lenient fallback must still surface the parsed message text.
+    """
+    response = _make_response('{"name": "Dana", "age": 9}')
+    # output_tokens_details=None is what trips ParsedResponse validation.
+    response.usage = ResponseUsage.model_construct(
+        input_tokens=5,
+        output_tokens=3,
+        total_tokens=8,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=None,
+    )
+
+    parsed = parse_responses_output(response, DataclassModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, DataclassModel)
+    assert parsed.output_parsed.age == 9
 
 
 def test_parse_responses_output_basemodel() -> None:


### PR DESCRIPTION
## Description

Fixes the failing `main` integration tests. Two real bugs in the Responses API structured-output path, plus two deprecated test models.

**1. Structured-output Responses bug (openai, groq, huggingface)**

The dataclass Responses path (`build_responses_text_format` -> `parse_responses_output`) failed across all three providers. The BaseModel path passed because it uses the SDK's native `responses.parse()` and never hits this code. Two defects in `src/any_llm/utils/structured_output.py`:

- Non-strict schema. `build_responses_text_format` emitted a plain JSON schema with no `additionalProperties: false` and no `strict`. OpenAI rejected it (`400 ... 'additionalProperties' is required to be supplied and to be false`), and lenient providers (Groq, HuggingFace) only echo back a complete `text.format` (including the `schema` field) when `strict` is set. Now builds the same strict schema `responses.parse()` sends, via a new `get_strict_json_schema` helper (reusing `openai.lib._pydantic._ensure_strict_json_schema`, consistent with the existing `openai.lib._parsing` import in the HF provider).
- Alias dropped on round-trip. `parse_responses_output` did `response.model_dump(warnings=False)` then re-validated as `ParsedResponse`. OpenAI's `ResponseFormatTextJSONSchemaConfig` stores the schema under attribute `schema_` with alias `schema`; without `by_alias=True` the dump emitted `schema_`, so re-validation failed (`schema Field required`). Fixed with `by_alias=True`.

**2. Deprecated integration test models (tests/conftest.py)**

- `cerebras` `llama3.1-8b` was deprecated 2026-05-27 -> `gpt-oss-120b` (current production model, already used elsewhere in the repo).
- `sambanova` vision model `Llama-4-Maverick-17B-128E-Instruct` is no longer available -> `gemma-4-31B-it` (current SambaNova multimodal model).

Note: I have no Cerebras or SambaNova API key, so these two conftest changes are grounded in current provider docs but not runtime-verified. The structured-output fix is verified end-to-end against the real OpenAI API.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Investigated the failing integration tests, root-caused the two structured-output defects, and refreshed deprecated provider model IDs. The OpenAI structured-output fix was verified end-to-end; the Cerebras/SambaNova model swaps are based on current provider docs (no API keys available locally to verify).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter JSON Schema for structured outputs and ensured text-format responses are generated as strict; parsing now preserves alias-only schema fields and handles validation failures gracefully.

* **New Features**
  * Added a mechanism to produce a strict JSON schema variant for response formats.

* **Tests**
  * Added unit tests for strict-schema generation, nested-object strictness, and round‑trip parsing.

* **Chores**
  * Updated test model configurations for two providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->