### PR TITLE
feat(ollama): support reasoning_effort via leveled thinking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ together = [
 ]
 
 ollama = [
-  "ollama>=0.5.1"
+  "ollama>=0.6.0"
 ]
 
 voyage = [

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -31,6 +31,18 @@ if TYPE_CHECKING:
     from any_llm.types.model import Model
 
 
+# Ollama's `think` parameter accepts only low/medium/high levels (plus booleans)
+# Reasoning_effort scale is collapsed at the extremes.
+REASONING_EFFORT_TO_OLLAMA_THINK: dict[str, str] = {
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "high",
+    "max": "high",
+}
+
+
 class OllamaProvider(AnyLLM):
     """
     Ollama Provider using the new response conversion utilities.
@@ -63,12 +75,14 @@ class OllamaProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for Ollama API."""
-        # Ollama does not support providing reasoning effort
         converted_params = params.model_dump(
-            exclude_none=True, exclude={"model_id", "messages", "response_format", "stream", "stream_options"}
+            exclude_none=True,
+            exclude={"model_id", "messages", "reasoning_effort", "response_format", "stream", "stream_options"},
         )
-        if converted_params.get("reasoning_effort") in ("auto", "none"):
-            converted_params.pop("reasoning_effort")
+        if params.reasoning_effort == "none":
+            converted_params["think"] = False
+        elif params.reasoning_effort is not None and params.reasoning_effort != "auto":
+            converted_params["think"] = REASONING_EFFORT_TO_OLLAMA_THINK[params.reasoning_effort]
         converted_params.update(kwargs)
         converted_params["num_ctx"] = converted_params.get("num_ctx", 32000)
         return converted_params
@@ -203,9 +217,6 @@ class OllamaProvider(AnyLLM):
             cleaned_messages.append(cleaned_message)
 
         completion_kwargs = self._convert_completion_params(params, **kwargs)
-
-        if completion_kwargs.get("reasoning_effort") is not None:
-            completion_kwargs["think"] = True
 
         if params.stream:
             return self._stream_completion_async(params.model_id, cleaned_messages, **completion_kwargs)

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -129,9 +129,19 @@ async def test_streaming_completion_passes_tools_top_level() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("reasoning_effort", ["auto", "none"])
-async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
-    """Test that reasoning_effort 'auto' and 'none' are filtered from Ollama API calls."""
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_think"),
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+    ],
+)
+async def test_reasoning_effort_maps_to_think_level(reasoning_effort: str, expected_think: str) -> None:
+    """Test that reasoning_effort is mapped to Ollama's leveled `think` parameter."""
     with patch.object(OllamaProvider, "_init_client"):
         provider = OllamaProvider(api_key=None)
         provider.client = Mock()
@@ -140,11 +150,88 @@ async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
         with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
             await provider._acompletion(
                 CompletionParams(
-                    model_id="llama3.1",
+                    model_id="qwen3",
                     messages=[{"role": "user", "content": "Hello"}],
                     reasoning_effort=reasoning_effort,  # type: ignore[arg-type]
                 ),
             )
 
             call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["think"] == expected_think
             assert "reasoning_effort" not in call_kwargs.get("options", {})
+            assert "think" not in call_kwargs.get("options", {})
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_none_disables_think() -> None:
+    """Test that reasoning_effort 'none' explicitly disables thinking."""
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=Mock())
+
+        with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="qwen3",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    reasoning_effort="none",
+                ),
+            )
+
+            call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["think"] is False
+            assert "reasoning_effort" not in call_kwargs.get("options", {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reasoning_effort", ["auto", None])
+async def test_reasoning_effort_auto_leaves_think_unset(reasoning_effort: str | None) -> None:
+    """Test that 'auto'/None leave `think` unset so Ollama uses its per-model default."""
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=Mock())
+
+        with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="qwen3",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    reasoning_effort=reasoning_effort,  # type: ignore[arg-type]
+                ),
+            )
+
+            call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["think"] is None
+            assert "reasoning_effort" not in call_kwargs.get("options", {})
+
+
+@pytest.mark.asyncio
+async def test_streaming_completion_passes_think_level_top_level() -> None:
+    """Test that the leveled `think` is passed as a top-level kwarg to client.chat(), not in options."""
+
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter())
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="qwen3",
+                messages=[{"role": "user", "content": "Hello"}],
+                reasoning_effort="medium",
+                stream=True,
+            ),
+        )
+        async for _ in result:  # type: ignore[union-attr]
+            pass
+
+        call_kwargs = provider.client.chat.call_args[1]
+        assert call_kwargs["think"] == "medium"
+        assert "think" not in call_kwargs.get("options", {})
+        assert "reasoning_effort" not in call_kwargs.get("options", {})


### PR DESCRIPTION
## Description

Passing **reasoning_effort** (low/medium/high) used to leave the value in the options dict forwarded to the **Ollama** server; the provider only ever sent a boolean `think`, ignoring Ollama's native thinking levels.

Map reasoning_effort onto Ollama's leveled `think` parameter (mirrors the anthropic provider): minimal/low->low, medium->medium, high/xhigh/max->high, none->think=False, auto/None->unset (per-model default). Exclude reasoning_effort from the params dump so it can never leak into `options`.

Bump ollama>=0.6.0 (first release typing `think` as bool | low/medium/high).

Add unit tests covering the level mapping, none, auto and the streaming path; the existing integration reasoning tests now pass for ollama.

## PR Type

- 🆕 New Feature

## Relevant issues

N/A

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Claude Opus 4.8 and Claude Opus 4.6
- AI Developer Tool used: Claude Code and Visual Studio Code with GitHub Copilot built in extension
- Any other info you'd like to share: AI assisted with code drafting and tests; design decisions and final review are mine.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama requests now support a wider range of reasoning effort settings, including direct mapping to the provider’s available thinking levels.
  * Streaming requests now pass the thinking setting correctly for more consistent behaviour.

* **Bug Fixes**
  * Improved handling of reasoning effort values so “none” disables thinking, while “auto” and unset values leave it unchanged.
  * Updated the minimum supported Ollama version for installations that enable this optional integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->