### PR TITLE
fix(gemini): strip additionalProperties from response schemas

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -37,6 +37,7 @@ try:
         _convert_tool_spec,
         _create_openai_chunk_from_google_chunk,
         _create_openai_embedding_response_from_google,
+        _strip_additional_properties,
     )
 except ImportError as e:
     MISSING_PACKAGES_ERROR = e
@@ -165,7 +166,7 @@ class GoogleProvider(AnyLLM):
             response_type = response_format.get("type")
             if response_type == "json_schema":
                 kwargs["response_mime_type"] = "application/json"
-                kwargs["response_schema"] = response_format["json_schema"]["schema"]
+                kwargs["response_schema"] = _strip_additional_properties(response_format["json_schema"]["schema"])
             elif response_type == "json_object":
                 kwargs["response_mime_type"] = "application/json"
             elif response_type == "text":

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -27,6 +27,7 @@ from any_llm.types.completion import (
 from any_llm.types.model import Model
 
 _INLINE_SIZE_LIMIT = 20 * 1024 * 1024
+JSONSchemaValue = dict[str, "JSONSchemaValue"] | list["JSONSchemaValue"] | str | int | float | bool | None
 
 
 def _has_json_schema_refs(schema: Any) -> bool:
@@ -45,7 +46,7 @@ def _has_json_schema_refs(schema: Any) -> bool:
     return False
 
 
-def _strip_additional_properties(schema: Any) -> Any:
+def _strip_additional_properties(schema: JSONSchemaValue, *, _in_properties_map: bool = False) -> JSONSchemaValue:
     """Return a schema copy without JSON Schema's ``additionalProperties`` keyword.
 
     Gemini's ``response_schema`` uses ``google.genai.types.Schema``, not the full
@@ -54,9 +55,12 @@ def _strip_additional_properties(schema: Any) -> Any:
     serializes that as ``additional_properties`` and Gemini rejects the request.
     """
     if isinstance(schema, dict):
-        return {
-            key: _strip_additional_properties(value) for key, value in schema.items() if key != "additionalProperties"
-        }
+        cleaned: dict[str, JSONSchemaValue] = {}
+        for key, value in schema.items():
+            if key == "additionalProperties" and not _in_properties_map:
+                continue
+            cleaned[key] = _strip_additional_properties(value, _in_properties_map=key == "properties")
+        return cleaned
     if isinstance(schema, list):
         return [_strip_additional_properties(value) for value in schema]
     return schema

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -45,6 +45,23 @@ def _has_json_schema_refs(schema: Any) -> bool:
     return False
 
 
+def _strip_additional_properties(schema: Any) -> Any:
+    """Return a schema copy without JSON Schema's ``additionalProperties`` keyword.
+
+    Gemini's ``response_schema`` uses ``google.genai.types.Schema``, not the full
+    JSON Schema dialect accepted by OpenAI structured outputs. OpenAI strict
+    schemas commonly include ``additionalProperties: false``; the Google SDK
+    serializes that as ``additional_properties`` and Gemini rejects the request.
+    """
+    if isinstance(schema, dict):
+        return {
+            key: _strip_additional_properties(value) for key, value in schema.items() if key != "additionalProperties"
+        }
+    if isinstance(schema, list):
+        return [_strip_additional_properties(value) for value in schema]
+    return schema
+
+
 def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
     converted_tools = []
     function_declarations = []

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,5 +1,6 @@
 import base64
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import Any, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -344,9 +345,10 @@ async def test_completion_with_dict_json_schema_strips_additional_properties() -
                     "metadata": {
                         "type": "object",
                         "properties": {
+                            "additionalProperties": {"type": "string"},
                             "value": {"type": "integer"},
                         },
-                        "required": ["value"],
+                        "required": ["additionalProperties", "value"],
                         "additionalProperties": False,
                     },
                 },
@@ -355,12 +357,14 @@ async def test_completion_with_dict_json_schema_strips_additional_properties() -
             },
         },
     }
+    original_response_format = deepcopy(response_format)
 
     with mock_gemini_provider() as mock_genai:
         provider = GeminiProvider(api_key=api_key)
         await provider._acompletion(
             CompletionParams(model_id=model, messages=messages, response_format=response_format)
         )
+        assert response_format == original_response_format
 
         _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
         generation_config = call_kwargs["config"]
@@ -373,9 +377,10 @@ async def test_completion_with_dict_json_schema_strips_additional_properties() -
                 "metadata": {
                     "type": "object",
                     "properties": {
+                        "additionalProperties": {"type": "string"},
                         "value": {"type": "integer"},
                     },
-                    "required": ["value"],
+                    "required": ["additionalProperties", "value"],
                 },
             },
             "required": ["name", "metadata"],

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -328,6 +328,61 @@ async def test_completion_with_dict_json_schema_response_format() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completion_with_dict_json_schema_strips_additional_properties() -> None:
+    api_key = "test-api-key"
+    model = "gemini-pro"
+    messages = [{"role": "user", "content": "Hello"}]
+    response_format: dict[str, Any] = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "TestOutput",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "integer"},
+                        },
+                        "required": ["value"],
+                        "additionalProperties": False,
+                    },
+                },
+                "required": ["name", "metadata"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key=api_key)
+        await provider._acompletion(
+            CompletionParams(model_id=model, messages=messages, response_format=response_format)
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        generation_config = call_kwargs["config"]
+
+        assert generation_config.response_mime_type == "application/json"
+        assert generation_config.response_schema == {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer"},
+                    },
+                    "required": ["value"],
+                },
+            },
+            "required": ["name", "metadata"],
+        }
+
+
+@pytest.mark.asyncio
 async def test_completion_with_json_object_response_format() -> None:
     api_key = "test-api-key"
     model = "gemini-pro"


### PR DESCRIPTION
## Description

Fixes #1143.

The Gemini provider accepts OpenAI-style dict `response_format` values after #969, but it forwards `json_schema.schema` directly to Gemini as `response_schema`. OpenAI strict structured-output schemas commonly include `additionalProperties: false`; the Google SDK serializes that key as `additional_properties`, and Gemini rejects it with:

```text
Invalid JSON payload received. Unknown name "additional_properties" at 'generation_config.response_schema': Cannot find field.
```

This patch strips `additionalProperties` recursively from dict-based Gemini response schemas before building `GenerateContentConfig`. The schema is copied, not mutated, and the existing behavior for simple dict schemas, `json_object`, and `text` remains unchanged.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1143

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: Implemented and tested interactively under human direction after reproducing the bug through Otari and directly through AnyLLM.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Verification

- `uv sync --extra gemini`
- `uv run pytest tests/unit/providers/test_gemini_provider.py -q` -> `80 passed`
- `uv run ruff format src/any_llm/providers/gemini/base.py src/any_llm/providers/gemini/utils.py tests/unit/providers/test_gemini_provider.py`
- `uv run ruff check src/any_llm/providers/gemini/base.py src/any_llm/providers/gemini/utils.py tests/unit/providers/test_gemini_provider.py`
- Live Gemini check against `gemini-3-flash-preview` with an OpenAI strict schema containing top-level and nested `additionalProperties: false` returned one choice with valid JSON.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of Gemini structured output by stripping unsupported `additionalProperties` from nested JSON schemas before requests are sent.

* **Tests**
  * Added unit coverage to verify nested schema processing and confirm the original `response_format` input remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->