### PR TITLE
fix(gemini): keep streamed tool_call index/id stable across chunks

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -250,7 +250,8 @@ class GoogleProvider(AnyLLM):
     @override
     def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
         """Convert Google chunk response to OpenAI format."""
-        return _create_openai_chunk_from_google_chunk(response)
+        tool_call_counter = kwargs.get("tool_call_counter")
+        return _create_openai_chunk_from_google_chunk(response, tool_call_counter)
 
     @staticmethod
     @override
@@ -303,8 +304,9 @@ class GoogleProvider(AnyLLM):
             response_stream = await self.client.aio.models.generate_content_stream(**converted_kwargs)
 
             async def _stream() -> AsyncIterator[ChatCompletionChunk]:
+                tool_call_counter: list[int] = [0]
                 async for chunk in response_stream:
-                    yield self._convert_completion_chunk_response(chunk)
+                    yield self._convert_completion_chunk_response(chunk, tool_call_counter=tool_call_counter)
 
             return _stream()
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -276,15 +276,14 @@ def _extract_usage_dict(response: types.GenerateContentResponse) -> dict[str, An
     return usage
 
 
-def _thought_signature_extra_content(part: Any) -> dict[str, Any] | None:
+def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
     """Build the OpenAI-compatible extra_content payload for a Gemini thought_signature, if present.
 
     Shared by both the non-streaming (_convert_response_to_response_dict) and streaming
     (_create_openai_chunk_from_google_chunk) conversion paths so they stay in sync.
     """
-    thought_signature = getattr(part, "thought_signature", None)
-    if thought_signature is not None and isinstance(thought_signature, bytes):
-        return {"google": {"thought_signature": base64.b64encode(thought_signature).decode("utf-8")}}
+    if part.thought_signature is not None and isinstance(part.thought_signature, bytes):
+        return {"google": {"thought_signature": base64.b64encode(part.thought_signature).decode("utf-8")}}
     return None
 
 
@@ -393,13 +392,26 @@ def _create_openai_embedding_response_from_google(
 
 def _create_openai_chunk_from_google_chunk(
     response: types.GenerateContentResponse,
+    tool_call_counter: list[int] | None = None,
 ) -> ChatCompletionChunk:
-    """Convert a Google GenerateContentResponse to an OpenAI ChatCompletionChunk."""
+    """Convert a Google GenerateContentResponse to an OpenAI ChatCompletionChunk.
+
+    Args:
+        response: The Google GenerateContentResponse streaming chunk.
+        tool_call_counter: Optional single-element list holding the number of tool
+            calls already emitted earlier in the same stream. This should be created
+            once per stream and passed in by the caller so that ``index`` (and the
+            generated tool call ``id``) stay stable and unique across chunks, rather
+            than restarting at 0 for every chunk.
+    """
 
     assert response.candidates
     candidate = response.candidates[0]
     assert candidate.content
     assert candidate.content.parts
+
+    if tool_call_counter is None:
+        tool_call_counter = [0]
 
     content = ""
     reasoning_content = ""
@@ -418,10 +430,13 @@ def _create_openai_chunk_from_google_chunk(
             # the non-streaming conversion in _convert_response_to_response_dict.
             extra_content = _thought_signature_extra_content(part)
 
+            tool_call_index = tool_call_counter[0]
+            tool_call_counter[0] += 1
+
             tool_calls_list.append(
                 ChoiceDeltaToolCall(
-                    index=len(tool_calls_list),
-                    id=f"call_{hash(function_call.name)}_{len(tool_calls_list)}",
+                    index=tool_call_index,
+                    id=f"call_{hash(function_call.name)}_{tool_call_index}",
                     type="function",
                     function=ChoiceDeltaToolCallFunction(
                         name=function_call.name,

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -15,7 +15,7 @@ from any_llm.providers.gemini.utils import (
     _convert_tool_spec,
     _create_openai_chunk_from_google_chunk,
 )
-from any_llm.types.completion import CompletionParams, PromptTokensDetails, ReasoningEffort
+from any_llm.types.completion import ChatCompletion, CompletionParams, PromptTokensDetails, ReasoningEffort
 
 TEST_IMAGE_BYTES = b"test-image-bytes"
 TEST_PDF_BYTES = b"%PDF-1.4\ntest"
@@ -1095,6 +1095,48 @@ def test_streaming_completion_multiple_tool_calls_within_chunk_after_prior_chunk
 
     assert second_chunk.choices[0].delta.tool_calls is not None
     assert [tc.index for tc in second_chunk.choices[0].delta.tool_calls] == [1, 2]
+
+
+async def _async_iter_chunks(items: list[Mock]) -> Any:
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_streaming_via_acompletion_keeps_tool_call_index_stable_across_chunks() -> None:
+    """End-to-end regression test for #1148 through GoogleProvider._acompletion.
+
+    Exercises the actual streaming plumbing (not just the pure conversion
+    helper) to make sure the `tool_call_counter` created in the `_stream()`
+    closure is correctly forwarded through `_convert_completion_chunk_response`'s
+    `**kwargs` for every chunk of the stream, so indices/ids stay stable across
+    chunks rather than resetting.
+    """
+    api_key = "test-api-key"
+    model = "gemini-pro"
+    messages = [{"role": "user", "content": "Read three files"}]
+
+    raw_chunks = [
+        _make_single_tool_call_chunk("read_file", {"path": "src/index.ts"}),
+        _make_single_tool_call_chunk("read_file", {"path": "src/page.ts"}),
+        _make_single_tool_call_chunk("read_file", {"path": "src/router.ts"}),
+    ]
+
+    with mock_gemini_provider() as mock_genai:
+        mock_client = mock_genai.return_value
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=_async_iter_chunks(raw_chunks))
+
+        provider = GeminiProvider(api_key=api_key)
+        result = await provider._acompletion(CompletionParams(model_id=model, messages=messages, stream=True))
+
+        tool_calls = []
+        assert not isinstance(result, ChatCompletion)
+        async for chunk in result:
+            assert chunk.choices[0].delta.tool_calls is not None
+            tool_calls.extend(chunk.choices[0].delta.tool_calls)
+
+    assert [tc.index for tc in tool_calls] == [0, 1, 2]
+    assert len({tc.id for tc in tool_calls}) == 3, "Each streamed tool call must have a unique id"
 
 
 def test_convert_response_preserves_thought_signature() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,4 +1,5 @@
 import base64
+from collections.abc import AsyncIterator
 from contextlib import contextmanager
 from typing import Any, get_args
 from unittest.mock import AsyncMock, Mock, patch
@@ -1097,7 +1098,7 @@ def test_streaming_completion_multiple_tool_calls_within_chunk_after_prior_chunk
     assert [tc.index for tc in second_chunk.choices[0].delta.tool_calls] == [1, 2]
 
 
-async def _async_iter_chunks(items: list[Mock]) -> Any:
+async def _async_iter_chunks(items: list[Mock]) -> AsyncIterator[Mock]:
     for item in items:
         yield item
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1001,6 +1001,102 @@ def test_streaming_completion_with_multiple_tool_calls() -> None:
     assert chunk.choices[0].delta.tool_calls[1].function.name == "get_weather"
 
 
+def _make_single_tool_call_chunk(name: str, args: dict[str, Any]) -> Mock:
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_function_call = Mock()
+    mock_function_call.name = name
+    mock_function_call.args = args
+
+    mock_part = Mock()
+    mock_part.function_call = mock_function_call
+    mock_part.thought = None
+    mock_part.text = None
+
+    mock_response.candidates[0].content.parts = [mock_part]
+    mock_response.candidates[0].finish_reason = Mock()
+    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.model_version = "gemini-2.5-flash"
+    mock_response.usage_metadata = None
+    return mock_response
+
+
+def test_streaming_completion_tool_call_index_stable_across_chunks() -> None:
+    """Tool call index/id must not reset to 0 for every chunk of the same stream.
+
+    Regression test for https://github.com/mozilla-ai/any-llm/issues/1148: each
+    chunk in a Gemini stream used to be converted independently, so repeated calls
+    to the same function across different chunks (e.g. three separate `read_file`
+    calls) all received index=0 and an identical tool call id.
+    """
+    tool_call_counter: list[int] = [0]
+
+    chunk_1 = _create_openai_chunk_from_google_chunk(
+        _make_single_tool_call_chunk("read_file", {"path": "src/index.ts"}), tool_call_counter
+    )
+    chunk_2 = _create_openai_chunk_from_google_chunk(
+        _make_single_tool_call_chunk("read_file", {"path": "src/page.ts"}), tool_call_counter
+    )
+    chunk_3 = _create_openai_chunk_from_google_chunk(
+        _make_single_tool_call_chunk("read_file", {"path": "src/router.ts"}), tool_call_counter
+    )
+
+    tool_calls = []
+    for chunk in (chunk_1, chunk_2, chunk_3):
+        assert chunk.choices[0].delta.tool_calls is not None
+        assert len(chunk.choices[0].delta.tool_calls) == 1
+        tool_calls.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert [tc.index for tc in tool_calls] == [0, 1, 2]
+    assert len({tc.id for tc in tool_calls}) == 3, "Each streamed tool call must have a unique id"
+
+
+def test_streaming_completion_multiple_tool_calls_within_chunk_after_prior_chunks() -> None:
+    """Indices for parallel tool calls within a chunk continue from prior chunks in the stream."""
+    tool_call_counter: list[int] = [0]
+
+    first_chunk = _create_openai_chunk_from_google_chunk(
+        _make_single_tool_call_chunk("read_file", {"path": "src/index.ts"}), tool_call_counter
+    )
+    assert first_chunk.choices[0].delta.tool_calls is not None
+    assert first_chunk.choices[0].delta.tool_calls[0].index == 0
+
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_function_call_1 = Mock()
+    mock_function_call_1.name = "get_weather"
+    mock_function_call_1.args = {"location": "Paris"}
+
+    mock_function_call_2 = Mock()
+    mock_function_call_2.name = "get_weather"
+    mock_function_call_2.args = {"location": "London"}
+
+    mock_part_1 = Mock()
+    mock_part_1.function_call = mock_function_call_1
+    mock_part_1.thought = None
+    mock_part_1.text = None
+
+    mock_part_2 = Mock()
+    mock_part_2.function_call = mock_function_call_2
+    mock_part_2.thought = None
+    mock_part_2.text = None
+
+    mock_response.candidates[0].content.parts = [mock_part_1, mock_part_2]
+    mock_response.candidates[0].finish_reason = Mock()
+    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.model_version = "gemini-2.5-flash"
+    mock_response.usage_metadata = None
+
+    second_chunk = _create_openai_chunk_from_google_chunk(mock_response, tool_call_counter)
+
+    assert second_chunk.choices[0].delta.tool_calls is not None
+    assert [tc.index for tc in second_chunk.choices[0].delta.tool_calls] == [1, 2]
+
+
 def test_convert_response_preserves_thought_signature() -> None:
     import base64
 


### PR DESCRIPTION
## Description

Fixes streamed tool call `index`/`id` for the Gemini provider.

`_create_openai_chunk_from_google_chunk` converts one Google `GenerateContentResponse` chunk at a time, but it was building `ChoiceDeltaToolCall.index` (and the generated `id`) from a list scoped to that single chunk. In a real stream, each chunk is converted independently, so:

- `index` reset to `0`/`1`/... for every chunk instead of tracking position across the whole assistant turn.
- Repeated calls to the *same* function across different chunks (e.g. three separate `read_file` calls, as in the issue's example) got an **identical `id`** (`hash(name)` + position-within-chunk), since the per-chunk counter always restarted at 0.

Downstream consumers that merge streamed tool-call deltas by `index`/`id` can therefore overwrite or misassociate arguments between tool calls.

### Fix

Thread a mutable `tool_call_counter` (a single-element list) through the stream, created once per `_stream()` call and passed into `_convert_completion_chunk_response(..., tool_call_counter=...)` on every chunk. This mirrors the `tool_index_map` pattern already used by the Bedrock provider (`src/any_llm/providers/bedrock/utils.py` / `bedrock.py`) to keep tool-call indices stable across a stream. The counter is optional (defaults to a fresh `[0]`) so existing single-chunk call sites/tests are unaffected.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1148

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Investigated the issue, designed and implemented the fix (following the existing `tool_index_map` pattern from the Bedrock provider), and added regression tests reproducing the reported scenario.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed Gemini tool-call handling so tool-call indices and generated IDs remain consistent and sequential across multi-chunk responses, including when tool calls are delivered in parallel later in the stream.
  * Enhanced thought-signature extraction for Gemini streaming to ensure OpenAI-compatible “extra content” is produced reliably when available.
* **Tests**
  * Added regression coverage for streamed tool-call index and ID stability across both sequential and parallel chunk scenarios, plus an end-to-end streaming check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->