### PR TITLE
feat: add Requesty provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all = [
-  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra]"
+  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra]"
 ]
 
 platform = [
@@ -128,6 +128,7 @@ openai = []
 openrouter = []
 portkey = []
 qiniu = []
+requesty = []
 sambanova = []
 minimax = []
 mzai = []

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -46,6 +46,7 @@ class LLMProvider(StrEnum):
     OPENROUTER = "openrouter"
     PORTKEY = "portkey"
     QINIU = "qiniu"
+    REQUESTY = "requesty"
     SAMBANOVA = "sambanova"
     SAGEMAKER = "sagemaker"
     TOGETHER = "together"

--- a/src/any_llm/providers/requesty/__init__.py
+++ b/src/any_llm/providers/requesty/__init__.py
@@ -1,0 +1,3 @@
+from .requesty import RequestyProvider
+
+__all__ = ["RequestyProvider"]

--- a/src/any_llm/providers/requesty/requesty.py
+++ b/src/any_llm/providers/requesty/requesty.py
@@ -1,0 +1,50 @@
+from collections.abc import Sequence
+from typing import Any
+
+from typing_extensions import override
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.providers.requesty.utils import _convert_models_list, build_reasoning_directive
+from any_llm.types.completion import CompletionParams
+from any_llm.types.model import Model
+
+
+class RequestyProvider(BaseOpenAIProvider):
+    API_BASE = "https://router.requesty.ai/v1"
+    ENV_API_KEY_NAME = "REQUESTY_API_KEY"
+    ENV_API_BASE_NAME = "REQUESTY_API_BASE"
+    PROVIDER_NAME = "requesty"
+    PROVIDER_DOCUMENTATION_URL = "https://docs.requesty.ai"
+
+    SUPPORTS_COMPLETION_STREAMING = True
+    SUPPORTS_COMPLETION = True
+    SUPPORTS_RESPONSES = False
+    SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_EMBEDDING = True
+    # Requesty does not expose a moderation endpoint.
+    SUPPORTS_MODERATION = False
+
+    @staticmethod
+    @override
+    def _convert_list_models_response(response: Any) -> Sequence[Model]:
+        """Convert Requesty list models response to valid Model objects."""
+        return _convert_models_list(response)
+
+    @staticmethod
+    @override
+    def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
+        """Convert CompletionParams to kwargs for Requesty API, including reasoning directive."""
+        converted_params = BaseOpenAIProvider._convert_completion_params(params, **kwargs)
+
+        reasoning_directive = build_reasoning_directive(
+            reasoning=kwargs.get("reasoning"),
+            reasoning_effort=params.reasoning_effort,
+        )
+
+        if reasoning_directive is not None:
+            converted_params.pop("reasoning_effort", None)
+            extra_body = converted_params.get("extra_body", {}).copy()
+            extra_body["reasoning"] = reasoning_directive
+            converted_params["extra_body"] = extra_body
+
+        return converted_params

--- a/src/any_llm/providers/requesty/requesty.py
+++ b/src/any_llm/providers/requesty/requesty.py
@@ -34,10 +34,14 @@ class RequestyProvider(BaseOpenAIProvider):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for Requesty API, including reasoning directive."""
+        # Extract ``reasoning`` before delegating so the base converter does not
+        # forward it as a top-level kwarg (unsupported by the OpenAI SDK's
+        # ``create()``). Requesty expects it nested under ``extra_body`` instead.
+        reasoning = kwargs.pop("reasoning", None)
         converted_params = BaseOpenAIProvider._convert_completion_params(params, **kwargs)
 
         reasoning_directive = build_reasoning_directive(
-            reasoning=kwargs.get("reasoning"),
+            reasoning=reasoning,
             reasoning_effort=params.reasoning_effort,
         )
 

--- a/src/any_llm/providers/requesty/utils.py
+++ b/src/any_llm/providers/requesty/utils.py
@@ -28,17 +28,14 @@ def build_reasoning_directive(
     Returns:
         Dict for request body "reasoning" key, or None to omit
     """
-    # Priority 1: Direct reasoning object for advanced users
     if reasoning is not None:
         return _normalize_reasoning_obj(reasoning)
 
-    # Priority 2: Standard reasoning_effort parameter
     if reasoning_effort and reasoning_effort not in ("auto", "none"):
         level = str(reasoning_effort).lower()
         if level in {"low", "medium", "high"}:
             return {"effort": level}
 
-    # Default: No reasoning (including for "auto")
     return None
 
 

--- a/src/any_llm/providers/requesty/utils.py
+++ b/src/any_llm/providers/requesty/utils.py
@@ -1,0 +1,93 @@
+"""Requesty Provider Utilities.
+
+Utilities for building Requesty-specific request parameters, with explicit
+opt-in handling for reasoning capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from any_llm.types.model import Model
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def build_reasoning_directive(
+    *,
+    reasoning: Any | None = None,
+    reasoning_effort: str | None = None,
+) -> dict[str, Any] | None:
+    """Build Requesty's reasoning directive from user parameters.
+
+    Args:
+        reasoning: Direct reasoning config (dict/object) for advanced control
+        reasoning_effort: Standard effort level ("low"/"medium"/"high")
+
+    Returns:
+        Dict for request body "reasoning" key, or None to omit
+    """
+    # Priority 1: Direct reasoning object for advanced users
+    if reasoning is not None:
+        return _normalize_reasoning_obj(reasoning)
+
+    # Priority 2: Standard reasoning_effort parameter
+    if reasoning_effort and reasoning_effort not in ("auto", "none"):
+        level = str(reasoning_effort).lower()
+        if level in {"low", "medium", "high"}:
+            return {"effort": level}
+
+    # Default: No reasoning (including for "auto")
+    return None
+
+
+def _convert_models_list(response: Any) -> Sequence[Model]:
+    """Convert Requesty list models response to valid Model objects.
+
+    Requesty's ``/v1/models`` endpoint omits the ``object`` and
+    ``owned_by`` fields that the OpenAI ``Model`` schema requires. The OpenAI
+    SDK silently accepts those missing fields via ``model_construct()``, but the
+    resulting objects fail round-trip serialization. This function fills the
+    missing required fields while preserving any extra Requesty attributes
+    (e.g. ``name``, ``pricing``) that may already be present on the SDK objects.
+    """
+    raw_models = response.data if hasattr(response, "data") else response
+    result: list[Model] = []
+    for model in raw_models:
+        data: dict[str, Any] = model.model_dump() if hasattr(model, "model_dump") else dict(vars(model))
+        if data.get("object") is None:
+            data["object"] = "model"
+        if data.get("owned_by") is None:
+            data["owned_by"] = "requesty"
+        if data.get("created") is None:
+            data["created"] = 0
+        result.append(Model.model_validate(data))
+    return result
+
+
+def _normalize_reasoning_obj(obj: Any) -> dict[str, Any]:
+    """Normalize reasoning config to Requesty format."""
+
+    def _get(o: Any, k: str) -> Any:
+        return o.get(k) if isinstance(o, dict) else getattr(o, k, None)
+
+    out: dict[str, Any] = {}
+
+    effort = _get(obj, "effort")
+    if effort is not None:
+        out["effort"] = str(effort).lower()
+
+    max_tokens = _get(obj, "max_tokens")
+    if max_tokens is not None:
+        out["max_tokens"] = int(max_tokens)
+
+    exclude = _get(obj, "exclude")
+    if exclude is not None:
+        out["exclude"] = bool(exclude)
+
+    enabled = _get(obj, "enabled")
+    if enabled is not None:
+        out["enabled"] = bool(enabled)
+
+    return out

--- a/tests/unit/providers/test_requesty_provider.py
+++ b/tests/unit/providers/test_requesty_provider.py
@@ -1,0 +1,374 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from any_llm.providers.requesty import RequestyProvider
+from any_llm.providers.requesty.utils import _convert_models_list
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    Choice,
+    CompletionParams,
+    Reasoning,
+)
+from any_llm.types.model import Model
+
+
+@pytest.mark.asyncio
+async def test_reasoning_param_added_with_explicit_effort() -> None:
+    """Test that reasoning parameter is added when reasoning_effort is specified."""
+    mock_completion = ChatCompletion(
+        id="test-123",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="Hello!",
+                    reasoning=Reasoning(content="Let me think..."),
+                ),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="low",
+        )
+
+        provider = RequestyProvider(api_key="sk-test")
+        await provider._acompletion(params)
+
+        mock_client.chat.completions.create.assert_called_once()
+        call_args = mock_client.chat.completions.create.call_args
+        assert "extra_body" in call_args.kwargs
+        assert call_args.kwargs["extra_body"]["reasoning"]["effort"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_auto_excludes_reasoning() -> None:
+    """Test that reasoning_effort='auto' does not include reasoning - no extra_body at all."""
+    mock_completion = ChatCompletion(
+        id="test-456",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content="Hello!"),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        provider = RequestyProvider(api_key="sk-test")
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        await provider._acompletion(params)
+
+        call_args = mock_client.chat.completions.create.call_args
+        # Should not have extra_body at all when "auto"
+        assert "extra_body" not in call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_reasoning_none_excludes_reasoning() -> None:
+    """Test that reasoning_effort='none' does not include reasoning - no extra_body at all."""
+    mock_completion = ChatCompletion(
+        id="test-none",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content="Hello!"),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        provider = RequestyProvider(api_key="sk-test")
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="none",
+        )
+
+        await provider._acompletion(params)
+
+        call_args = mock_client.chat.completions.create.call_args
+        # Should not have extra_body at all when "none"
+        assert "extra_body" not in call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_reasoning_with_custom_reasoning_object() -> None:
+    """Test that custom reasoning object overrides reasoning_effort."""
+    mock_completion = ChatCompletion(
+        id="test-custom",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="Hello!",
+                    reasoning=Reasoning(content="Custom reasoning"),
+                ),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="low",  # This should be overridden
+        )
+
+        provider = RequestyProvider(api_key="sk-test")
+        await provider._acompletion(params, reasoning={"effort": "high", "max_tokens": 1000})
+
+        call_args = mock_client.chat.completions.create.call_args
+        assert "extra_body" in call_args.kwargs
+        assert call_args.kwargs["extra_body"]["reasoning"]["effort"] == "high"
+        assert call_args.kwargs["extra_body"]["reasoning"]["max_tokens"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_no_extra_body_when_no_reasoning() -> None:
+    """Test that no extra_body is sent when reasoning is not requested."""
+    mock_completion = ChatCompletion(
+        id="test-no-extra",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content="Hello!"),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort=None,  # No reasoning
+        )
+        provider = RequestyProvider(api_key="sk-test")
+        await provider._acompletion(params)
+
+        call_args = mock_client.chat.completions.create.call_args
+        # Should not have extra_body at all when no reasoning
+        assert "extra_body" not in call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_preserve_existing_extra_body() -> None:
+    """Test that existing extra_body is preserved when no reasoning is added."""
+    mock_completion = ChatCompletion(
+        id="test-preserve",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content="Hello!"),
+            )
+        ],
+    )
+
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        provider = RequestyProvider(api_key="sk-test")
+        await provider._acompletion(params, extra_body={"some_other_param": "value"})
+
+        call_args = mock_client.chat.completions.create.call_args
+        # Should preserve existing extra_body but not add reasoning
+        assert "extra_body" in call_args.kwargs
+        assert call_args.kwargs["extra_body"]["some_other_param"] == "value"
+        assert "reasoning" not in call_args.kwargs["extra_body"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_with_reasoning() -> None:
+    """Test that streaming passes through reasoning parameters correctly."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_stream = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_stream)
+
+        params = CompletionParams(
+            model_id="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="high",
+            stream=True,
+        )
+        provider = RequestyProvider(api_key="sk-test")
+        await provider._acompletion(params)
+
+        mock_client.chat.completions.create.assert_called_once()
+        call_args = mock_client.chat.completions.create.call_args
+        assert call_args.kwargs["stream"] is True
+        assert "extra_body" in call_args.kwargs
+        assert call_args.kwargs["extra_body"]["reasoning"]["effort"] == "high"
+
+
+def test_requesty_remaps_max_tokens_to_max_completion_tokens() -> None:
+    params = CompletionParams(model_id="openai/gpt-4", messages=[{"role": "user", "content": "Hello"}], max_tokens=8192)
+    result = RequestyProvider._convert_completion_params(params)
+    assert "max_tokens" not in result
+    assert result["max_completion_tokens"] == 8192
+
+
+def _make_requesty_model(**overrides: object) -> Model:
+    """Build a fake model object resembling what the OpenAI SDK constructs from a Requesty response.
+
+    Uses ``Model.model_construct`` to match how the OpenAI SDK actually builds
+    model objects from raw API responses, including extra Requesty fields.
+    """
+    defaults: dict[str, object] = {
+        "id": "qwen/qwen3.7-max",
+        "created": 1779376861,
+        "object": None,
+        "owned_by": None,
+    }
+    defaults.update(overrides)
+    return Model.model_construct(**defaults)  # type: ignore[arg-type]
+
+
+def test_convert_models_list_fills_missing_object_and_owned_by() -> None:
+    """Models with None object/owned_by are rebuilt with valid defaults."""
+    response = SimpleNamespace(data=[_make_requesty_model()])
+    result = _convert_models_list(response)
+
+    assert len(result) == 1
+    model = result[0]
+    assert model.id == "qwen/qwen3.7-max"
+    assert model.object == "model"
+    assert model.owned_by == "requesty"
+    assert model.created == 1779376861
+
+
+def test_convert_models_list_preserves_existing_owned_by() -> None:
+    """When the API does provide owned_by, it should be kept."""
+    response = SimpleNamespace(data=[_make_requesty_model(owned_by="qwen")])
+    result = _convert_models_list(response)
+
+    assert result[0].owned_by == "qwen"
+
+
+def test_convert_models_list_defaults_created_to_zero_when_none() -> None:
+    """A None created timestamp falls back to 0."""
+    response = SimpleNamespace(data=[_make_requesty_model(created=None)])
+    result = _convert_models_list(response)
+
+    assert result[0].created == 0
+
+
+def test_convert_models_list_handles_empty_response() -> None:
+    response = SimpleNamespace(data=[])
+    result = _convert_models_list(response)
+
+    assert result == []
+
+
+def test_convert_models_list_round_trip_serialization() -> None:
+    """Converted models must survive model_dump_json -> model_validate_json."""
+    response = SimpleNamespace(data=[_make_requesty_model()])
+    models = _convert_models_list(response)
+
+    for model in models:
+        json_data = model.model_dump_json()
+        restored = Model.model_validate_json(json_data)
+        assert restored.id == model.id
+        assert restored.object == "model"
+        assert restored.owned_by == "requesty"
+
+
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+def test_list_models_returns_valid_model_objects(mock_openai_class: MagicMock) -> None:
+    """End-to-end: RequestyProvider.list_models() returns spec-compliant Model objects."""
+    raw_models = [
+        _make_requesty_model(id="openai/gpt-4o"),
+        _make_requesty_model(id="anthropic/claude-3.5-sonnet", owned_by="anthropic"),
+    ]
+    mock_client = AsyncMock()
+    mock_client.models.list.return_value = SimpleNamespace(data=raw_models)
+    mock_openai_class.return_value = mock_client
+
+    provider = RequestyProvider(api_key="sk-test")
+    result = provider.list_models()
+
+    assert len(result) == 2
+    for model in result:
+        assert isinstance(model, Model)
+        assert model.object == "model"
+        assert model.owned_by is not None
+
+    assert result[0].id == "openai/gpt-4o"
+    assert result[0].owned_by == "requesty"
+    assert result[1].id == "anthropic/claude-3.5-sonnet"
+    assert result[1].owned_by == "anthropic"
+
+
+def test_convert_models_list_preserves_extra_requesty_fields() -> None:
+    """Extra Requesty attributes (name, pricing, etc.) survive conversion."""
+    model = _make_requesty_model(
+        name="Qwen3.7 Max",
+        pricing={"prompt": "0.001", "completion": "0.002"},
+    )
+    response = SimpleNamespace(data=[model])
+    result = _convert_models_list(response)
+
+    assert len(result) == 1
+    converted = result[0]
+    assert converted.id == "qwen/qwen3.7-max"
+    assert converted.object == "model"
+    assert converted.owned_by == "requesty"
+    assert converted.model_extra is not None
+    assert converted.model_extra["name"] == "Qwen3.7 Max"
+    assert converted.model_extra["pricing"] == {"prompt": "0.001", "completion": "0.002"}

--- a/tests/unit/providers/test_requesty_provider.py
+++ b/tests/unit/providers/test_requesty_provider.py
@@ -162,6 +162,9 @@ async def test_reasoning_with_custom_reasoning_object() -> None:
         assert "extra_body" in call_args.kwargs
         assert call_args.kwargs["extra_body"]["reasoning"]["effort"] == "high"
         assert call_args.kwargs["extra_body"]["reasoning"]["max_tokens"] == 1000
+        # Regression guard: the top-level ``reasoning`` kwarg must not leak to the
+        # API call; it should only appear nested under ``extra_body``.
+        assert "reasoning" not in call_args.kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds **Requesty** as a new named LLM provider, mirroring the existing OpenRouter provider exactly. Requesty is an OpenAI-compatible LLM router (base URL `https://router.requesty.ai/v1`) that uses the same `provider/model` naming scheme as OpenRouter (e.g. `openai/gpt-4o-mini`).

Because Requesty is OpenAI-compatible and behaves like OpenRouter (including the same optional reasoning directive shape), the implementation is a structural 1:1 mirror of `src/any_llm/providers/openrouter/`, changing only the provider id, class name, base URL, env var, and documentation URL.

## What changed

- **`src/any_llm/providers/requesty/`** (new package): `requesty.py`, `__init__.py`, `utils.py` mirroring the OpenRouter provider.
  - `API_BASE = "https://router.requesty.ai/v1"`
  - `ENV_API_KEY_NAME` = `REQUESTY_API_KEY`, `ENV_API_BASE_NAME = "REQUESTY_API_BASE"`
  - `PROVIDER_NAME = "requesty"`, docs at `https://docs.requesty.ai`
  - Subclasses `BaseOpenAIProvider`, same reasoning-directive handling and `_convert_models_list` model-normalization as OpenRouter.
- **`src/any_llm/constants.py`**: added `REQUESTY = "requesty"` to the `LLMProvider` enum.
- **`pyproject.toml`**: added the `requesty = []` optional-dependency group and included `requesty` in the `all` extra (the OpenAI-compatible base requires no extra SDK, same as OpenRouter).
- **`tests/unit/providers/test_requesty_provider.py`** (new): full mirror of `test_openrouter_provider.py` (reasoning directive, streaming, max_tokens remap, model-list normalization, round-trip serialization).

The factory (`AnyLLM._create_provider`) discovers providers dynamically from the enum value, so no factory/mapping edit is needed; the enum + matching package name + pyproject group is the full registration surface, which the repo's exhaustiveness tests enforce.

## Note on the README

The README does not contain a committed supported-provider list/table (the provider list is generated to GitBook via `scripts/convert_to_gitbook.py` and published to `docs.mozilla.ai`, not committed). The only OpenRouter mention in the README is the "Proxy Only Solutions" comparison paragraph, where adding Requesty would be inappropriate. Happy to add a docs/provider entry wherever the maintainers prefer.

## Usage

```python
from any_llm import AnyLLM

provider = AnyLLM.create("requesty", api_key="<REQUESTY_API_KEY>")
completion = provider.completion(
    model="openai/gpt-4o-mini",
    messages=[{"role": "user", "content": "Hello!"}],
)
```

Set `REQUESTY_API_KEY` in your environment, or pass `api_key=` directly.

## Testing & linting

- `uv run pytest tests/unit/providers/test_requesty_provider.py tests/unit/providers/test_openrouter_provider.py tests/unit/test_provider.py tests/unit/test_provider_pyproject_options.py -q` -> **127 passed, 9 skipped** (includes the enum/pyproject/load exhaustiveness tests that load every provider).
- `ruff@0.15.12 check` and `ruff@0.15.12 format --check` (the pinned pre-commit version) -> clean on the new files.
- `uv run mypy src/any_llm/providers/requesty/` (strict) -> `Success: no issues found`.

## Disclosure

I work at Requesty. Happy to adjust scope/naming or close if out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Requesty provider, including completion streaming.
  * Enabled reasoning support for Requesty-based completions, with correct request shaping.

* **Tests**
  * Added comprehensive unit tests for Requesty completion parameters, reasoning injection, and model-list conversion.

* **Chores**
  * Updated optional dependencies to include the Requesty provider extra (as a newly available provider option).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## PR Type

- 🆕 New Feature

## Relevant issues

N/A

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude Opus
- AI Developer Tool used: CLI agent
- Any other info you'd like to share: The provider is a structural 1:1 mirror of the existing OpenRouter provider; I reviewed every line, ran the unit tests (new + openrouter) and the enum/pyproject exhaustiveness tests locally, and confirmed ruff + mypy pass before submitting.

- [ ] I am an AI Agent filling out this form (check box if true)
