### PR TITLE
fix(messages): report Anthropic streaming usage from the trailing usage-only chunk

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -785,16 +785,11 @@ class AnyLLM(ABC):
 
         async def convert_stream() -> AsyncIterator[MessageStreamEvent]:
             state = StreamingState()
-            emitted_stop = False
             async for chunk in result:
-                events = chat_completion_chunk_to_message_stream_events(chunk, state)
-                for event in events:
-                    if isinstance(event, MessageStopEvent):
-                        emitted_stop = True
+                for event in chat_completion_chunk_to_message_stream_events(chunk, state):
                     yield event
-            # Some providers don't send a final chunk with finish_reason,
-            # so ensure the stream always ends with message_stop.
-            if state.started and not emitted_stop:
+            # Emit the closing events after the full stream is consumed so trailing-chunk usage is included.
+            if state.started:
                 if state.current_block_type is not None:
                     yield ContentBlockStopEvent(
                         type="content_block_stop",
@@ -802,10 +797,11 @@ class AnyLLM(ABC):
                     )
                 yield MessageDeltaEvent(
                     type="message_delta",
-                    delta=MessageDelta(stop_reason="end_turn"),
+                    delta=MessageDelta(stop_reason=state.stop_reason or "end_turn"),
                     usage=MessageDeltaUsage(
                         output_tokens=state.output_tokens,
                         input_tokens=state.input_tokens,
+                        cache_read_input_tokens=state.cache_read_input_tokens or None,
                     ),
                 )
                 yield MessageStopEvent(type="message_stop")

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -804,8 +804,10 @@ class AnyLLM(ABC):
                         yield event
             except Exception:
                 # Flush the usage accumulated so far before re-raising, so a mid-stream failure still reports tokens.
+                # Report stop_reason=None so a finish_reason seen before the failure is never mistaken for a
+                # successful completion; message_stop stays reserved for the clean-completion path below.
                 if state.started:
-                    yield usage_delta(state.stop_reason)
+                    yield usage_delta(None)
                 raise
             # Emit the closing events after the full stream is consumed so trailing-chunk usage is included.
             if state.started:

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -37,6 +37,7 @@ from any_llm.types.messages import (
     MessageStopEvent,
     MessageStreamEvent,
     ParsedMessage,
+    StopReason,
 )
 from any_llm.types.provider import ProviderMetadata
 from any_llm.types.responses import (
@@ -785,9 +786,27 @@ class AnyLLM(ABC):
 
         async def convert_stream() -> AsyncIterator[MessageStreamEvent]:
             state = StreamingState()
-            async for chunk in result:
-                for event in chat_completion_chunk_to_message_stream_events(chunk, state):
-                    yield event
+
+            def usage_delta(stop_reason: StopReason | None) -> MessageDeltaEvent:
+                return MessageDeltaEvent(
+                    type="message_delta",
+                    delta=MessageDelta(stop_reason=stop_reason),
+                    usage=MessageDeltaUsage(
+                        output_tokens=state.output_tokens,
+                        input_tokens=state.input_tokens,
+                        cache_read_input_tokens=state.cache_read_input_tokens or None,
+                    ),
+                )
+
+            try:
+                async for chunk in result:
+                    for event in chat_completion_chunk_to_message_stream_events(chunk, state):
+                        yield event
+            except Exception:
+                # Flush the usage accumulated so far before re-raising, so a mid-stream failure still reports tokens.
+                if state.started:
+                    yield usage_delta(state.stop_reason)
+                raise
             # Emit the closing events after the full stream is consumed so trailing-chunk usage is included.
             if state.started:
                 if state.current_block_type is not None:
@@ -795,15 +814,7 @@ class AnyLLM(ABC):
                         type="content_block_stop",
                         index=state.current_block_index,
                     )
-                yield MessageDeltaEvent(
-                    type="message_delta",
-                    delta=MessageDelta(stop_reason=state.stop_reason or "end_turn"),
-                    usage=MessageDeltaUsage(
-                        output_tokens=state.output_tokens,
-                        input_tokens=state.input_tokens,
-                        cache_read_input_tokens=state.cache_read_input_tokens or None,
-                    ),
-                )
+                yield usage_delta(state.stop_reason or "end_turn")
                 yield MessageStopEvent(type="message_stop")
 
         return convert_stream()

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -10,12 +10,8 @@ from any_llm.types.messages import (
     ContentBlockStartEvent,
     ContentBlockStopEvent,
     InputJSONDelta,
-    MessageDelta,
-    MessageDeltaEvent,
-    MessageDeltaUsage,
     MessageResponse,
     MessageStartEvent,
-    MessageStopEvent,
     MessageUsage,
     StopReason,
     TextBlock,
@@ -316,6 +312,8 @@ class StreamingState:
         self.model = "unknown"
         self.input_tokens = 0
         self.output_tokens = 0
+        self.cache_read_input_tokens = 0
+        self.stop_reason: StopReason | None = None
         self.tool_call_id: str | None = None
         self.tool_call_name: str | None = None
 
@@ -323,27 +321,13 @@ class StreamingState:
 def chat_completion_chunk_to_message_stream_events(
     chunk: ChatCompletionChunk,
     state: StreamingState,
-) -> list[
-    MessageStartEvent
-    | MessageDeltaEvent
-    | MessageStopEvent
-    | ContentBlockStartEvent
-    | ContentBlockDeltaEvent
-    | ContentBlockStopEvent
-]:
+) -> list[MessageStartEvent | ContentBlockStartEvent | ContentBlockDeltaEvent | ContentBlockStopEvent]:
     """Convert a ChatCompletionChunk to a list of MessageStreamEvents.
 
     This is stateful: it tracks the current content block index and type to emit
     the correct lifecycle events (start/delta/stop).
     """
-    events: list[
-        MessageStartEvent
-        | MessageDeltaEvent
-        | MessageStopEvent
-        | ContentBlockStartEvent
-        | ContentBlockDeltaEvent
-        | ContentBlockStopEvent
-    ] = []
+    events: list[MessageStartEvent | ContentBlockStartEvent | ContentBlockDeltaEvent | ContentBlockStopEvent] = []
     state.model = chunk.model
 
     if chunk.usage:
@@ -351,6 +335,9 @@ def chat_completion_chunk_to_message_stream_events(
             state.input_tokens = chunk.usage.prompt_tokens
         if chunk.usage.completion_tokens:
             state.output_tokens = chunk.usage.completion_tokens
+        prompt_details = chunk.usage.prompt_tokens_details
+        if prompt_details and prompt_details.cached_tokens:
+            state.cache_read_input_tokens = prompt_details.cached_tokens
 
     if not state.started:
         state.started = True
@@ -444,29 +431,14 @@ def chat_completion_chunk_to_message_stream_events(
 
     if choice.finish_reason:
         _close_current_block(state, events)
-        stop_reason = _finish_reason_to_stop_reason(choice.finish_reason)
-        events.append(
-            MessageDeltaEvent(
-                type="message_delta",
-                delta=MessageDelta(stop_reason=stop_reason),
-                usage=MessageDeltaUsage(output_tokens=state.output_tokens, input_tokens=state.input_tokens),
-            )
-        )
-        events.append(MessageStopEvent(type="message_stop"))
+        state.stop_reason = _finish_reason_to_stop_reason(choice.finish_reason)
 
     return events
 
 
 def _close_current_block(
     state: StreamingState,
-    events: list[
-        MessageStartEvent
-        | MessageDeltaEvent
-        | MessageStopEvent
-        | ContentBlockStartEvent
-        | ContentBlockDeltaEvent
-        | ContentBlockStopEvent
-    ],
+    events: list[MessageStartEvent | ContentBlockStartEvent | ContentBlockDeltaEvent | ContentBlockStopEvent],
 ) -> None:
     """Emit a content_block_stop event for the current block if one is open."""
     if state.current_block_type is not None:

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -504,6 +504,62 @@ async def test_default_amessages_streaming_flushes_usage_when_stream_fails() -> 
 
 
 @pytest.mark.asyncio
+async def test_default_amessages_streaming_failure_after_finish_reason_reports_no_stop_reason() -> None:
+    """A stream that emits finish_reason and then fails must not report a completion stop_reason."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+            usage=CompletionUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110),
+        )
+        yield ChatCompletionChunk(
+            id="chunk-2",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+        )
+        # The trailing usage-only chunk never arrives; the provider stream drops instead.
+        msg = "provider stream dropped"
+        raise RuntimeError(msg)
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    seen: list[Any] = []
+
+    async def consume() -> None:
+        async for event in result:
+            seen.append(event)
+
+    with pytest.raises(RuntimeError, match="provider stream dropped"):
+        await consume()
+
+    delta = next(e for e in seen if isinstance(e, MessageDeltaEvent))
+    assert delta.usage.input_tokens == 100
+    assert delta.usage.output_tokens == 10
+    # Even though finish_reason="stop" was seen, the failure path must report stop_reason=None
+    # so consumers cannot mistake the flushed delta for a successful completion.
+    assert delta.delta.stop_reason is None
+    # message_stop stays reserved for clean completion; it must never appear on the failure path.
+    # (content_block_stop legitimately appears here: the content block was closed when finish_reason arrived.)
+    assert all(e.type != "message_stop" for e in seen)
+
+
+@pytest.mark.asyncio
 async def test_default_amessages_streaming_failure_before_first_chunk_emits_nothing() -> None:
     """A stream that fails before producing any chunk emits no events, only the exception."""
 

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,12 +1,21 @@
 """Tests for messages()/amessages() SDK API."""
 
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from any_llm.any_llm import AnyLLM
 from any_llm.api import amessages
-from any_llm.types.messages import MessageResponse, ParsedMessage, ParsedTextBlock
+from any_llm.types.completion import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+    ChunkChoice,
+    CompletionUsage,
+    PromptTokensDetails,
+)
+from any_llm.types.messages import MessageDeltaEvent, MessageResponse, MessagesParams, ParsedMessage, ParsedTextBlock
 
 
 @pytest.mark.asyncio
@@ -399,16 +408,8 @@ async def test_default_amessages_streaming() -> None:
 @pytest.mark.asyncio
 async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
     """Usage (incl. cache) from a trailing usage-only chunk after finish_reason is reported in message_delta."""
-    from any_llm.types.completion import (
-        ChatCompletionChunk,
-        ChoiceDelta,
-        ChunkChoice,
-        CompletionUsage,
-        PromptTokensDetails,
-    )
-    from any_llm.types.messages import MessageDeltaEvent, MessagesParams
 
-    async def mock_stream() -> Any:
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
         yield ChatCompletionChunk(
             id="chunk-1",
             model="gpt-4",
@@ -440,8 +441,6 @@ async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
     mock_provider = Mock()
     mock_provider._acompletion = AsyncMock(return_value=mock_stream())
 
-    from any_llm.any_llm import AnyLLM
-
     params = MessagesParams(
         model="gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
@@ -458,6 +457,219 @@ async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
     assert delta.usage.cache_read_input_tokens == 80
     assert delta.delta.stop_reason == "end_turn"
     assert events[-1].type == "message_stop"
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_flushes_usage_when_stream_fails() -> None:
+    """A stream that raises mid-iteration still emits a message_delta with the accumulated usage."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+            usage=CompletionUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110),
+        )
+        msg = "provider stream dropped"
+        raise RuntimeError(msg)
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    seen: list[Any] = []
+
+    async def consume() -> None:
+        async for event in result:
+            seen.append(event)
+
+    with pytest.raises(RuntimeError, match="provider stream dropped"):
+        await consume()
+
+    delta = next(e for e in seen if isinstance(e, MessageDeltaEvent))
+    assert delta.usage.input_tokens == 100
+    assert delta.usage.output_tokens == 10
+    assert delta.delta.stop_reason is None
+    assert all(e.type not in ("message_stop", "content_block_stop") for e in seen)
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_failure_before_first_chunk_emits_nothing() -> None:
+    """A stream that fails before producing any chunk emits no events, only the exception."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        msg = "connect failed"
+        raise RuntimeError(msg)
+        yield  # unreachable, makes this function an async generator
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    seen: list[Any] = []
+
+    async def consume() -> None:
+        async for event in result:
+            seen.append(event)
+
+    with pytest.raises(RuntimeError, match="connect failed"):
+        await consume()
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_early_close_is_clean() -> None:
+    """Closing the event stream before it is exhausted does not raise from the cleanup path."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hello"), finish_reason=None)],
+        )
+        yield ChatCompletionChunk(
+            id="chunk-2",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content=" world"), finish_reason=None)],
+        )
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert isinstance(result, AsyncGenerator)
+
+    first = await anext(result)
+    assert first.type == "message_start"
+    await result.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_close_after_failure_flush_is_clean() -> None:
+    """Closing the stream at the failure-path usage flush does not raise from the cleanup path."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+            usage=CompletionUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110),
+        )
+        msg = "provider stream dropped"
+        raise RuntimeError(msg)
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert isinstance(result, AsyncGenerator)
+
+    delta: MessageDeltaEvent | None = None
+    async for event in result:
+        if isinstance(event, MessageDeltaEvent):
+            delta = event
+            break
+    assert delta is not None
+    assert delta.usage.input_tokens == 100
+    await result.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_no_finish_reason_closes_open_block() -> None:
+    """A stream that ends without finish_reason still closes the open block and defaults to end_turn."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hello"), finish_reason=None)],
+        )
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    events = [event async for event in result]
+    assert [e.type for e in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    delta = next(e for e in events if isinstance(e, MessageDeltaEvent))
+    assert delta.delta.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_empty_stream_emits_nothing() -> None:
+    """A stream that ends without producing any chunks emits no events."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        return
+        yield  # unreachable, makes this function an async generator
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    events = [event async for event in result]
+    assert events == []
 
 
 def test_supports_messages_flag() -> None:

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -396,6 +396,70 @@ async def test_default_amessages_streaming() -> None:
     assert "message_stop" in types
 
 
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
+    """Usage (incl. cache) from a trailing usage-only chunk after finish_reason is reported in message_delta."""
+    from any_llm.types.completion import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+        ChunkChoice,
+        CompletionUsage,
+        PromptTokensDetails,
+    )
+    from any_llm.types.messages import MessageDeltaEvent, MessagesParams
+
+    async def mock_stream() -> Any:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hello"), finish_reason=None)],
+        )
+        yield ChatCompletionChunk(
+            id="chunk-2",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+        )
+        yield ChatCompletionChunk(
+            id="chunk-3",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[],
+            usage=CompletionUsage(
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=80),
+            ),
+        )
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    from any_llm.any_llm import AnyLLM
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+
+    events = [event async for event in result]
+    delta = next(e for e in events if isinstance(e, MessageDeltaEvent))
+    assert delta.usage.input_tokens == 100
+    assert delta.usage.output_tokens == 50
+    assert delta.usage.cache_read_input_tokens == 80
+    assert delta.delta.stop_reason == "end_turn"
+    assert events[-1].type == "message_stop"
+
+
 def test_supports_messages_flag() -> None:
     """Test that SUPPORTS_MESSAGES defaults to True."""
     from any_llm.any_llm import AnyLLM

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -13,6 +13,7 @@ from any_llm.types.completion import (
     ChunkChoice,
     CompletionUsage,
     Function,
+    PromptTokensDetails,
     Reasoning,
 )
 from any_llm.types.messages import MessagesParams
@@ -409,9 +410,8 @@ def test_streaming_text_events() -> None:
     )
     events2 = chat_completion_chunk_to_message_stream_events(chunk2, state)
     types2 = [e.type for e in events2]
-    assert "content_block_stop" in types2
-    assert "message_delta" in types2
-    assert "message_stop" in types2
+    assert types2 == ["content_block_stop"]
+    assert state.stop_reason == "end_turn"
 
 
 def test_streaming_tool_call_events() -> None:
@@ -918,7 +918,7 @@ def test_streaming_empty_content_no_delta() -> None:
 
 
 def test_streaming_finish_reason_length() -> None:
-    """Test streaming with finish_reason 'length' emits correct stop_reason."""
+    """Test streaming finish_reason 'length' records the correct stop_reason on state."""
     state = StreamingState()
     state.started = True
     state.current_block_index = 0
@@ -932,11 +932,68 @@ def test_streaming_finish_reason_length() -> None:
         choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="length")],
     )
     events = chat_completion_chunk_to_message_stream_events(chunk, state)
-    from any_llm.types.messages import MessageDeltaEvent
 
-    delta_event = next(e for e in events if e.type == "message_delta")
-    assert isinstance(delta_event, MessageDeltaEvent)
-    assert delta_event.delta.stop_reason == "max_tokens"
+    assert [e.type for e in events] == ["content_block_stop"]
+    assert state.stop_reason == "max_tokens"
+
+
+def test_streaming_usage_cache_read_from_prompt_tokens_details() -> None:
+    """A usage chunk's prompt_tokens_details.cached_tokens is recorded as cache_read on state."""
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=80),
+        ),
+    )
+    chat_completion_chunk_to_message_stream_events(chunk, state)
+    assert state.cache_read_input_tokens == 80
+
+
+def test_streaming_usage_zero_cached_tokens_leaves_cache_read_unset() -> None:
+    """cached_tokens=0 is falsy and must not set cache_read_input_tokens."""
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=0),
+        ),
+    )
+    chat_completion_chunk_to_message_stream_events(chunk, state)
+    assert state.cache_read_input_tokens == 0
+
+
+def test_streaming_usage_no_prompt_tokens_details_leaves_cache_read_unset() -> None:
+    """Usage without prompt_tokens_details leaves cache_read_input_tokens at its default."""
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+        ),
+    )
+    chat_completion_chunk_to_message_stream_events(chunk, state)
+    assert state.cache_read_input_tokens == 0
 
 
 def test_close_current_block_when_none() -> None:


### PR DESCRIPTION
## Description

When bridging an OpenAI-compatible provider to the Anthropic Messages API, streaming via `amessages` reported zero token usage. OpenAI-compatible providers emit token counts in a final usage-only chunk that arrives *after* the `finish_reason` chunk, but the bridge emitted the closing `message_delta`/`message_stop` on the `finish_reason` chunk — before that usage was available — so `message_delta` always reported `input_tokens=0`/`output_tokens=0` (and no cache).

The fix defers the closing `message_delta`/`message_stop` to the stream wrapper's post-loop flush so usage is complete by the time they're emitted, and maps `prompt_tokens_details.cached_tokens` → `cache_read_input_tokens`. Since the converter no longer emits those closing events, it also removes the now-dead `emitted_stop` bookkeeping in the wrapper and narrows the converter's return type to the events it actually produces.

**Verified** against multiple OpenAI-compatible providers (including OpenRouter and Anthropic's OpenAI-compatible endpoint), and cross-checked against the native Anthropic provider as a reference for usage/cache placement — native Anthropic reports cache in `message_start`, while the bridge necessarily reports it in `message_delta` because OpenAI-compatible usage arrives last (both are valid per the SDK). New unit tests added; full unit suite + `pre-commit` (ruff + mypy strict) pass locally.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None found.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary <!-- no public docs affected; internal behavior fix -->
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: AI-authored, but human-directed and reviewed change-by-change. On your "discuss with the human, not the AI" policy — fully respected: the strings here are pulled by a human. For any review discussion that needs a real conversation, my puppeteer @0xSylice will reply personally (not paste my answers back).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming event ordering so final stop reasons are emitted reliably, including when a stream ends with trailing usage-only chunks.
  * Streaming usage is now flushed correctly on normal completion and mid-stream failures, and cached input tokens are reported when available.
  * Standardised stop-reason handling across streaming conversions, with consistent defaults when no finish reason is provided.
* **Tests**
  * Expanded unit and compatibility tests for cached-token scenarios (present/zero/missing), stop-reason semantics, and robustness during exceptions and early closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->