### PR TITLE
fix(ollama): assign distinct indices to streamed tool calls

### DIFF
--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -172,8 +172,22 @@ class OllamaProvider(AnyLLM):
             stream=True,
             options=kwargs,
         )
+        # Ollama streams each tool call in its own chunk, and the chunk
+        # converter (_create_openai_chunk_from_ollama_chunk) stamps every
+        # tool-call delta with index=0. A consumer that accumulates streaming
+        # deltas by index then concatenates the arguments of distinct tool calls
+        # into a single, invalid JSON string. Assign a stream-global,
+        # monotonically increasing index so each tool call stays in its own slot.
+        tool_call_index = 0
         async for chunk in response:
-            yield self._convert_completion_chunk_response(chunk)
+            converted = self._convert_completion_chunk_response(chunk)
+            for choice in converted.choices:
+                delta = choice.delta
+                if delta is not None and delta.tool_calls:
+                    for tool_call in delta.tool_calls:
+                        tool_call.index = tool_call_index
+                        tool_call_index += 1
+            yield converted
 
     @override
     async def _acompletion(

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -129,6 +129,69 @@ async def test_streaming_completion_passes_tools_top_level() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_assigns_distinct_tool_call_indices() -> None:
+    """Ollama streams each tool call in its own chunk and the chunk converter
+    stamps every tool-call delta with index=0. When a model emits several tool
+    calls, a consumer that accumulates streaming deltas by index concatenates
+    the arguments of distinct calls into one invalid JSON string. The provider
+    must reassign a stream-global, monotonically increasing index so each tool
+    call stays in its own slot."""
+
+    def _make_chunk(name: str, arguments: dict[str, str]) -> Mock:
+        func = Mock()
+        func.name = name
+        func.arguments = arguments
+        tool_call = Mock()
+        tool_call.function = func
+
+        message = Mock(spec=OllamaMessage)
+        message.content = None
+        message.role = "assistant"
+        message.thinking = None
+        message.tool_calls = [tool_call]
+
+        chunk = Mock(spec=OllamaChatResponse)
+        chunk.message = message
+        chunk.created_at = None
+        chunk.model = "llama3.1"
+        chunk.done_reason = None
+        chunk.prompt_eval_count = None
+        chunk.eval_count = None
+        return chunk
+
+    chunks = [
+        _make_chunk("find", {"query": "diode connected nmos"}),
+        _make_chunk("find", {"query": "5t nmos ota"}),
+        _make_chunk("find", {"query": "source follower"}),
+    ]
+
+    async def chunk_iter() -> AsyncIterator[Mock]:
+        for chunk in chunks:
+            yield chunk
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=chunk_iter())
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="llama3.1",
+                messages=[{"role": "user", "content": "find three fixtures"}],
+                stream=True,
+            ),
+        )
+
+        indices = []
+        async for chunk in result:  # type: ignore[union-attr]
+            for choice in chunk.choices:
+                for tool_call in choice.delta.tool_calls or []:
+                    indices.append(tool_call.index)
+
+    assert indices == [0, 1, 2], f"expected distinct per-call indices, got {indices}"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_think"),
     [


### PR DESCRIPTION
The Ollama streaming chunk converter stamps every tool-call delta with index=0 (_create_openai_chunk_from_ollama_chunk). Ollama streams each tool call in its own chunk, so when a model emits several tool calls in one turn they all arrive at index 0. A consumer that accumulates streaming deltas by index (the OpenAI streaming convention) then concatenates the arguments of distinct calls into a single, invalid JSON string — e.g. `{"query":"a"}{"query":"b"}` — which fails json.loads with "Extra data".

Reassign a stream-global, monotonically increasing index in _stream_completion_async so each tool call keeps its own slot.

Adds a regression test asserting three streamed tool calls receive distinct indices [0, 1, 2].

## Description
<!-- What does this PR do? -->


## PR Type
<!-- Delete the types that don't apply -->

- 🆕 New Feature
- 🐛 Bug Fix

## Relevant issues
<!-- e.g. "Fixes #123" -->
None that I am aware of.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [ x] I understand the code I am submitting.
- [ x] I have added unit tests that prove my fix/feature works
- [ x] I have run this code locally and verified it fixes the issue.
- [ x] New and existing tests pass locally
- [ x] Documentation was updated where necessary
- [ x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x ] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: This was discovered with a new mcp I am developping, that didn't work when multiple tools were called together.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming tool-call handling so each tool call now receives a unique, increasing index across the full response.
  * This prevents separate tool-call updates from being merged incorrectly during streaming, reducing the chance of malformed JSON in tool arguments.
  * Added test coverage to verify streamed tool calls are assigned distinct indices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->