### PR TITLE
feat(ollama): translate OpenAI-style response_format and pass format in streaming completions.

### DIFF
--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -137,7 +137,11 @@ class OllamaProvider(AnyLLM):
         if isinstance(response_format, dict):
             response_type = response_format.get("type")
             if response_type == "json_schema":
-                schema: dict[str, Any] = response_format["json_schema"]["schema"]
+                json_schema = response_format.get("json_schema")
+                if json_schema is None or "schema" not in json_schema:
+                    msg = "json_schema response_format must include 'json_schema.schema'"
+                    raise ValueError(msg)
+                schema: dict[str, Any] = json_schema["schema"]
                 return schema
             if response_type == "json_object":
                 return "json"

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import override
 
@@ -119,6 +119,33 @@ class OllamaProvider(AnyLLM):
         """Convert Ollama list models response to OpenAI format."""
         return _convert_models_list(response)
 
+    @staticmethod
+    def _convert_response_format(
+        response_format: dict[str, Any] | type | None,
+    ) -> Literal["json"] | dict[str, Any] | None:
+        """Convert a `response_format` into Ollama's `format` argument.
+
+        Ollama's `format` accepts either the string "json" (unconstrained JSON mode) or a raw
+        JSON schema dict (https://docs.ollama.com/capabilities/structured-outputs). OpenAI-style
+        dicts (`json_object`, `json_schema`, `text`) are translated accordingly; any other dict
+        is assumed to already be a raw schema and passed through unchanged.
+        """
+        if response_format is None:
+            return None
+        if is_structured_output_type(response_format):
+            return get_json_schema(response_format)
+        if isinstance(response_format, dict):
+            response_type = response_format.get("type")
+            if response_type == "json_schema":
+                schema: dict[str, Any] = response_format["json_schema"]["schema"]
+                return schema
+            if response_type == "json_object":
+                return "json"
+            if response_type == "text":
+                return None
+            return response_format
+        return None
+
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self.client = AsyncClient(host=api_base, **kwargs)
@@ -160,7 +187,7 @@ class OllamaProvider(AnyLLM):
         self,
         model: str,
         messages: list[dict[str, Any]],
-        output_format: dict[str, Any] | None = None,
+        output_format: Literal["json"] | dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         """Handle streaming completion - extracted to avoid generator issues."""
@@ -199,12 +226,7 @@ class OllamaProvider(AnyLLM):
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         """Create a chat completion using Ollama."""
 
-        output_format: dict[str, Any] | None = None
-        if params.response_format is not None:
-            if is_structured_output_type(params.response_format):
-                output_format = get_json_schema(params.response_format)
-            elif isinstance(params.response_format, dict):
-                output_format = params.response_format
+        output_format = self._convert_response_format(params.response_format)
 
         # (https://www.reddit.com/r/ollama/comments/1ked8x2/feeding_tool_output_back_to_llm/)
         cleaned_messages = []

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -160,6 +160,7 @@ class OllamaProvider(AnyLLM):
         self,
         model: str,
         messages: list[dict[str, Any]],
+        output_format: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         """Handle streaming completion - extracted to avoid generator issues."""
@@ -169,6 +170,7 @@ class OllamaProvider(AnyLLM):
             messages=messages,
             tools=kwargs.pop("tools", None),
             think=kwargs.pop("think", None),
+            format=output_format,
             stream=True,
             options=kwargs,
         )
@@ -233,7 +235,9 @@ class OllamaProvider(AnyLLM):
         completion_kwargs = self._convert_completion_params(params, **kwargs)
 
         if params.stream:
-            return self._stream_completion_async(params.model_id, cleaned_messages, **completion_kwargs)
+            return self._stream_completion_async(
+                params.model_id, cleaned_messages, output_format=output_format, **completion_kwargs
+            )
 
         response: OllamaChatResponse = await self.client.chat(
             model=params.model_id,

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -154,6 +155,19 @@ async def test_completion_with_raw_schema_response_format() -> None:
 
             call_kwargs = provider.client.chat.call_args[1]
             assert call_kwargs["format"] == response_format
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        {"type": "json_schema"},
+        {"type": "json_schema", "json_schema": {"name": "TestOutput"}},
+    ],
+)
+def test_convert_response_format_malformed_json_schema_raises(response_format: dict[str, Any]) -> None:
+    """Test that a json_schema response_format missing the inner schema raises a descriptive error."""
+    with pytest.raises(ValueError, match=r"must include 'json_schema\.schema'"):
+        OllamaProvider._convert_response_format(response_format)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -68,9 +68,75 @@ async def test_completion_with_dataclass_response_format() -> None:
 
 
 @pytest.mark.asyncio
-async def test_completion_with_dict_response_format() -> None:
-    """Test that dict response_format is passed through unchanged."""
-    response_format = {"type": "json_object"}
+async def test_completion_with_json_object_response_format() -> None:
+    """Test that OpenAI-style {"type": "json_object"} is translated to Ollama's "json" mode."""
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=Mock())
+
+        with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="llama3.1",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+            call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["format"] == "json"
+
+
+@pytest.mark.asyncio
+async def test_completion_with_json_schema_response_format() -> None:
+    """Test that OpenAI-style {"type": "json_schema", ...} has its inner schema extracted."""
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+    response_format = {"type": "json_schema", "json_schema": {"name": "TestOutput", "schema": schema}}
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=Mock())
+
+        with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="llama3.1",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    response_format=response_format,
+                ),
+            )
+
+            call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["format"] == schema
+
+
+@pytest.mark.asyncio
+async def test_completion_with_text_response_format() -> None:
+    """Test that OpenAI-style {"type": "text"} disables Ollama's format constraint."""
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=Mock())
+
+        with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="llama3.1",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    response_format={"type": "text"},
+                ),
+            )
+
+            call_kwargs = provider.client.chat.call_args[1]
+            assert call_kwargs["format"] is None
+
+
+@pytest.mark.asyncio
+async def test_completion_with_raw_schema_response_format() -> None:
+    """Test that a raw JSON schema dict (Ollama's native style) is passed through unchanged."""
+    response_format = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
 
     with patch.object(OllamaProvider, "_init_client"):
         provider = OllamaProvider(api_key=None)
@@ -123,6 +189,34 @@ async def test_streaming_completion_passes_format_top_level() -> None:
         assert isinstance(call_kwargs["format"], dict)
         assert "name" in call_kwargs["format"]["properties"]
         assert "format" not in call_kwargs.get("options", {})
+
+
+@pytest.mark.asyncio
+async def test_streaming_completion_translates_json_object_format() -> None:
+    """Test that OpenAI-style {"type": "json_object"} is translated to "json" when streaming."""
+
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter())
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="llama3.1",
+                messages=[{"role": "user", "content": "Hello"}],
+                response_format={"type": "json_object"},
+                stream=True,
+            ),
+        )
+        async for _ in result:  # type: ignore[union-attr]
+            pass
+
+        call_kwargs = provider.client.chat.call_args[1]
+        assert call_kwargs["format"] == "json"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -91,6 +91,41 @@ async def test_completion_with_dict_response_format() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_completion_passes_format_top_level() -> None:
+    """Test that response_format is converted and passed as a top-level `format` kwarg when streaming."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class TestOutput:
+        name: str
+
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter())
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="llama3.1",
+                messages=[{"role": "user", "content": "Hello"}],
+                response_format=TestOutput,
+                stream=True,
+            ),
+        )
+        async for _ in result:  # type: ignore[union-attr]
+            pass
+
+        call_kwargs = provider.client.chat.call_args[1]
+        assert isinstance(call_kwargs["format"], dict)
+        assert "name" in call_kwargs["format"]["properties"]
+        assert "format" not in call_kwargs.get("options", {})
+
+
+@pytest.mark.asyncio
 async def test_streaming_completion_passes_tools_top_level() -> None:
     """Test that tools are passed as a top-level kwarg to client.chat(), not inside options."""
     tools = [


### PR DESCRIPTION
## Description

Fixes two gaps in how the Ollama provider handles `response_format`:

1. **Streaming dropped `format` entirely.** `_acompletion` computed the output format but only the non-streaming `client.chat()` call used it; the streaming path never passed it, so structured output was silently ignored when `stream=True`. Same class of bug as #1113 (tools not passed during streaming, fixed in #1114). The converted format is now threaded through `_stream_completion_async` and passed as `format=` on the streaming `client.chat()` call.

2. **OpenAI-style `response_format` dicts were passed verbatim.** `{"type": "json_object"}` or `{"type": "json_schema", "json_schema": {...}}` went straight into Ollama's `format`, which interprets them as a literal (invalid) JSON schema. Ollama expects either the string `"json"` or a raw JSON schema dict (https://docs.ollama.com/capabilities/structured-outputs). A new `_convert_response_format` helper now translates them: `json_object` → `"json"`, `json_schema` → the inner schema, `text` → no constraint. Any other dict is passed through unchanged, preserving backward compatibility for callers already passing raw JSON schemas (Ollama's native style). The translation mirrors the existing dispatch in the Gemini provider.

**Verification:**
- Unit tests cover every branch of the translation (json_object, json_schema, text, raw schema passthrough, dataclass) plus the streaming path (format passed top-level, not leaked into `options`).
- Integration tests `test_response_format[ollama]` and `test_response_format_dataclass[ollama]` pass against a local Ollama server (`llama3.2:1b`).
- Verified end-to-end against a real Ollama server: `stream=True` with a Pydantic model returns schema-conformant JSON, `stream=True` with `{"type": "json_object"}` returns valid JSON, and an OpenAI-style `json_schema` dict is constrained to the inner schema.

## PR Type

- 🆕 New Feature
- 🐛 Bug Fix

## Relevant issues

Same class of bug as #1113 (fixed in #1114), this time for `format` instead of `tools`.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Opus 4.8, Claude Fable 5, Sonnet 5
- AI Developer Tool used: Claude Code and vscode + GitHub Copilot
- Any other info you'd like to share: Implementation and tests were drafted , verified and submitted by me (unit + integration tests against a local Ollama server).

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of structured response formats for Ollama chat requests, including JSON object and JSON schema output modes.
* **Bug Fixes**
  * Streaming and non-streaming requests now apply response-format conversion consistently when sending requests to Ollama.
  * Ensured text responses don’t force structured output formatting.
  * Added validation for malformed JSON schema inputs with clear errors.
* **Tests**
  * Added focused unit coverage for both streaming and non-streaming response-format handling, including error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->