### PR TITLE
fix(openai): forward embedding dimensions to the client exactly once

### DIFF
--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, cast
 
 from openai import AsyncOpenAI
 from openai._streaming import AsyncStream
-from openai._types import NOT_GIVEN, Omit
+from openai._types import Omit
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
 from openai.types.chat.parsed_chat_completion import ParsedChatCompletion as OpenAIParsedChatCompletion
@@ -279,11 +279,15 @@ class BaseOpenAIProvider(AnyLLM):
             msg = "This provider does not support embeddings."
             raise NotImplementedError(msg)
 
+        # `_convert_embedding_params` already folds `dimensions` (and any other
+        # caller kwargs) into the dict, so spread it straight through — mirroring
+        # `_acompletion`, which names only `model`/`messages` and spreads the
+        # rest. Forwarding `dimensions` explicitly *as well* passed it twice and
+        # raised "got multiple values for keyword argument 'dimensions'".
         embedding_kwargs = self._convert_embedding_params(inputs, **kwargs)
         return self._convert_embedding_response(
             await self.client.embeddings.create(
                 model=model,
-                dimensions=kwargs.get("dimensions", NOT_GIVEN),
                 **embedding_kwargs,
             )
         )

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -1,12 +1,22 @@
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from any_llm import AnyLLM
 from any_llm.api import aembedding
 from any_llm.constants import LLMProvider
+from any_llm.providers.openai.openai import OpenaiProvider
 from any_llm.types.completion import CreateEmbeddingResponse, Embedding, Usage
+
+
+def _embedding_response() -> CreateEmbeddingResponse:
+    return CreateEmbeddingResponse(
+        data=[Embedding(embedding=[0.1, 0.2, 0.3], index=0, object="embedding")],
+        model="text-embedding-3-small",
+        object="list",
+        usage=Usage(prompt_tokens=2, total_tokens=2),
+    )
 
 
 @pytest.mark.asyncio
@@ -48,3 +58,44 @@ async def test_embedding_unsupported_provider_raises_not_implemented(provider: L
             await aembedding(f"{provider.value}/does-not-matter", inputs="Hello world", api_key="test_key")
     else:
         pytest.skip(f"{provider.value} supports embeddings, skipping")
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_openai_embedding_forwards_dimensions_once(mock_openai_class: MagicMock) -> None:
+    """Regression: `dimensions` must reach the OpenAI client exactly once.
+
+    It used to be forwarded both explicitly and via ``**embedding_kwargs``
+    (``_convert_embedding_params`` copies it out of ``kwargs``), which raised
+    ``got multiple values for keyword argument 'dimensions'`` for every
+    embeddings request that set ``dimensions``.
+    """
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_response = _embedding_response()
+    mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+    provider = OpenaiProvider(api_key="test_key")
+    result = await provider._aembedding("text-embedding-3-small", "hello world", dimensions=512)
+
+    assert result == mock_response
+    mock_client.embeddings.create.assert_awaited_once_with(
+        model="text-embedding-3-small", dimensions=512, input="hello world"
+    )
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+@pytest.mark.asyncio
+async def test_openai_embedding_omits_dimensions_when_absent(mock_openai_class: MagicMock) -> None:
+    """When `dimensions` is not passed, it must not be forwarded to the client."""
+    mock_client = AsyncMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create = AsyncMock(return_value=_embedding_response())
+
+    provider = OpenaiProvider(api_key="test_key")
+    await provider._aembedding("text-embedding-3-small", "hello world")
+
+    kwargs = mock_client.embeddings.create.await_args.kwargs
+    assert "dimensions" not in kwargs
+    assert kwargs["model"] == "text-embedding-3-small"
+    assert kwargs["input"] == "hello world"


### PR DESCRIPTION
## Description

`BaseOpenAIProvider._aembedding` forwarded `dimensions` to the OpenAI client twice — once explicitly (`dimensions=kwargs.get("dimensions", NOT_GIVEN)`) and again via `**embedding_kwargs` (which `_convert_embedding_params` builds from `**kwargs`). Every embeddings request that set `dimensions` raised:

```
AsyncEmbeddings.create() got multiple values for keyword argument 'dimensions'
```

The converter already folds `dimensions` (and any other caller kwargs) into the request dict, so this spreads it straight through — mirroring `_acompletion`, which names only `model`/`messages` and spreads the rest. Removes the now-unused `NOT_GIVEN` import.

Verified equivalent for both branches: when `dimensions` is set it reaches the client exactly once; when absent it is omitted (the OpenAI SDK default), so behavior is unchanged apart from no longer crashing.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1135

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where embedding API requests were failing due to duplicate parameter forwarding, eliminating "multiple values for keyword argument" errors.

* **Tests**
  * Added regression tests for embedding parameter handling, including verification of dimension parameter forwarding and omission when absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->