### PR TITLE
feat(otari): image+audio via otari 0.2.0, web search/MCP e2e, run otari in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ databricks = []
 deepseek = []
 fireworks = []
 otari = [
-  "otari>=0.1.0",
+  "otari>=0.2.0",
 ]
 github = []
 inception = []

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -168,12 +168,9 @@ class OtariProvider(BaseOpenAIProvider):
     SUPPORTS_MODERATION = True
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = True
-    # otari 0.1.0's public async client dropped the embedded OpenAI passthrough and
-    # does not expose image generation or audio (speech/transcription). Tracked for
-    # upstream re-enablement; see the otari issue linked in the any-llm PR.
-    SUPPORTS_IMAGE_GENERATION = False
-    SUPPORTS_AUDIO_TRANSCRIPTION = False
-    SUPPORTS_AUDIO_SPEECH = False
+    SUPPORTS_IMAGE_GENERATION = True
+    SUPPORTS_AUDIO_TRANSCRIPTION = True
+    SUPPORTS_AUDIO_SPEECH = True
     SUPPORTS_RERANK = True
 
     otari_client: Any
@@ -392,27 +389,48 @@ class OtariProvider(BaseOpenAIProvider):
 
     @override
     async def _aimage_generation(self, params: ImageGenerationParams, **kwargs: Any) -> ImagesResponse:
-        msg = (
-            "otari 0.1.0 does not expose image generation in its public async client. "
-            "Re-enable once otari adds it upstream."
+        from any_llm.types.image import ImagesResponse
+
+        api_kwargs = params.to_api_kwargs()
+        api_kwargs.update(kwargs)
+        prompt = api_kwargs.pop("prompt")
+        result = await self.otari_client.image_generation(
+            model=params.model_id,
+            prompt=prompt,
+            **api_kwargs,
         )
-        raise NotImplementedError(msg)
+        return ImagesResponse.model_validate(_as_plain_dict(result))
 
     @override
     async def _atranscription(self, params: AudioTranscriptionParams, **kwargs: Any) -> Transcription:
-        msg = (
-            "otari 0.1.0 does not expose audio transcription in its public async client. "
-            "Re-enable once otari adds it upstream."
+        from any_llm.types.audio import Transcription
+
+        api_kwargs = params.to_api_kwargs()
+        api_kwargs.update(kwargs)
+        file_bytes = params.file if isinstance(params.file, bytes) else params.file.read()
+        result = await self.otari_client.transcription(
+            model=params.model_id,
+            file=file_bytes,
+            **api_kwargs,
         )
-        raise NotImplementedError(msg)
+        # otari wraps the response: ``json`` for JSON formats, ``text`` for text/srt/vtt.
+        if result.json is not None:
+            return Transcription.model_validate(result.json)
+        return Transcription(text=result.text)
 
     @override
     async def _aspeech(self, params: AudioSpeechParams, **kwargs: Any) -> bytes:
-        msg = (
-            "otari 0.1.0 does not expose audio speech in its public async client. "
-            "Re-enable once otari adds it upstream."
+        api_kwargs = params.to_api_kwargs()
+        api_kwargs.update(kwargs)
+        return cast(
+            "bytes",
+            await self.otari_client.speech(
+                model=params.model_id,
+                input=params.input,
+                voice=params.voice,
+                **api_kwargs,
+            ),
         )
-        raise NotImplementedError(msg)
 
     @override
     async def _amoderation(

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -2,12 +2,15 @@ import os
 
 from any_llm.constants import LLMProvider
 
+# otari is a hosted gateway (api.otari.ai), not a local server. It must stay out of
+# LOCAL_PROVIDERS so the token-bearing integration job (INCLUDE_LOCAL_PROVIDERS=false)
+# actually parametrizes and runs it; the unconfigured case is skipped in
+# tests/integration/conftest.py instead.
 LOCAL_PROVIDERS = [
     LLMProvider.LLAMACPP,
     LLMProvider.OLLAMA,
     LLMProvider.LMSTUDIO,
     LLMProvider.LLAMAFILE,
-    LLMProvider.OTARI,
 ]
 
 # Providers that should never run in CI (only for local development)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -2,10 +2,6 @@ import os
 
 from any_llm.constants import LLMProvider
 
-# otari is a hosted gateway (api.otari.ai), not a local server. It must stay out of
-# LOCAL_PROVIDERS so the token-bearing integration job (INCLUDE_LOCAL_PROVIDERS=false)
-# actually parametrizes and runs it; the unconfigured case is skipped in
-# tests/integration/conftest.py instead.
 LOCAL_PROVIDERS = [
     LLMProvider.LLAMACPP,
     LLMProvider.OLLAMA,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,12 +42,12 @@ _OTARI_SKIPPED_TESTS: dict[str, str] = {
     "test_responses_async": "no Responses-API upstream on the test account (otari-ai#907)",
     "test_responses_format_basemodel": "no Responses-API upstream on the test account (otari-ai#907)",
     "test_responses_format_dataclass": "no Responses-API upstream on the test account (otari-ai#907)",
-    "test_create_and_retrieve_batch": "batch needs provider_name + gateway batch support",
-    "test_list_batches": "batch needs provider_name + gateway batch support",
-    "test_retrieve_batch_results_not_complete": "batch needs provider_name + gateway batch support",
-    "test_retrieve_batch_results_with_api_function": "batch needs provider_name + gateway batch support",
-    "test_completion_with_image": "gateway returns 502 on multimodal image content",
-    "test_completion_with_pdf": "gateway returns 502 on multimodal pdf content",
+    "test_create_and_retrieve_batch": "batch endpoints return 404 on the hosted platform (otari-ai#1117)",
+    "test_list_batches": "batch endpoints return 404 on the hosted platform (otari-ai#1117)",
+    "test_retrieve_batch_results_not_complete": "batch endpoints return 404 on the hosted platform (otari-ai#1117)",
+    "test_retrieve_batch_results_with_api_function": "batch endpoints return 404 on the hosted platform (otari-ai#1117)",
+    "test_completion_with_image": "gateway returns 502 on multimodal image content (otari#183)",
+    "test_completion_with_pdf": "gateway returns 502 on multimodal pdf content (otari#183)",
 }
 
 

--- a/tests/integration/test_otari_builtin_tools.py
+++ b/tests/integration/test_otari_builtin_tools.py
@@ -1,0 +1,79 @@
+"""End-to-end tests for otari gateway built-in tools: web search and MCP execution.
+
+These are otari-specific (not provider-parametrized): web search is the gateway-managed
+``otari_web_search`` tool type, and MCP execution is driven by the top-level
+``mcp_servers`` request field. Both run inside the gateway rather than the upstream
+provider, so they only exist on otari.
+
+The tests require a real otari endpoint. They run in platform mode against the hosted
+gateway when ``OTARI_AI_TOKEN`` is set, or against a self-hosted deployment via
+``OTARI_API_BASE`` (or the legacy ``GATEWAY_API_BASE``); otherwise they skip. CI provides
+``OTARI_AI_TOKEN`` and lists otari in ``EXPECTED_PROVIDERS``, so they run there.
+"""
+
+import os
+
+import pytest
+
+from any_llm import AnyLLM, LLMProvider
+from any_llm.types.completion import ChatCompletion
+
+_OTARI_ENV_VARS = ("OTARI_AI_TOKEN", "OTARI_API_BASE", "GATEWAY_API_BASE")
+
+# The hosted test account routes Anthropic completions reliably (mirrors tests/conftest.py).
+_OTARI_MODEL = "anthropic:claude-haiku-4-5"
+
+# Public streamable-HTTP MCP server used to exercise gateway MCP execution. Its tools are
+# scoped to the Hugging Face Hub, so a model-lookup prompt forces a real tool call.
+_MCP_SERVER = {"name": "huggingface", "url": "https://huggingface.co/mcp"}
+
+pytestmark = pytest.mark.skipif(
+    not any(os.getenv(var) for var in _OTARI_ENV_VARS),
+    reason=f"otari endpoint not configured (set {' or '.join(_OTARI_ENV_VARS)})",
+)
+
+
+def _make_client() -> AnyLLM:
+    # Let the provider auto-resolve auth: a platform token selects platform mode, otherwise
+    # it falls back to OTARI_API_BASE/GATEWAY_API_BASE for a self-hosted deployment.
+    return AnyLLM.create(LLMProvider.OTARI)
+
+
+@pytest.mark.asyncio
+async def test_otari_web_search_returns_answer() -> None:
+    """tools=[{"type": "otari_web_search"}] runs the gateway web-search backend."""
+    llm = _make_client()
+    result = await llm.acompletion(
+        model=_OTARI_MODEL,
+        messages=[{"role": "user", "content": "Use web search to give me one news headline from today."}],
+        tools=[{"type": "otari_web_search"}],
+    )
+    assert isinstance(result, ChatCompletion)
+    content = result.choices[0].message.content
+    assert content is not None
+    assert content.strip()
+
+
+@pytest.mark.asyncio
+async def test_otari_mcp_execution_invokes_server_tool() -> None:
+    """mcp_servers=[...] makes the gateway connect to the MCP server and run its tools."""
+    llm = _make_client()
+    result = await llm.acompletion(
+        model=_OTARI_MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Use the Hugging Face tools to look up the model 'bert-base-uncased' and report its full model id."
+                ),
+            }
+        ],
+        mcp_servers=[_MCP_SERVER],
+        max_tool_iterations=5,
+    )
+    assert isinstance(result, ChatCompletion)
+    content = result.choices[0].message.content
+    assert content is not None
+    # The HF MCP lookup tool resolves the canonical id (google-bert/bert-base-uncased);
+    # a grounded answer echoes it.
+    assert "bert-base-uncased" in content.lower()

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -48,6 +48,9 @@ def _mock_otari_client() -> MagicMock:
     client.message = AsyncMock()
     client.embedding = AsyncMock()
     client.moderation = AsyncMock()
+    client.image_generation = AsyncMock()
+    client.transcription = AsyncMock()
+    client.speech = AsyncMock()
     client.rerank = AsyncMock()
     client.list_models = AsyncMock()
     client.retrieve_batch = AsyncMock()
@@ -282,36 +285,80 @@ async def test_otari_acompletion_rejects_stream_with_response_format() -> None:
         await provider._acompletion(params)
 
 
-def test_otari_does_not_advertise_image_or_audio_support() -> None:
-    # otari 0.1.0's public async client dropped the OpenAI passthrough that backed
-    # these capabilities; they should report as unsupported.
-    assert OtariProvider.SUPPORTS_IMAGE_GENERATION is False
-    assert OtariProvider.SUPPORTS_AUDIO_TRANSCRIPTION is False
-    assert OtariProvider.SUPPORTS_AUDIO_SPEECH is False
+def test_otari_advertises_image_and_audio_support() -> None:
+    # otari 0.2.0's public async client exposes image generation and audio (speech/
+    # transcription), so the provider wires them through and reports support.
+    assert OtariProvider.SUPPORTS_IMAGE_GENERATION is True
+    assert OtariProvider.SUPPORTS_AUDIO_TRANSCRIPTION is True
+    assert OtariProvider.SUPPORTS_AUDIO_SPEECH is True
 
 
 @pytest.mark.asyncio
-async def test_otari_image_generation_raises_not_implemented() -> None:
-    provider = _build_provider(_mock_otari_client())
+async def test_otari_image_generation_calls_client_and_converts() -> None:
+    mocked_client = _mock_otari_client()
+    mocked_client.image_generation.return_value = {"created": 0, "data": [{"url": "https://img/cat.png"}]}
+    provider = _build_provider(mocked_client)
     params = ImageGenerationParams(model_id="gpt-image", prompt="cat")
-    with pytest.raises(NotImplementedError):
-        await provider._aimage_generation(params, size="1024x1024")
+
+    result = await provider._aimage_generation(params, size="1024x1024")
+
+    mocked_client.image_generation.assert_awaited_once_with(model="gpt-image", prompt="cat", size="1024x1024")
+    assert result.data is not None
+    assert result.data[0].url == "https://img/cat.png"
 
 
 @pytest.mark.asyncio
-async def test_otari_transcription_raises_not_implemented() -> None:
-    provider = _build_provider(_mock_otari_client())
+async def test_otari_transcription_json_format_returns_text() -> None:
+    mocked_client = _mock_otari_client()
+    mocked_client.transcription.return_value = SimpleNamespace(json={"text": "hello world"}, text=None)
+    provider = _build_provider(mocked_client)
     params = AudioTranscriptionParams(model_id="whisper", file=b"audio", language="en")
-    with pytest.raises(NotImplementedError):
-        await provider._atranscription(params)
+
+    result = await provider._atranscription(params)
+
+    mocked_client.transcription.assert_awaited_once_with(model="whisper", file=b"audio", language="en")
+    assert result.text == "hello world"
 
 
 @pytest.mark.asyncio
-async def test_otari_speech_raises_not_implemented() -> None:
-    provider = _build_provider(_mock_otari_client())
+async def test_otari_transcription_text_format_returns_text() -> None:
+    mocked_client = _mock_otari_client()
+    mocked_client.transcription.return_value = SimpleNamespace(json=None, text="plain transcript")
+    provider = _build_provider(mocked_client)
+    params = AudioTranscriptionParams(model_id="whisper", file=b"audio", response_format="text")
+
+    result = await provider._atranscription(params)
+
+    assert result.text == "plain transcript"
+
+
+@pytest.mark.asyncio
+async def test_otari_transcription_reads_file_handle() -> None:
+    import io
+
+    mocked_client = _mock_otari_client()
+    mocked_client.transcription.return_value = SimpleNamespace(json={"text": "hi"}, text=None)
+    provider = _build_provider(mocked_client)
+    # IO handles do not pass AudioTranscriptionParams validation, so build the params
+    # without validation to exercise the file-handle (.read()) branch directly.
+    params = AudioTranscriptionParams.model_construct(model_id="whisper", file=io.BytesIO(b"audio-bytes"))
+
+    await provider._atranscription(params)
+
+    mocked_client.transcription.assert_awaited_once_with(model="whisper", file=b"audio-bytes")
+
+
+@pytest.mark.asyncio
+async def test_otari_speech_returns_bytes() -> None:
+    mocked_client = _mock_otari_client()
+    mocked_client.speech.return_value = b"audio-bytes"
+    provider = _build_provider(mocked_client)
     params = AudioSpeechParams(model_id="tts", input="hello", voice="alloy", response_format="mp3")
-    with pytest.raises(NotImplementedError):
-        await provider._aspeech(params)
+
+    result = await provider._aspeech(params)
+
+    mocked_client.speech.assert_awaited_once_with(model="tts", input="hello", voice="alloy", response_format="mp3")
+    assert result == b"audio-bytes"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_audio.py
+++ b/tests/unit/test_audio.py
@@ -401,7 +401,7 @@ def test_speech_params_rejects_extra_fields() -> None:
 
 
 def test_supports_audio_only_on_expected_providers() -> None:
-    expected_supported = {LLMProvider.OPENAI, LLMProvider.AZUREOPENAI}
+    expected_supported = {LLMProvider.OPENAI, LLMProvider.AZUREOPENAI, LLMProvider.OTARI}
 
     for provider_enum in expected_supported:
         cls = AnyLLM.get_provider_class(provider_enum)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -166,6 +166,7 @@ def test_supports_image_generation_only_on_expected_providers() -> None:
         LLMProvider.OPENAI,
         LLMProvider.AZUREOPENAI,
         LLMProvider.NEOSANTARA,
+        LLMProvider.OTARI,
     }
 
     for provider_enum in expected_supported:


### PR DESCRIPTION
## Description

otari 0.2.0 exposes image generation and audio (speech / transcription) on its
public async client, and the hosted gateway now serves web search and MCP
execution in prod. This PR wires those into the otari provider and adds the e2e
coverage requested in #1138.

Changes:

- Bump the `otari` extra to `>=0.2.0`.
- Re-enable `SUPPORTS_IMAGE_GENERATION`, `SUPPORTS_AUDIO_TRANSCRIPTION`, and
  `SUPPORTS_AUDIO_SPEECH` on `OtariProvider`, routing each through the 0.2.0
  public client methods (`image_generation`, `speech`, `transcription`) instead
  of raising `NotImplementedError`. `transcription` maps otari's
  `TranscriptionResult` (`.json` / `.text`) onto any-llm's `Transcription`.
- Add `tests/integration/test_otari_builtin_tools.py`: e2e tests for the
  gateway built-in tools, web search (the `otari_web_search` tool type) and MCP
  execution (the top-level `mcp_servers` field). Both are otari specific because
  those are gateway wire shapes with no shared any-llm abstraction. They are
  gated on a configured endpoint (`OTARI_AI_TOKEN` / `OTARI_API_BASE`).
- Remove otari from `LOCAL_PROVIDERS`. otari is a hosted gateway, so this lets
  the token bearing integration job (which runs with `INCLUDE_LOCAL_PROVIDERS=false`)
  actually parametrize and run it, and folds otari into the shared tool calling
  test (`test_agent_loop`).

Verified live against api.otari.ai: web search, MCP execution, completion,
streaming, reasoning, response_format, messages, and both tool calling tests
pass. The remaining gaps (list_models, embedding, moderation, responses, batch,
multimodal image/pdf) stay skipped via the existing `_OTARI_SKIPPED_TESTS`
entries and their tracking issues; each was re-verified as still unavailable on
the hosted test account.

Image / audio e2e is intentionally not added yet: the capability is wired and
unit tested, but the hosted test account has no image or audio models, so a
cross provider integration test would skip for otari. It can be added once those
models are routed.

## PR Type

- 🆕 New Feature
- 🚦 Infrastructure

## Relevant issues

Refs #1138

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

This PR was drafted by Claude via back and forth with @njbrake. The reasoning and
decisions are his; the prose and code drafting are Claude's.

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Live verification was run against api.otari.ai.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Otari provider now supports image generation.
  * Otari provider now supports audio transcription and audio speech (text-to-speech).
  * Otari built-in tools enabled, including web search and Model Context Protocol server tool execution.
* **Testing**
  * Added end-to-end integration tests covering Otari web search and MCP tool calls.
  * Updated unit tests and test expectations for supported image/audio formats; adjusted integration test skipping and provider parametrisation.
* **Chores**
  * Updated the Otari optional dependency to `otari>=0.2.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->