### PR TITLE
feat(messages): accept raw output_config dict for non-Pydantic structured output

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -691,7 +691,7 @@ class AnyLLM(ABC):
         metadata: dict[str, Any] | None = None,
         thinking: dict[str, Any] | None = None,
         cache_control: dict[str, Any] | None = None,
-        output_format: type | None = None,
+        output_format: type | dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> MessageResponse | ParsedMessage[Any] | AsyncIterator[MessageStreamEvent]:
         """Create a message using the Anthropic Messages API asynchronously.
@@ -714,10 +714,11 @@ class AnyLLM(ABC):
             metadata: Request metadata.
             thinking: Thinking/reasoning configuration.
             cache_control: Cache control configuration for prompt caching.
-            output_format: Structured-output type, mirroring Anthropic's
-                ``messages.parse(output_format=...)``. A Pydantic ``BaseModel`` or dataclass
-                makes the call return Anthropic's ``ParsedMessage``, with the typed object on
-                its ``parsed_output`` property. Not supported with ``stream=True``.
+            output_format: Structured output, mirroring Anthropic's ``messages.parse``/
+                ``output_config``. Either a Pydantic ``BaseModel``/dataclass **type** (typed
+                ``parsed_output``) or a raw Anthropic ``output_config`` **dict** for non-Pydantic
+                JSON schemas (``parsed_output`` holds the parsed JSON). The call returns
+                Anthropic's ``ParsedMessage``. Not supported with ``stream=True``.
             **kwargs: Additional provider-specific arguments.
 
         Returns:
@@ -728,7 +729,7 @@ class AnyLLM(ABC):
             ValueError: If `output_format` is combined with `stream=True`.
 
         """
-        if is_structured_output_type(output_format) and stream:
+        if output_format is not None and stream:
             msg = "stream is not supported for output_format"
             raise ValueError(msg)
 
@@ -751,9 +752,10 @@ class AnyLLM(ABC):
         )
         result = await self._amessages(params, **kwargs)
 
-        # The Anthropic provider already returns a ParsedMessage via native messages.parse;
-        # for bridged providers, build the same shape from the response's JSON text.
-        if is_structured_output_type(output_format) and isinstance(result, MessageResponse):
+        # The Anthropic provider already returns a ParsedMessage via native messages.parse (typed
+        # case); for the raw-dict case and for all bridged providers it returns a MessageResponse,
+        # so build the same ParsedMessage shape from the response's JSON text here.
+        if output_format is not None and isinstance(result, MessageResponse):
             return build_parsed_message(result, output_format)
 
         return result

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -539,7 +539,7 @@ def messages(
     metadata: dict[str, Any] | None = None,
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
-    output_format: type | None = None,
+    output_format: type | dict[str, Any] | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
     client_args: dict[str, Any] | None = None,
@@ -564,9 +564,11 @@ def messages(
         metadata: Request metadata.
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
-        output_format: Structured-output type, mirroring Anthropic's ``messages.parse(output_format=...)``.
-            A Pydantic ``BaseModel`` or dataclass makes the call return Anthropic's ``ParsedMessage``,
-            with the typed object on its ``parsed_output`` property. Not supported with streaming.
+        output_format: Structured output, mirroring Anthropic's ``messages.parse``/``output_config``.
+            Either a Pydantic ``BaseModel``/dataclass **type** (typed ``parsed_output``) or a raw
+            Anthropic ``output_config`` **dict** for non-Pydantic JSON schemas (``parsed_output``
+            holds the parsed JSON). The call returns Anthropic's ``ParsedMessage``. Not supported
+            with streaming.
         api_key: API key for the provider.
         api_base: Base URL for the provider API.
         client_args: Additional provider-specific arguments for client instantiation.
@@ -621,7 +623,7 @@ async def amessages(
     metadata: dict[str, Any] | None = None,
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
-    output_format: type | None = None,
+    output_format: type | dict[str, Any] | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
     client_args: dict[str, Any] | None = None,
@@ -646,9 +648,11 @@ async def amessages(
         metadata: Request metadata.
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
-        output_format: Structured-output type, mirroring Anthropic's ``messages.parse(output_format=...)``.
-            A Pydantic ``BaseModel`` or dataclass makes the call return Anthropic's ``ParsedMessage``,
-            with the typed object on its ``parsed_output`` property. Not supported with streaming.
+        output_format: Structured output, mirroring Anthropic's ``messages.parse``/``output_config``.
+            Either a Pydantic ``BaseModel``/dataclass **type** (typed ``parsed_output``) or a raw
+            Anthropic ``output_config`` **dict** for non-Pydantic JSON schemas (``parsed_output``
+            holds the parsed JSON). The call returns Anthropic's ``ParsedMessage``. Not supported
+            with streaming.
         api_key: API key for the provider.
         api_base: Base URL for the provider API.
         client_args: Additional provider-specific arguments for client instantiation.

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -19,6 +19,7 @@ from any_llm.types.messages import (
     MessageStreamEvent,
     ThinkingBlock,
 )
+from any_llm.utils.structured_output import is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
 try:
@@ -193,14 +194,21 @@ class BaseAnthropicProvider(AnyLLM, ABC):
     ) -> MessageResponse | ParsedMessage[Any] | AsyncIterator[MessageStreamEvent]:
         """Native Anthropic Messages API pass-through.
 
-        When ``output_format`` is set, uses native ``messages.parse`` (which drives the GA
-        ``output_config`` primitive) so generation is schema-constrained, and returns the
-        SDK's ``ParsedMessage`` unchanged.
+        When ``output_format`` is a structured-output type, uses native ``messages.parse``
+        (which drives the GA ``output_config`` primitive) and returns the SDK's ``ParsedMessage``
+        unchanged. When it is a raw ``output_config`` dict, passes it straight to native
+        ``messages.create(output_config=...)`` and returns a ``MessageResponse`` (the base layer
+        then builds the matching ``ParsedMessage`` from its JSON text).
         """
         if params.output_format is not None:
-            parse_kwargs = params.model_dump(exclude_none=True, exclude={"output_format", "stream"})
-            parse_kwargs.update(kwargs)
-            return await self.client.messages.parse(output_format=params.output_format, **parse_kwargs)
+            native_kwargs = params.model_dump(exclude_none=True, exclude={"output_format", "stream"})
+            native_kwargs.update(kwargs)
+            if is_structured_output_type(params.output_format):
+                return await self.client.messages.parse(output_format=params.output_format, **native_kwargs)
+            message = await self.client.messages.create(
+                output_config=cast("Any", params.output_format), **native_kwargs
+            )
+            return self._convert_native_message_to_response(message)
 
         api_kwargs = params.model_dump(exclude_none=True)
         api_kwargs.pop("stream", None)

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -119,11 +119,14 @@ class MessagesParams(BaseModel):
     cache_control: dict[str, Any] | None = None
     """Cache control configuration for prompt caching"""
 
-    output_format: type | None = None
-    """Structured-output type, mirroring Anthropic's ``messages.parse(output_format=...)``.
+    output_format: type | dict[str, Any] | None = None
+    """Structured output, mirroring Anthropic's ``messages.parse``/``output_config``.
 
-    A Pydantic ``BaseModel`` subclass or a dataclass type. The Anthropic provider passes it
-    to native ``messages.parse`` (which builds ``output_config.format`` from it); other
-    providers route it through the completion bridge. Either way the result is Anthropic's
-    ``ParsedMessage``, with the typed object on its ``parsed_output`` property.
+    Either a Pydantic ``BaseModel`` subclass or dataclass **type**, or a raw Anthropic
+    ``output_config`` **dict** (e.g. ``{"format": {"type": "json_schema", "schema": {...}}}``)
+    for non-Pydantic JSON schemas. A type goes to native ``messages.parse`` on Anthropic; a
+    dict is passed through to native ``messages.create(output_config=...)``. Other providers
+    route either form through the completion bridge. The result is Anthropic's ``ParsedMessage``:
+    its ``parsed_output`` holds the typed object for a type, or the parsed JSON (plain
+    ``dict``/``list``) for a raw schema.
     """

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from any_llm.types.messages import (
     ContentBlockDeltaEvent,
@@ -24,12 +24,26 @@ from any_llm.types.messages import (
     ThinkingDelta,
     ToolUseBlock,
 )
+from any_llm.utils.structured_output import is_structured_output_type
 
 if TYPE_CHECKING:
     from anthropic.types import ContentBlock as SDKContentBlock
 
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
     from any_llm.types.messages import MessagesParams
+
+
+def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str, Any]:
+    """Translate a raw Anthropic ``output_config`` dict into a completion ``response_format``.
+
+    Lets the bridge carry a non-Pydantic JSON schema to non-Anthropic providers: the schema
+    under ``output_config["format"]["schema"]`` is rewrapped as the OpenAI ``json_schema``
+    response format. The name falls back to the schema's ``title`` (or ``"structured_output"``).
+    """
+    fmt = output_config.get("format") or {}
+    schema = fmt.get("schema") or {}
+    name = schema.get("title", "structured_output")
+    return {"type": "json_schema", "json_schema": {"name": name, "schema": schema}}
 
 
 def messages_params_to_completion_params(params: MessagesParams) -> dict[str, Any]:
@@ -62,7 +76,10 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
         result["stream"] = params.stream
 
     if params.output_format is not None:
-        result["response_format"] = params.output_format
+        if is_structured_output_type(params.output_format):
+            result["response_format"] = params.output_format
+        else:
+            result["response_format"] = _output_config_to_response_format(cast("dict[str, Any]", params.output_format))
 
     if params.tools:
         result["tools"] = _convert_tools_to_openai(params.tools)

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -143,30 +143,42 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
     return parsed
 
 
-def build_parsed_message(message: AnthropicMessage, output_format: type) -> ParsedMessage[Any]:
+def build_parsed_message(message: AnthropicMessage, output_format: type | dict[str, Any]) -> ParsedMessage[Any]:
     """Build Anthropic's ``ParsedMessage`` from a Messages API response.
 
     Mirrors what ``client.messages.parse`` returns: each text block becomes a
-    ``ParsedTextBlock`` whose ``parsed_output`` holds the typed object, and the message's
+    ``ParsedTextBlock`` whose ``parsed_output`` holds the parsed value, and the message's
     ``parsed_output`` property surfaces the first one. Used for providers without a native
     parse helper so the structured-output result shape matches Anthropic's exactly.
-    Works with both Pydantic BaseModel subclasses and dataclass types.
+
+    ``output_format`` is either a structured-output type (Pydantic ``BaseModel`` subclass or
+    dataclass), in which case ``parsed_output`` holds the typed object, or a raw Anthropic
+    ``output_config`` dict, in which case ``parsed_output`` holds the parsed JSON (a plain
+    ``dict``/``list``) and the generics are parametrized as ``Any``.
     """
+    import json
+
     from anthropic.types import TextBlock
     from anthropic.types.parsed_message import ParsedMessage, ParsedTextBlock
 
+    def _parse(text: str) -> Any:
+        if is_structured_output_type(output_format):
+            return parse_json_content(output_format, text)
+        return json.loads(text)
+
     # Parametrize the generics at runtime so pydantic validates parsed_output against the
     # requested type; route through Any since a type held in a variable is not valid as a
-    # static type parameter.
+    # static type parameter, and a raw schema has no Python type to validate against.
     parsed_text_block: Any = ParsedTextBlock
     parsed_message: Any = ParsedMessage
-    text_block_cls = parsed_text_block[output_format]
-    message_cls = parsed_message[output_format]
+    type_param: Any = output_format if is_structured_output_type(output_format) else Any
+    text_block_cls = parsed_text_block[type_param]
+    message_cls = parsed_message[type_param]
 
     content: list[Any] = []
     for block in message.content:
         if isinstance(block, TextBlock):
-            parsed = parse_json_content(output_format, block.text) if block.text else None
+            parsed = _parse(block.text) if block.text else None
             content.append(
                 text_block_cls(type="text", text=block.text, citations=block.citations, parsed_output=parsed)
             )

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import TYPE_CHECKING, Any, TypeGuard
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
@@ -156,8 +157,6 @@ def build_parsed_message(message: AnthropicMessage, output_format: type | dict[s
     ``output_config`` dict, in which case ``parsed_output`` holds the parsed JSON (a plain
     ``dict``/``list``) and the generics are parametrized as ``Any``.
     """
-    import json
-
     from anthropic.types import TextBlock
     from anthropic.types.parsed_message import ParsedMessage, ParsedTextBlock
 

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -161,7 +161,7 @@ def build_parsed_message(message: AnthropicMessage, output_format: type | dict[s
     from anthropic.types import TextBlock
     from anthropic.types.parsed_message import ParsedMessage, ParsedTextBlock
 
-    def _parse(text: str) -> Any:
+    def _parse(text: str) -> object:
         if is_structured_output_type(output_format):
             return parse_json_content(output_format, text)
         return json.loads(text)

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -224,6 +224,37 @@ async def test_amessages_output_format_uses_native_parse() -> None:
     # output_format is passed to parse as its dedicated kwarg; other params still flow through.
     call_kwargs = mock_client.messages.parse.call_args.kwargs
     assert call_kwargs["output_format"] is City
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_config_dict_passes_through_to_create() -> None:
+    """A raw output_config dict goes to native messages.create(output_config=...), not parse."""
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    mock_message = _make_message(content=[TextBlock(type="text", text='{"city_name": "Paris"}')])
+
+    mock_client = Mock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+    mock_client.messages.parse = AsyncMock()
+
+    provider = Mock(spec=BaseAnthropicProvider)
+    provider.client = mock_client
+    provider._convert_native_message_to_response = BaseAnthropicProvider._convert_native_message_to_response
+
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=1024,
+        output_format=output_config,
+    )
+    result = await BaseAnthropicProvider._amessages(provider, params)
+
+    # The raw-dict path returns a MessageResponse (the base layer builds the ParsedMessage).
+    assert isinstance(result, MessageResponse)
+    mock_client.messages.parse.assert_not_called()
+    mock_client.messages.create.assert_called_once()
+    call_kwargs = mock_client.messages.create.call_args.kwargs
+    assert call_kwargs["output_config"] == output_config
+    assert "output_format" not in call_kwargs
     assert call_kwargs["model"] == "claude-3-5-sonnet"
     assert call_kwargs["max_tokens"] == 1024
 

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -580,3 +580,51 @@ async def test_amessages_output_format_rejects_streaming() -> None:
             output_format=City,
             stream=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_config_dict_returns_parsed_message() -> None:
+    """A raw output_config dict yields a ParsedMessage with plain-JSON parsed_output via the bridge."""
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object", "title": "City"}}}
+
+    provider = _openai_provider()
+    provider._acompletion = AsyncMock(return_value=_json_completion())
+
+    result = await provider.amessages(
+        model="test-model",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=128,
+        output_format=output_config,
+    )
+
+    assert isinstance(result, ParsedMessage)
+    # No Python type: parsed_output is the JSON-loaded object.
+    assert result.parsed_output == {"city_name": "Paris"}
+    block = result.content[0]
+    assert isinstance(block, ParsedTextBlock)
+    assert block.parsed_output == {"city_name": "Paris"}
+
+    # The output_config schema is bridged as an OpenAI json_schema response_format.
+    completion_params = provider._acompletion.call_args.args[0]
+    assert completion_params.response_format == {
+        "type": "json_schema",
+        "json_schema": {"name": "City", "schema": {"type": "object", "title": "City"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_config_dict_rejects_streaming() -> None:
+    """A raw output_config dict combined with stream=True also raises ValueError."""
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+
+    provider = _openai_provider()
+    provider._acompletion = AsyncMock(return_value=_json_completion())
+
+    with pytest.raises(ValueError, match="stream is not supported for output_format"):
+        await provider.amessages(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=128,
+            output_format=output_config,
+            stream=True,
+        )

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -39,6 +39,39 @@ def test_basic_text_message_conversion() -> None:
     assert result["messages"][0]["content"] == "Hello"
 
 
+def test_output_format_type_passes_through_as_response_format() -> None:
+    """A structured-output type is forwarded to the bridge as the completion response_format."""
+    from pydantic import BaseModel
+
+    class Schema(BaseModel):
+        city: str
+
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format=Schema,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["response_format"] is Schema
+
+
+def test_output_config_dict_translated_to_json_schema_response_format() -> None:
+    """A raw Anthropic output_config dict becomes an OpenAI json_schema response_format."""
+    output_config = {"format": {"type": "json_schema", "schema": {"title": "City", "type": "object"}}}
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format=output_config,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {"name": "City", "schema": {"title": "City", "type": "object"}},
+    }
+
+
 def test_system_message_prepended() -> None:
     """Test that system message is prepended as a system role message."""
     params = MessagesParams(

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -72,6 +72,22 @@ def test_output_config_dict_translated_to_json_schema_response_format() -> None:
     }
 
 
+def test_output_config_without_title_uses_structured_output_name() -> None:
+    """A schema with no title falls back to the default json_schema name."""
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format=output_config,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {"name": "structured_output", "schema": {"type": "object"}},
+    }
+
+
 def test_system_message_prepended() -> None:
     """Test that system message is prepended as a system role message."""
     params = MessagesParams(

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -309,3 +309,22 @@ def test_build_parsed_message_raw_output_config_dict() -> None:
     block = parsed.content[0]
     assert isinstance(block, ParsedTextBlock)
     assert block.parsed_output == {"name": "Alice", "age": 30}
+
+
+def test_build_parsed_message_raw_dict_malformed_json_raises() -> None:
+    """Malformed text on the raw-dict path raises raw, mirroring the typed path.
+
+    The typed path lets pydantic's ValidationError propagate; the raw-dict path
+    likewise lets json.loads raise JSONDecodeError (a ValueError subclass) rather
+    than wrapping it, so both stay consistent.
+    """
+    import json
+
+    import pytest
+    from anthropic.types import TextBlock
+
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    message = _make_anthropic_message([TextBlock(type="text", text="{not valid json")])
+
+    with pytest.raises(json.JSONDecodeError):
+        build_parsed_message(message, output_config)

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -292,3 +292,20 @@ def test_build_parsed_message_passes_non_text_blocks_through() -> None:
     assert isinstance(text_block, ParsedTextBlock)
     assert text_block.parsed_output is None
     assert parsed.parsed_output is None
+
+
+def test_build_parsed_message_raw_output_config_dict() -> None:
+    """A raw output_config dict yields a ParsedMessage whose parsed_output is plain JSON."""
+    from anthropic.types import TextBlock
+    from anthropic.types.parsed_message import ParsedMessage, ParsedTextBlock
+
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    message = _make_anthropic_message([TextBlock(type="text", text='{"name": "Alice", "age": 30}')])
+    parsed = build_parsed_message(message, output_config)
+
+    assert isinstance(parsed, ParsedMessage)
+    # No Python type to validate into: parsed_output is the JSON-loaded object.
+    assert parsed.parsed_output == {"name": "Alice", "age": 30}
+    block = parsed.content[0]
+    assert isinstance(block, ParsedTextBlock)
+    assert block.parsed_output == {"name": "Alice", "age": 30}

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -1,6 +1,8 @@
 import dataclasses
+import json
 from typing import Any
 
+import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from pydantic import BaseModel
 
@@ -318,9 +320,6 @@ def test_build_parsed_message_raw_dict_malformed_json_raises() -> None:
     likewise lets json.loads raise JSONDecodeError (a ValueError subclass) rather
     than wrapping it, so both stay consistent.
     """
-    import json
-
-    import pytest
     from anthropic.types import TextBlock
 
     output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}


### PR DESCRIPTION
## Description

@njbrake offered this one there — "the raw `output_config` dict passthrough for non-Pydantic JSON schemas is a clean, self-contained follow-up and it is yours if you want it" — so I'm picking it up.

#1133 added structured output to the Messages API via `output_format`, but only as a Pydantic `BaseModel`/dataclass **type**. This extends `output_format` to also accept a raw Anthropic `output_config` **dict**, so callers with a non-Pydantic JSON schema (e.g. loaded from a file) can use schema-constrained generation without defining a Python type.

It keeps #1133's approach of mirroring the Anthropic Messages API:
- **Anthropic provider**: a dict is passed straight to native `messages.create(output_config=...)` (the same GA primitive `messages.parse` drives for the typed path); a type still uses `messages.parse`.
- **Other providers**: the dict's schema is bridged to the completion `response_format` as an OpenAI `json_schema`, the same path types already take.
- **Return shape**: both produce Anthropic's `ParsedMessage`. For a type, `parsed_output` holds the typed object; for a raw dict, it holds the parsed JSON (a plain `dict`/`list`), since there is no Python type to validate into.
- `output_format` with `stream=True` raises `ValueError` for the dict case too, matching the typed path.

No SDK floor bump beyond what #1133 already assumes — `output_config` is the same GA primitive. Validated against the pinned `anthropic` (0.104.1): `messages.create(output_config=...)` accepts the dict and the `OutputConfigParam`/`JSONOutputFormatParam` shape matches.

## PR Type

- 🆕 New Feature

## Relevant issues

Follows #1073 / #1133.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Architecture and all design decisions are @avalyset's, carried over from the #1073 analysis — the cross-provider raw-dict passthrough returning ParsedMessage, the bridge semantics, and the streaming behavior. Claude implemented the chosen design and wrote the tests.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured-output now accepts raw JSON-schema-style `output_config` dictionaries in addition to type-based definitions, with matching parsing behaviour.

* **Bug Fixes**
  * Improved handling of structured parsing vs non-parsed text paths to ensure the correct output is produced for each `output_format` form.

* **Documentation**
  * Updated public API docs to describe both supported structured-output inputs and reiterated that structured parsing is not supported with streaming.

* **Tests**
  * Added coverage for the raw `output_config` pass-through path, JSON decoding/parsing outcomes, translation to response formats, and the expected error when used with streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->