### PR TITLE
fix(openai): handle None created field in streaming responses

### DIFF
--- a/src/any_llm/providers/openai/base.py
+++ b/src/any_llm/providers/openai/base.py
@@ -3,6 +3,7 @@ import json
 from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
 from pathlib import Path
+import time
 from typing import Any, Literal, cast
 
 from openai import AsyncOpenAI
@@ -128,7 +129,7 @@ class BaseOpenAIProvider(AnyLLM):
                     "API returned an unexpected created type: %s. Setting to int.",
                     type(response.created),
                 )
-                response.created = int(response.created)
+                response.created = int(response.created) if response.created is not None else int(time.time())
             normalized_chunk = _normalize_openai_dict_response(response.model_dump())
             # Some APIs (i.e. Perplexity) return `chat.completion` without the chunk
             # We can hardcode it as openai expects a literal

--- a/src/any_llm/providers/openai/utils.py
+++ b/src/any_llm/providers/openai/utils.py
@@ -1,5 +1,6 @@
 """OpenAI Provider Utilities."""
 
+import time
 from typing import Any
 
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
@@ -78,7 +79,7 @@ def _convert_chat_completion(response: OpenAIChatCompletion) -> ChatCompletion:
             "API returned an unexpected created type: %s. Setting to int.",
             type(response.created),
         )
-        response.created = int(response.created)
+        response.created = int(response.created) if response.created is not None else int(time.time())
     normalized = _normalize_openai_dict_response(response.model_dump())
     return ChatCompletion.model_validate(normalized)
 


### PR DESCRIPTION
## Problem

Some OpenAI-compatible APIs return `"created": null` in streaming chunks instead of an integer timestamp. When this happens, `int(response.created)` at two locations crashes with:

```
TypeError: int() argument must be a string, a bytes-like object or a real number, not NoneType
```

The existing comments mention Sambanova returning float — the non-int case was anticipated, but `None` was missed.

## Fix

Guard `int(response.created)` with a `None` check. When `created` is `None`, fall back to `int(time.time())`.

Other providers already handle this pattern:
- `together/utils.py`: `created or int(datetime.now().timestamp())`
- `sagemaker/utils.py`: `response.get("created", int(time()))`
- `lmstudio/utils.py`: `created=int(time.time())`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing response timestamps, falling back to the current time when needed.
  * Made chat and completion response parsing more resilient to incomplete timestamp data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->