### PR TITLE
feat(atlascloud): add Atlas Cloud provider (OpenAI-compatible)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all = [
-  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra]"
+  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud]"
 ]
 
 platform = [
@@ -109,6 +109,7 @@ lmstudio = [
 ]
 
 # These providers don't require any additional dependencies, but are included for completeness.
+atlascloud = []
 azureopenai = []
 cascadia = []
 databricks = []

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -21,6 +21,7 @@ class LLMProvider(StrEnum):
     AZURE = "azure"
     AZUREANTHROPIC = "azureanthropic"
     AZUREOPENAI = "azureopenai"
+    ATLASCLOUD = "atlascloud"
     CASCADIA = "cascadia"
     CEREBRAS = "cerebras"
     COHERE = "cohere"

--- a/src/any_llm/providers/atlascloud/__init__.py
+++ b/src/any_llm/providers/atlascloud/__init__.py
@@ -1,0 +1,3 @@
+from any_llm.providers.atlascloud.atlascloud import AtlascloudProvider
+
+__all__ = ["AtlascloudProvider"]

--- a/src/any_llm/providers/atlascloud/atlascloud.py
+++ b/src/any_llm/providers/atlascloud/atlascloud.py
@@ -1,0 +1,30 @@
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+
+class AtlascloudProvider(BaseOpenAIProvider):
+    """Provider for Atlas Cloud (https://www.atlascloud.ai).
+
+    Atlas Cloud is an OpenAI-compatible inference platform serving DeepSeek, Qwen,
+    Kimi, GLM and MiniMax models. It exposes the standard chat completions and model
+    listing endpoints under https://api.atlascloud.ai/v1, so this provider only needs
+    to set configuration defaults and capability flags on top of BaseOpenAIProvider.
+    """
+
+    API_BASE = "https://api.atlascloud.ai/v1"
+    ENV_API_KEY_NAME = "ATLASCLOUD_API_KEY"
+    ENV_API_BASE_NAME = "ATLASCLOUD_API_BASE"
+    PROVIDER_NAME = "atlascloud"
+    PROVIDER_DOCUMENTATION_URL = "https://www.atlascloud.ai/docs"
+
+    SUPPORTS_COMPLETION = True
+    SUPPORTS_COMPLETION_STREAMING = True
+    SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_COMPLETION_IMAGE = False
+    SUPPORTS_COMPLETION_PDF = False
+    SUPPORTS_EMBEDDING = False
+    SUPPORTS_MODERATION = False
+    SUPPORTS_LIST_MODELS = True
+    SUPPORTS_BATCH = False
+    SUPPORTS_IMAGE_GENERATION = False
+    SUPPORTS_RERANK = False
+    SUPPORTS_RESPONSES = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.LLAMACPP: "N/A",
         LLMProvider.VLLM: "N/A",
         LLMProvider.CASCADIA: "N/A",
+        LLMProvider.ATLASCLOUD: "deepseek-ai/deepseek-v4-flash",
         LLMProvider.LMSTUDIO: "qwen3-0.6b",
         LLMProvider.AZUREOPENAI: "gpt-4.1-nano",
         LLMProvider.CEREBRAS: "gpt-oss-120b",
@@ -99,6 +100,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.LMSTUDIO: "qwen/qwen3-1.7b",  # small model keeps the LM Studio cache under the 10GB Actions limit; you must have LM Studio running and the server enabled
         LLMProvider.VLLM: "Qwen/Qwen2.5-0.5B-Instruct",
         LLMProvider.CASCADIA: "Qwen/Qwen2.5-0.5B-Instruct",
+        LLMProvider.ATLASCLOUD: "deepseek-v3",
         LLMProvider.COHERE: "command-a-03-2025",
         LLMProvider.CEREBRAS: "gpt-oss-120b",
         LLMProvider.HUGGINGFACE: "Qwen/Qwen2.5-72B-Instruct",

--- a/tests/unit/providers/test_atlascloud_provider.py
+++ b/tests/unit/providers/test_atlascloud_provider.py
@@ -1,0 +1,69 @@
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.constants import LLMProvider
+from any_llm.exceptions import MissingApiKeyError
+from any_llm.providers.atlascloud.atlascloud import AtlascloudProvider
+
+
+def test_provider_metadata() -> None:
+    provider = AtlascloudProvider(api_key="test-api-key")
+    assert provider.PROVIDER_NAME == "atlascloud"
+    assert provider.API_BASE == "https://api.atlascloud.ai/v1"
+    assert provider.ENV_API_KEY_NAME == "ATLASCLOUD_API_KEY"
+    assert provider.ENV_API_BASE_NAME == "ATLASCLOUD_API_BASE"
+    assert provider.PROVIDER_DOCUMENTATION_URL == "https://www.atlascloud.ai/docs"
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Atlas Cloud is a hosted, keyed API: constructing without a key must fail.
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    with pytest.raises(MissingApiKeyError):
+        AtlascloudProvider()
+
+
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+    provider = AtlascloudProvider()
+    assert provider._verify_and_set_api_key(None) == "env-key"
+
+
+def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+    provider = AtlascloudProvider(api_key="explicit-key")
+    assert provider._verify_and_set_api_key("explicit-key") == "explicit-key"
+
+
+def test_api_base_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://proxy.internal/v1")
+    provider = AtlascloudProvider(api_key="test-api-key")
+    assert provider._resolve_api_base(None) == "https://proxy.internal/v1"
+
+
+def test_api_base_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+    provider = AtlascloudProvider(api_key="test-api-key")
+    # No env var, no explicit base: falls through to the class default.
+    assert provider._resolve_api_base(None) is None
+    assert str(provider.client.base_url).rstrip("/") == "https://api.atlascloud.ai/v1"
+
+
+def test_capability_flags() -> None:
+    assert AtlascloudProvider.SUPPORTS_COMPLETION
+    assert AtlascloudProvider.SUPPORTS_COMPLETION_STREAMING
+    assert AtlascloudProvider.SUPPORTS_COMPLETION_REASONING
+    assert AtlascloudProvider.SUPPORTS_LIST_MODELS
+    assert not AtlascloudProvider.SUPPORTS_COMPLETION_IMAGE
+    assert not AtlascloudProvider.SUPPORTS_COMPLETION_PDF
+    assert not AtlascloudProvider.SUPPORTS_EMBEDDING
+    assert not AtlascloudProvider.SUPPORTS_MODERATION
+    assert not AtlascloudProvider.SUPPORTS_BATCH
+    assert not AtlascloudProvider.SUPPORTS_IMAGE_GENERATION
+    assert not AtlascloudProvider.SUPPORTS_RERANK
+    assert not AtlascloudProvider.SUPPORTS_RESPONSES
+
+
+def test_registered_in_enum_and_loader() -> None:
+    assert LLMProvider.from_string("atlascloud") is LLMProvider.ATLASCLOUD
+    assert AnyLLM.get_provider_class("atlascloud") is AtlascloudProvider
+    assert "atlascloud" in AnyLLM.get_supported_providers()


### PR DESCRIPTION
Atlas Cloud (https://www.atlascloud.ai) exposes an OpenAI-compatible API at https://api.atlascloud.ai/v1 serving DeepSeek, Qwen, Kimi, GLM and MiniMax models. Add it as a first-class provider so it can be selected as "atlascloud/<model>" with its own ATLASCLOUD_API_KEY env var.

Implemented as a thin BaseOpenAIProvider subclass (no new dependency, reuses the openai client). Declared capabilities: completion, streaming, reasoning and list_models. Embeddings, moderation, vision/PDF, rerank, batch, responses and image generation are left off as they are not exposed on the /v1 base.

- constants: register ATLASCLOUD in the LLMProvider enum
- pyproject: add the empty "atlascloud" extra and include it in "all"
- conftest: add deepseek-ai/deepseek-v4-flash to the model and reasoning model maps
- tests: unit coverage for metadata, key/base resolution, missing-key error, capability flags and enum/loader registration

## Description

Adds **Atlas Cloud** as a first-class, OpenAI-compatible provider. It already works today by pointing the `openai` provider at `https://api.atlascloud.ai/v1`; this PR makes it a named provider (`atlascloud/<model>`) with its own `ATLASCLOUD_API_KEY` / `ATLASCLOUD_API_BASE` env vars and auto-generated docs.

The provider is a thin `BaseOpenAIProvider` subclass that only sets configuration defaults and capability flags, so it reuses the existing `openai` client and needs no new dependency. Declared capabilities (completion, streaming, reasoning, list_models) reflect what Atlas Cloud exposes on its `/v1` base; embeddings, moderation, vision/PDF, rerank, batch, responses and image generation are intentionally left off because they are not available there (image/video generation live on a separate `/api/v1` base).

## PR Type

- 🆕 New Feature

## Relevant issues

N/A

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it ~fixes the issue~ works correctly.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8 and Claude Opus 4.6
- AI Developer Tool used: Claude Code and Visual Studio Code with GitHub Copilot built in extension
- Any other info you'd like to share: AI assisted with code drafting and tests; design decisions and final review are mine.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Atlas Cloud provider, including provider discovery and configuration.
  * Expanded the bundled “all” option to include additional provider extras.
  * Added a new `atlascloud` optional dependency entry.

* **Bug Fixes**
  * Improved provider detection so Atlas Cloud can be selected from its string name.
  * Added validation for API key and base URL handling, with sensible defaults when not set.

* **Tests**
  * Added coverage for Atlas Cloud setup, capability flags, and provider registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->