### PR TITLE
fix: repair the chronically-red integration test suite (provider bugs + drift)

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -147,17 +147,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # This job downloads several local models (ollama x3, llamafile, a llamacpp GGUF,
-      # and lmstudio's gemma-3-4b) plus a docker image, which fills the runner's ~14G of
-      # free disk and crashes the runner agent with "No space left on device", terminating
-      # the job mid-run. Reclaim ~25G by removing pre-installed toolchains we don't use.
-      - name: Free up disk space
-        run: |
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          df -h /
-
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: 3.13

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -147,6 +147,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      # This job downloads several local models (ollama x3, llamafile, a llamacpp GGUF,
+      # and lmstudio's gemma-3-4b) plus a docker image, which fills the runner's ~14G of
+      # free disk and crashes the runner agent with "No space left on device", terminating
+      # the job mid-run. Reclaim ~25G by removing pre-installed toolchains we don't use.
+      - name: Free up disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: 3.13

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -244,12 +244,12 @@ jobs:
 
       - name: Download LM Studio model
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
-        run: lms get google/gemma-3-4b --yes
+        run: lms get qwen/qwen3-1.7b --yes
 
       - name: Load model and start LM Studio server
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
         run: |
-          lms load google/gemma-3-4b --yes &
+          lms load qwen/qwen3-1.7b --yes &
           lms server start
 
       - name: Wait for LM Studio to be ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,22 @@ This repo uses `uv` for local dev (Python 3.11+). For the full, up-to-date comma
 - Do not use class-based test grouping (`class TestFoo:`). All tests should be standalone functions.
 - Do not add decorative section-separator comments (e.g., `# -----------` banners). Well-named test functions and natural file ordering are sufficient.
 - Place imports at the top of test files unless the import is for an optional dependency that may not be installed (e.g., provider-specific SDKs like `mistralai`, `cohere`). In that case, inline imports inside the test function are acceptable to avoid breaking the entire file.
+- Integration tests run on `main` post-merge, and on a PR only via the `run-integration-tests` label (auto-removed after each run); they are not a merge gate, so failures accumulate. A red suite is usually a backlog of unrelated causes, not one regression: check a test's history (`gh run view <id> --log`) before assuming a recent break, then root-cause each as an any-llm bug (fix + test), a deprecated/wrong test model (update `tests/conftest.py`, cite docs), missing CI infra (skip, naming it), or a provider outage (a whole provider failing at once, e.g. 429s, is transient).
+- The dataclass/dict structured-output path (`parse_responses_output`) is separate from the Pydantic `responses.parse()` path; a bug can hit one and not the other, so test both.
 
 ## Commit & Pull Request Guidelines
 
 - Commits follow the project’s history: Conventional Commits such as `feat(scope): ...`, `fix: ...`, `chore(deps): ...`, `tests: ...`.
 - PRs should follow [.github/pull_request_template.md](.github/pull_request_template.md): clear description, linked issues (e.g., `Fixes #123`), completed checklist, and AI-usage disclosure when applicable.
+
+## Definition of done
+
+Before requesting review, every PR must clear:
+
+1. **`uv run pre-commit run --all-files`** clean (ruff lint + format, `mypy` strict). Don't drop `# type: ignore` based on local mypy; CI `run-linter` is authoritative.
+2. **`uv run pytest tests/unit`** green, with tests for every branch in changed code (~85% patch coverage; Codecov gates it).
+3. **Integration tests for any provider/feature you touched**, run with real keys locally or via the `run-integration-tests` label on the PR. Don't claim a provider works without running it.
+4. **Every skip and fix is root-caused**, with a concrete reason (HTTP status, deprecated model, missing CI infra), never "flaky" or "does not reliably support".
 
 ## Mypy and Provider SDKs
 

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -289,8 +289,13 @@ def _convert_cohere_embedding_response(model: str, response: Any) -> CreateEmbed
 
     prompt_tokens = 0
     total_tokens = 0
-    if response.meta and response.meta.tokens:
-        prompt_tokens = int(response.meta.tokens.input_tokens or 0)
+    if response.meta:
+        # Cohere reports embed usage under meta.billed_units.input_tokens; meta.tokens is
+        # typically null for embeddings, so fall back to billed_units to avoid reporting 0.
+        if response.meta.tokens and response.meta.tokens.input_tokens:
+            prompt_tokens = int(response.meta.tokens.input_tokens)
+        elif response.meta.billed_units and response.meta.billed_units.input_tokens:
+            prompt_tokens = int(response.meta.billed_units.input_tokens)
         total_tokens = prompt_tokens
 
     return CreateEmbeddingResponse(

--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -292,9 +292,10 @@ def _convert_cohere_embedding_response(model: str, response: Any) -> CreateEmbed
     if response.meta:
         # Cohere reports embed usage under meta.billed_units.input_tokens; meta.tokens is
         # typically null for embeddings, so fall back to billed_units to avoid reporting 0.
-        if response.meta.tokens and response.meta.tokens.input_tokens:
+        # Use explicit None checks so an API-reported 0 is preserved rather than treated as absent.
+        if response.meta.tokens is not None and response.meta.tokens.input_tokens is not None:
             prompt_tokens = int(response.meta.tokens.input_tokens)
-        elif response.meta.billed_units and response.meta.billed_units.input_tokens:
+        elif response.meta.billed_units is not None and response.meta.billed_units.input_tokens is not None:
             prompt_tokens = int(response.meta.billed_units.input_tokens)
         total_tokens = prompt_tokens
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -418,7 +418,9 @@ class GoogleProvider(AnyLLM):
     ) -> Sequence[Batch]:
         """List batch jobs using the Google GenAI Batch API."""
         config_kwargs: dict[str, Any] = {}
-        if limit:
+        if limit is not None:
+            if limit <= 0:
+                return []
             config_kwargs["page_size"] = limit
         if after:
             config_kwargs["page_token"] = after
@@ -430,7 +432,7 @@ class GoogleProvider(AnyLLM):
             batches.append(_convert_google_batch_job_to_openai_batch(job))
             # page_size only caps results per page; the pager auto-follows every page,
             # so enforce limit as a total cap to stop once we have enough.
-            if limit and len(batches) >= limit:
+            if limit is not None and len(batches) >= limit:
                 break
         return batches
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -428,6 +428,10 @@ class GoogleProvider(AnyLLM):
         batches: list[Batch] = []
         async for job in pager:
             batches.append(_convert_google_batch_job_to_openai_batch(job))
+            # page_size only caps results per page; the pager auto-follows every page,
+            # so enforce limit as a total cap to stop once we have enough.
+            if limit and len(batches) >= limit:
+                break
         return batches
 
     @override

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -49,21 +49,19 @@ if TYPE_CHECKING:
     from any_llm.types.responses import ParsedResponse, Response, ResponsesParams
 
 
-def _normalize_tool_calls(tool_calls: Any) -> Any:
-    """Coerce HF tool-call ``function.arguments`` to a string.
+def _normalize_tool_calls(tool_calls: list[dict[str, Any]] | None) -> None:
+    """Coerce HF tool-call ``function.arguments`` to a string, in place.
 
     HuggingFace returns ``arguments: null`` for tool calls with no arguments (e.g. a
     parameterless function), but OpenAI's ``ChatCompletionMessage`` requires a string,
     so the raw payload fails validation. Default the missing arguments to ``"{}"``.
     """
-    if not isinstance(tool_calls, list):
-        return tool_calls
+    if not tool_calls:
+        return
     for tool_call in tool_calls:
-        if isinstance(tool_call, dict):
-            function = tool_call.get("function")
-            if isinstance(function, dict) and function.get("arguments") is None:
-                function["arguments"] = "{}"
-    return tool_calls
+        function = tool_call.get("function")
+        if isinstance(function, dict) and function.get("arguments") is None:
+            function["arguments"] = "{}"
 
 
 class HuggingfaceProvider(AnyLLM):
@@ -191,10 +189,11 @@ class HuggingfaceProvider(AnyLLM):
                 if "content" in msg["reasoning"]:
                     reasoning_obj = Reasoning(content=msg["reasoning"]["content"])
 
+            _normalize_tool_calls(msg.get("tool_calls"))
             message = ChatCompletionMessage(
                 role="assistant",
                 content=msg.get("content"),
-                tool_calls=_normalize_tool_calls(msg.get("tool_calls")),
+                tool_calls=msg.get("tool_calls"),
                 reasoning=reasoning_obj,
             )
             choices_out.append(Choice(index=i, finish_reason=ch.get("finish_reason"), message=message))

--- a/src/any_llm/providers/huggingface/huggingface.py
+++ b/src/any_llm/providers/huggingface/huggingface.py
@@ -49,6 +49,23 @@ if TYPE_CHECKING:
     from any_llm.types.responses import ParsedResponse, Response, ResponsesParams
 
 
+def _normalize_tool_calls(tool_calls: Any) -> Any:
+    """Coerce HF tool-call ``function.arguments`` to a string.
+
+    HuggingFace returns ``arguments: null`` for tool calls with no arguments (e.g. a
+    parameterless function), but OpenAI's ``ChatCompletionMessage`` requires a string,
+    so the raw payload fails validation. Default the missing arguments to ``"{}"``.
+    """
+    if not isinstance(tool_calls, list):
+        return tool_calls
+    for tool_call in tool_calls:
+        if isinstance(tool_call, dict):
+            function = tool_call.get("function")
+            if isinstance(function, dict) and function.get("arguments") is None:
+                function["arguments"] = "{}"
+    return tool_calls
+
+
 class HuggingfaceProvider(AnyLLM):
     """HuggingFace Provider using the new response conversion utilities."""
 
@@ -177,7 +194,7 @@ class HuggingfaceProvider(AnyLLM):
             message = ChatCompletionMessage(
                 role="assistant",
                 content=msg.get("content"),
-                tool_calls=msg.get("tool_calls"),
+                tool_calls=_normalize_tool_calls(msg.get("tool_calls")),
                 reasoning=reasoning_obj,
             )
             choices_out.append(Choice(index=i, finish_reason=ch.get("finish_reason"), message=message))

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -123,6 +123,11 @@ def parse_responses_output(response: Any, response_format: type) -> ParsedRespon
     (e.g. an OpenResponses ``ResponseResource`` whose schema diverges), so callers can fall
     back to the original object.
     """
+    # construct_type_unchecked is a private OpenAI SDK helper (the same one responses.parse()
+    # uses) with no public equivalent: it does lenient type coercion, which is exactly what we
+    # need here. Pydantic's model_validate cannot replace it because strict validation is what
+    # breaks on non-standardized provider output. If the SDK relocates it, this import breaks
+    # loudly in CI; the repo already depends on other openai.lib internals (see the HF provider).
     from openai._models import construct_type_unchecked
 
     from any_llm.types.responses import ParsedResponse, Response

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -4,7 +4,7 @@ import dataclasses
 import json
 from typing import TYPE_CHECKING, Any, TypeGuard
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import BaseModel, TypeAdapter
 
 from any_llm.logging import logger
 
@@ -110,38 +110,45 @@ def build_responses_text_format(response_format: type) -> dict[str, Any]:
 def parse_responses_output(response: Any, response_format: type) -> ParsedResponse[Any] | None:
     """Normalize a raw Responses result into a ``ParsedResponse`` with ``output_parsed``.
 
-    Takes an OpenAI ``Response`` (what every provider yields on the structured-output
-    path) and returns an OpenAI ``ParsedResponse`` whose ``output_parsed`` holds the
-    typed object. Works with both Pydantic BaseModel subclasses and dataclass types.
+    Builds the ``ParsedResponse`` with the OpenAI SDK's tolerant ``construct_type_unchecked``
+    (the same primitive ``responses.parse()`` uses for Pydantic models) rather than strictly
+    re-validating the whole response. Strict validation is brittle: providers can return output
+    items that a raw ``Response`` accepts but the stricter ``ParsedResponse`` output union
+    rejects (e.g. Fireworks echoes the request input back as a ``role="user"`` / ``input_text``
+    message). The structured JSON is parsed out of each assistant ``output_text`` into
+    ``response_format``; all other content and items are preserved untouched. Works with both
+    Pydantic ``BaseModel`` subclasses and dataclass types.
 
-    Returns ``None`` (after logging a warning) if ``response`` cannot be normalized into
-    a ``ParsedResponse`` (e.g. an OpenResponses ``ResponseResource`` whose schema diverges
-    from OpenAI's), so callers can fall back to the original object.
+    Returns ``None`` (after logging a warning) if ``response`` is not an OpenAI ``Response``
+    (e.g. an OpenResponses ``ResponseResource`` whose schema diverges), so callers can fall
+    back to the original object.
     """
-    from openai.types.responses import ParsedResponseOutputMessage, ParsedResponseOutputText
+    from openai._models import construct_type_unchecked
 
     from any_llm.types.responses import ParsedResponse, Response
 
-    try:
-        # by_alias=True preserves alias-only fields (e.g. ResponseFormatTextJSONSchemaConfig.schema,
-        # whose Python attribute is schema_) so the round-trip re-validates cleanly.
-        parsed: ParsedResponse[Any] = ParsedResponse.model_validate(response.model_dump(by_alias=True, warnings=False))
-    except ValidationError:
-        if isinstance(response, Response):  # pragma: no cover - a valid Response always validates as ParsedResponse
-            raise
+    if not isinstance(response, Response):
         logger.warning(
             "Could not normalize %s into a ParsedResponse; returning it without output_parsed.",
             type(response).__name__,
         )
         return None
 
-    for output in parsed.output:
-        if not isinstance(output, ParsedResponseOutputMessage):
+    # by_alias=True preserves alias-only fields (e.g. ResponseFormatTextJSONSchemaConfig.schema,
+    # whose Python attribute is schema_); warnings=False silences serialization notices for
+    # provider output items that diverge from the strict response schema.
+    dumped = response.model_dump(by_alias=True, warnings=False)
+
+    # Parse the structured JSON out of each assistant ``output_text`` into the requested type.
+    # Non-text content (refusals, echoed ``input_text``) and non-message items are left as-is.
+    for item in dumped.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
             continue
-        for content in output.content:
-            if isinstance(content, ParsedResponseOutputText) and content.text and content.parsed is None:
-                content.parsed = parse_json_content(response_format, content.text)
-    return parsed
+        for content in item.get("content") or []:
+            if isinstance(content, dict) and content.get("type") == "output_text" and content.get("text"):
+                content["parsed"] = parse_json_content(response_format, content["text"])
+
+    return construct_type_unchecked(type_=ParsedResponse[Any], value=dumped)
 
 
 def build_parsed_message(message: AnthropicMessage, output_format: type | dict[str, Any]) -> ParsedMessage[Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,9 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.CEREBRAS: "gpt-oss-120b",
         LLMProvider.COHERE: "command-a-reasoning-08-2025",
         LLMProvider.DEEPSEEK: "deepseek-reasoner",
-        LLMProvider.MOONSHOT: "kimi-thinking-preview",
+        # kimi-k2-thinking and kimi-thinking-preview are discontinued; kimi-k2.6 is the
+        # current reasoning-capable model (thinking mode, native multimodal).
+        LLMProvider.MOONSHOT: "kimi-k2.6",
         LLMProvider.BEDROCK: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",
         LLMProvider.NEOSANTARA: "deepseek-v4-flash",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.CEREBRAS: "gpt-oss-120b",
         LLMProvider.COHERE: "command-a-reasoning-08-2025",
         LLMProvider.DEEPSEEK: "deepseek-reasoner",
-        LLMProvider.MOONSHOT: "kimi-k2-thinking",
+        LLMProvider.MOONSHOT: "kimi-thinking-preview",
         LLMProvider.BEDROCK: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",
         LLMProvider.NEOSANTARA: "deepseek-v4-flash",
@@ -125,6 +125,7 @@ def provider_image_model_map(provider_model_map: dict[LLMProvider, str]) -> dict
         LLMProvider.SAMBANOVA: "gemma-4-31B-it",
         LLMProvider.NEBIUS: "Qwen/Qwen2.5-VL-72B-Instruct",
         LLMProvider.OPENROUTER: "google/gemini-2.5-flash-lite",
+        LLMProvider.COHERE: "command-a-vision-07-2025",  # command-a-03-2025 rejects image content
         LLMProvider.OLLAMA: "llava-phi3",  # Fast vision model compatible with OpenAI format
         LLMProvider.FIREWORKS: "accounts/fireworks/models/kimi-k2p5",
         LLMProvider.BEDROCK: "anthropic.claude-3-haiku-20240307-v1:0",  # Claude 3 Haiku with vision support

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.NEBIUS: "openai/gpt-oss-120b",
         LLMProvider.OLLAMA: "llama3.2:1b",
         LLMProvider.LLAMAFILE: "N/A",
-        LLMProvider.LMSTUDIO: "google/gemma-3-4b",  # You must have LM Studio running and the server enabled
+        LLMProvider.LMSTUDIO: "qwen/qwen3-1.7b",  # small model keeps the LM Studio cache under the 10GB Actions limit; you must have LM Studio running and the server enabled
         LLMProvider.VLLM: "Qwen/Qwen2.5-0.5B-Instruct",
         LLMProvider.COHERE: "command-a-03-2025",
         LLMProvider.CEREBRAS: "gpt-oss-120b",

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -15,10 +15,12 @@ from any_llm.exceptions import BatchNotCompleteError, MissingApiKeyError
 from any_llm.types.batch import Batch
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
-# Providers whose batch API is not OpenAI-file-style. These tests upload a local
-# JSONL file and create a batch from it; Bedrock instead requires S3 URIs plus a
-# role_arn/output_s3_uri/model_id, so the generic file-based flow can never apply.
-FILE_BATCH_UNSUPPORTED_PROVIDERS = [LLMProvider.BEDROCK]
+# Providers whose batch API needs infrastructure not provisioned in CI. Bedrock supports
+# batch, but its API is S3-based: it requires an IAM role ARN, an output S3 URI, and the
+# input pre-uploaded to S3. None of that is configured in CI (only AWS_BEARER_TOKEN_BEDROCK
+# for inference), so these file-based tests, which upload a local JSONL, can't exercise it.
+# Bedrock batch is covered by tests/unit/providers/test_bedrock_batch.py.
+BATCH_INFRA_NOT_CONFIGURED_IN_CI = [LLMProvider.BEDROCK]
 
 
 @pytest.mark.asyncio
@@ -32,8 +34,8 @@ async def test_create_and_retrieve_batch(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
-        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
-            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
+        if provider in BATCH_INFRA_NOT_CONFIGURED_IN_CI:
+            pytest.skip(f"{provider.value} batch infra (IAM role + S3) is not configured in CI, skipping")
 
         model_id = provider_model_map[provider]
 
@@ -228,8 +230,8 @@ async def test_retrieve_batch_results_not_complete(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
-        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
-            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
+        if provider in BATCH_INFRA_NOT_CONFIGURED_IN_CI:
+            pytest.skip(f"{provider.value} batch infra (IAM role + S3) is not configured in CI, skipping")
 
         model_id = provider_model_map[provider]
 
@@ -290,8 +292,8 @@ async def test_retrieve_batch_results_with_api_function(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
-        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
-            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
+        if provider in BATCH_INFRA_NOT_CONFIGURED_IN_CI:
+            pytest.skip(f"{provider.value} batch infra (IAM role + S3) is not configured in CI, skipping")
 
         model_id = provider_model_map[provider]
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -15,6 +15,11 @@ from any_llm.exceptions import BatchNotCompleteError, MissingApiKeyError
 from any_llm.types.batch import Batch
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
+# Providers whose batch API is not OpenAI-file-style. These tests upload a local
+# JSONL file and create a batch from it; Bedrock instead requires S3 URIs plus a
+# role_arn/output_s3_uri/model_id, so the generic file-based flow can never apply.
+FILE_BATCH_UNSUPPORTED_PROVIDERS = [LLMProvider.BEDROCK]
+
 
 @pytest.mark.asyncio
 async def test_create_and_retrieve_batch(
@@ -27,6 +32,8 @@ async def test_create_and_retrieve_batch(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
+        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
+            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
 
         model_id = provider_model_map[provider]
 
@@ -221,6 +228,8 @@ async def test_retrieve_batch_results_not_complete(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
+        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
+            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
 
         model_id = provider_model_map[provider]
 
@@ -281,6 +290,8 @@ async def test_retrieve_batch_results_with_api_function(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_BATCH:
             pytest.skip(f"{provider.value} does not support batch completions, skipping")
+        if provider in FILE_BATCH_UNSUPPORTED_PROVIDERS:
+            pytest.skip(f"{provider.value} does not support file-based batch creation, skipping")
 
         model_id = provider_model_map[provider]
 

--- a/tests/integration/test_embedding.py
+++ b/tests/integration/test_embedding.py
@@ -39,7 +39,6 @@ async def test_embedding_providers_async(
     assert len(result.data) > 0
     for entry in result.data:
         assert all(isinstance(v, float) for v in entry.embedding)
-    # Cohere's embed-v4.0 returns the embeddings but reports usage as 0 tokens.
-    if provider not in (LLMProvider.GEMINI, LLMProvider.VERTEXAI, LLMProvider.LMSTUDIO, LLMProvider.COHERE):
+    if provider not in (LLMProvider.GEMINI, LLMProvider.VERTEXAI, LLMProvider.LMSTUDIO):
         assert result.usage.prompt_tokens > 0
         assert result.usage.total_tokens > 0

--- a/tests/integration/test_embedding.py
+++ b/tests/integration/test_embedding.py
@@ -39,6 +39,7 @@ async def test_embedding_providers_async(
     assert len(result.data) > 0
     for entry in result.data:
         assert all(isinstance(v, float) for v in entry.embedding)
-    if provider not in (LLMProvider.GEMINI, LLMProvider.VERTEXAI, LLMProvider.LMSTUDIO):
+    # Cohere's embed-v4.0 returns the embeddings but reports usage as 0 tokens.
+    if provider not in (LLMProvider.GEMINI, LLMProvider.VERTEXAI, LLMProvider.LMSTUDIO, LLMProvider.COHERE):
         assert result.usage.prompt_tokens > 0
         assert result.usage.total_tokens > 0

--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -12,6 +12,16 @@ from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.types.responses import ParsedResponse, Response
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
+# HuggingFace routes the Responses API through a community OpenResponses Space that
+# returns a server-side 400 for strict json_schema requests, so structured output is
+# unreliable there regardless of the model.
+STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS = [LLMProvider.HUGGINGFACE]
+
+# Fireworks' Responses API echoes the input back instead of returning a conformant
+# structured response on the create()+text-format path used for non-Pydantic schemas
+# (e.g. dataclasses); the native parse() path used for Pydantic models works.
+NONPYDANTIC_RESPONSES_UNSUPPORTED_PROVIDERS = [*STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS, LLMProvider.FIREWORKS]
+
 
 @pytest.mark.asyncio
 async def test_responses_async(
@@ -56,6 +66,8 @@ async def test_responses_format_basemodel(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_RESPONSES:
             pytest.skip(f"{provider.value} does not support responses, skipping")
+        if provider in STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS:
+            pytest.skip(f"{provider.value} does not reliably support structured responses, skipping")
         model_id = provider_model_map[provider]
         result = await llm.aresponses(
             model_id,
@@ -94,6 +106,8 @@ async def test_responses_format_dataclass(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_RESPONSES:
             pytest.skip(f"{provider.value} does not support responses, skipping")
+        if provider in NONPYDANTIC_RESPONSES_UNSUPPORTED_PROVIDERS:
+            pytest.skip(f"{provider.value} does not reliably support non-Pydantic structured responses, skipping")
         model_id = provider_model_map[provider]
         result = await llm.aresponses(
             model_id,

--- a/tests/integration/test_responses.py
+++ b/tests/integration/test_responses.py
@@ -12,15 +12,11 @@ from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.types.responses import ParsedResponse, Response
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
-# HuggingFace routes the Responses API through a community OpenResponses Space that
-# returns a server-side 400 for strict json_schema requests, so structured output is
-# unreliable there regardless of the model.
-STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS = [LLMProvider.HUGGINGFACE]
-
-# Fireworks' Responses API echoes the input back instead of returning a conformant
-# structured response on the create()+text-format path used for non-Pydantic schemas
-# (e.g. dataclasses); the native parse() path used for Pydantic models works.
-NONPYDANTIC_RESPONSES_UNSUPPORTED_PROVIDERS = [*STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS, LLMProvider.FIREWORKS]
+# HuggingFace routes the Responses API through a community OpenResponses Space
+# (evalstate-openresponses.hf.space) that returns a server-side HTTP 400 for json_schema
+# (structured-output) requests, while plain responses succeed. The failure is upstream of
+# any-llm (the Space never runs the model), so it cannot be parsed around.
+HF_STRUCTURED_RESPONSES_BROKEN = [LLMProvider.HUGGINGFACE]
 
 
 @pytest.mark.asyncio
@@ -66,8 +62,11 @@ async def test_responses_format_basemodel(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_RESPONSES:
             pytest.skip(f"{provider.value} does not support responses, skipping")
-        if provider in STRUCTURED_RESPONSES_UNSUPPORTED_PROVIDERS:
-            pytest.skip(f"{provider.value} does not reliably support structured responses, skipping")
+        if provider in HF_STRUCTURED_RESPONSES_BROKEN:
+            pytest.skip(
+                f"{provider.value} OpenResponses Space returns HTTP 400 for structured-output "
+                "(json_schema) requests, skipping"
+            )
         model_id = provider_model_map[provider]
         result = await llm.aresponses(
             model_id,
@@ -106,8 +105,11 @@ async def test_responses_format_dataclass(
         llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
         if not llm.SUPPORTS_RESPONSES:
             pytest.skip(f"{provider.value} does not support responses, skipping")
-        if provider in NONPYDANTIC_RESPONSES_UNSUPPORTED_PROVIDERS:
-            pytest.skip(f"{provider.value} does not reliably support non-Pydantic structured responses, skipping")
+        if provider in HF_STRUCTURED_RESPONSES_BROKEN:
+            pytest.skip(
+                f"{provider.value} OpenResponses Space returns HTTP 400 for structured-output "
+                "(json_schema) requests, skipping"
+            )
         model_id = provider_model_map[provider]
         result = await llm.aresponses(
             model_id,

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -434,6 +434,20 @@ def test_convert_cohere_embedding_response_no_meta() -> None:
     assert len(result.data) == 1
 
 
+def test_convert_cohere_embedding_response_uses_billed_units_when_tokens_absent() -> None:
+    """embed-v4.0 reports usage under meta.billed_units; meta.tokens is null, so fall back to it."""
+    vectors = [[0.1, 0.2, 0.3]]
+    mock_response = _mock_embed_by_type_response(vectors)
+    mock_response.meta.tokens = None
+    mock_response.meta.billed_units = Mock()
+    mock_response.meta.billed_units.input_tokens = 7
+
+    result = _convert_cohere_embedding_response("embed-v4.0", mock_response)
+
+    assert result.usage.prompt_tokens == 7
+    assert result.usage.total_tokens == 7
+
+
 def test_convert_cohere_embedding_response_empty_vectors() -> None:
     mock_response = _mock_embed_by_type_response(vectors=[])
 

--- a/tests/unit/providers/test_gemini_batch.py
+++ b/tests/unit/providers/test_gemini_batch.py
@@ -671,6 +671,25 @@ async def test_alist_batches_with_pagination() -> None:
 
 
 @pytest.mark.asyncio
+async def test_alist_batches_limit_caps_total_results() -> None:
+    """The pager auto-follows pages, so limit must cap the total returned count.
+
+    Regression for the integration failure where ``page_size`` only bounded the
+    per-page size and the full pager (e.g. 109 jobs) was returned despite limit=5.
+    """
+    pytest.importorskip("google.genai")
+
+    provider, mock_client = _create_provider_with_mock_client()
+
+    mock_jobs = [_make_mock_batch_job(name=f"batches/job{i}") for i in range(20)]
+    mock_client.aio.batches.list = AsyncMock(return_value=_MockAsyncPager(mock_jobs))
+
+    result = await provider._alist_batches(limit=5)
+
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
 async def test_aretrieve_batch_results_not_completed() -> None:
     """Test that BatchNotCompleteError is raised for incomplete batch."""
     pytest.importorskip("google.genai")

--- a/tests/unit/providers/test_gemini_batch.py
+++ b/tests/unit/providers/test_gemini_batch.py
@@ -690,6 +690,22 @@ async def test_alist_batches_limit_caps_total_results() -> None:
 
 
 @pytest.mark.asyncio
+async def test_alist_batches_limit_zero_returns_empty() -> None:
+    """limit=0 must return an empty list without iterating the pager."""
+    pytest.importorskip("google.genai")
+
+    provider, mock_client = _create_provider_with_mock_client()
+
+    mock_jobs = [_make_mock_batch_job(name=f"batches/job{i}") for i in range(3)]
+    mock_client.aio.batches.list = AsyncMock(return_value=_MockAsyncPager(mock_jobs))
+
+    result = await provider._alist_batches(limit=0)
+
+    assert result == []
+    mock_client.aio.batches.list.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_aretrieve_batch_results_not_completed() -> None:
     """Test that BatchNotCompleteError is raised for incomplete batch."""
     pytest.importorskip("google.genai")

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -416,3 +416,42 @@ async def test_huggingface_aresponses_without_response_format() -> None:
 
     client.responses.parse.assert_not_called()
     assert "text" not in client.responses.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_huggingface_tool_call_with_null_arguments() -> None:
+    """HF returns arguments=None for no-arg tool calls; coerce to a string so parsing succeeds.
+
+    Regression for the agent-loop failure where ChatCompletionMessage validation rejected
+    a tool call whose function.arguments was null.
+    """
+    messages = [{"role": "user", "content": "What is the date?"}]
+
+    with mock_huggingface_provider() as mock_huggingface:
+        mock_huggingface.return_value.chat_completion.return_value = {
+            "id": "hf-response-id",
+            "created": 0,
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "get_current_date", "arguments": None},
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+        provider = HuggingfaceProvider(api_key="test-api-key")
+        result = await provider._acompletion(CompletionParams(model_id="model-id", messages=messages))
+
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert tool_calls[0].function.arguments == "{}"

--- a/tests/unit/providers/test_huggingface_provider.py
+++ b/tests/unit/providers/test_huggingface_provider.py
@@ -4,6 +4,9 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
+)
 
 from any_llm.providers.huggingface.huggingface import HuggingfaceProvider
 from any_llm.providers.huggingface.utils import _create_openai_chunk_from_huggingface_chunk
@@ -452,6 +455,9 @@ async def test_huggingface_tool_call_with_null_arguments() -> None:
         provider = HuggingfaceProvider(api_key="test-api-key")
         result = await provider._acompletion(CompletionParams(model_id="model-id", messages=messages))
 
+    assert isinstance(result, ChatCompletion)
     tool_calls = result.choices[0].message.tool_calls
     assert tool_calls is not None
-    assert tool_calls[0].function.arguments == "{}"
+    tool_call = tool_calls[0]
+    assert isinstance(tool_call, OpenAIChatCompletionMessageFunctionToolCall)
+    assert tool_call.function.arguments == "{}"

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -241,6 +241,51 @@ def test_parse_responses_output_skips_non_message_output() -> None:
     assert parsed.output_parsed.name == "Alice"
 
 
+def test_parse_responses_output_tolerates_echoed_input_items() -> None:
+    """Providers like Fireworks echo the request input back as a user/input_text output item.
+
+    A raw Response accepts it but strict ParsedResponse validation does not, so parsing must
+    skip it and still extract output_parsed from the real assistant output_text.
+    """
+    from openai._models import construct_type_unchecked
+
+    echoed_input = {
+        "id": "msg-0",
+        "type": "message",
+        "role": "user",
+        "status": "completed",
+        "content": [{"type": "input_text", "text": "What is the capital of France?"}],
+    }
+    assistant = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text='{"name": "Bob", "age": 7}', annotations=[])],
+    )
+    # Build a Response that carries the non-conformant echoed-input item without validating it.
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp-1",
+            "created_at": 0,
+            "model": "test-model",
+            "object": "response",
+            "output": [echoed_input, assistant.model_dump()],
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+        },
+    )
+
+    parsed = parse_responses_output(response, DataclassModel)
+    assert isinstance(parsed, ParsedResponse)
+    assert isinstance(parsed.output_parsed, DataclassModel)
+    assert parsed.output_parsed.age == 7
+    # The echoed input item is preserved, not dropped.
+    assert len(parsed.output) == 2
+
+
 def _make_anthropic_message(content: list[Any]) -> Any:
     from any_llm.types.messages import MessageResponse, MessageUsage
 


### PR DESCRIPTION
## Description

The integration suite has been red on `main` for weeks (since the relevant features
merged in mid-to-late May / early June), not a fresh regression. It runs post-merge and
isn't a merge gate, so failures accumulated. This PR root-causes each one: several are
genuine any-llm bugs, the rest are provider drift or CI-infra gaps.

Real code fixes (each with a regression test):

- **Gemini `list_batches` ignored `limit`.** The Google GenAI `batches.list` pager
  auto-follows every page, so `ListBatchJobsConfig.page_size` only bounds the per-page
  size, not the total. `_alist_batches` returned the full account history (109 batches)
  even with `limit=5`. Now stops once the requested limit is reached, and `limit <= 0`
  returns an empty list.
- **HuggingFace null tool-call arguments.** HF returns `function.arguments=null` for
  tool calls with no arguments (e.g. a parameterless function), but OpenAI's
  `ChatCompletionMessage` requires a string, so parsing raised a `ValidationError`.
  Missing arguments are now coerced to `"{}"`. Surfaced intermittently by
  `test_agent_loop_sequential_tool_calls[huggingface]`.
- **Cohere embedding usage.** The embed converter only read `meta.tokens.input_tokens`,
  but Cohere reports embedding usage under `meta.billed_units.input_tokens`
  (`meta.tokens` is null for embeddings, confirmed for `embed-v4.0`), so usage was
  reported as 0. Now falls back to `billed_units`, using explicit `None` checks so an
  API-reported 0 is preserved.
- **Responses structured output (fixes Fireworks dataclasses).** `parse_responses_output`
  (the non-Pydantic / dataclass path) strictly re-validated the whole response into
  `ParsedResponse` and raised when a valid `Response` did not round-trip. That assumption
  was wrong: Fireworks echoes the request input back as a `role="user"` / `input_text`
  output item, which a raw `Response` accepts but strict `ParsedResponse` validation
  rejects. The Pydantic path (SDK `responses.parse()`) tolerated it; the dataclass path
  crashed. Rebuilt the parsing on the SDK's own tolerant `construct_type_unchecked`
  primitive, so the dataclass path matches the Pydantic path. `test_responses_format_dataclass[fireworks]`
  now passes live.

Test/config changes for provider drift:

- **Cohere image:** `command-a-03-2025` is text-only and rejects image content; the
  image test now uses the vision model `command-a-vision-07-2025`.
- **Moonshot reasoning:** `kimi-k2-thinking` and `kimi-thinking-preview` are both
  discontinued on the Moonshot platform; the reasoning tests now use `kimi-k2.6`.

Honest skips (not any-llm bugs):

- **Bedrock batch:** batch support is new (#1077) and S3-based by design (requires
  `role_arn`/`output_s3_uri`/`model_id` and a pre-uploaded S3 input). CI has no IAM role
  or S3 bucket configured (only `AWS_BEARER_TOKEN_BEDROCK`), so the generic file-based
  tests skip it. It retains unit coverage; real integration coverage needs AWS infra in
  CI (follow-up).
- **HuggingFace structured responses:** routes through a community OpenResponses Space
  that returns a server-side HTTP 400 for `json_schema` requests (upstream of any-llm, so
  not parseable around). Skipped with that specific reason.

Docs:

- Added a `Definition of done` section and integration-test triage guidance to
  `AGENTS.md` so the suite stops getting symptom-patched.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A (integration test failures on `main`)

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8 (1M context)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Investigated and authored by Claude Code via back-and-forth with @njbrake. The reasoning and decisions are his; the code and prose are Claude's. Unit tests verified locally; cloud integration tests verified by running the labeled CI workflow on this PR.

- [x] I am an AI Agent filling out this form (check box if true)
