### PR TITLE
fix(lmstudio): strip synthetic reasoning marker from structured-output content

### DIFF
--- a/src/any_llm/providers/lmstudio/utils.py
+++ b/src/any_llm/providers/lmstudio/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -64,16 +65,27 @@ def _usage_from_stats(stats: LlmPredictionStats | None) -> CompletionUsage:
     )
 
 
-def _split_reasoning_from_content(content: str) -> tuple[str, str | None]:
-    """Extract reasoning wrapped in <think></think> tags from the content (if present).
+_SYNTHETIC_REASONING_END = re.compile(r"__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_[0-9a-f]+__")
 
-    Any text before the opening tag or after the closing tag is preserved as content,
-    so a model that emits a preface before its reasoning block does not lose output.
+
+def _split_reasoning_from_content(content: str) -> tuple[str, str | None]:
+    """Extract reasoning from the content (if present).
+
+    Handles the two shapes LM Studio surfaces depending on the model:
+    - reasoning wrapped in <think></think> tags, where any text before the opening tag or
+      after the closing tag is preserved as content
+    - a reasoning prefix terminated by a synthetic
+      __LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_<hex>__ marker, emitted by reasoning
+      models when a response_format is requested; the prefix is reasoning and the trailing text
+      (the structured JSON answer) is the content
     """
     if "<think>" in content and "</think>" in content:
         before, after_open = content.split("<think>", 1)
         reasoning, after_close = after_open.split("</think>", 1)
         return before + after_close, reasoning
+    match = _SYNTHETIC_REASONING_END.search(content)
+    if match:
+        return content[match.end() :], content[: match.start()]
     return content, None
 
 

--- a/src/any_llm/providers/lmstudio/utils.py
+++ b/src/any_llm/providers/lmstudio/utils.py
@@ -65,7 +65,7 @@ def _usage_from_stats(stats: LlmPredictionStats | None) -> CompletionUsage:
     )
 
 
-_SYNTHETIC_REASONING_END = re.compile(r"__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_[0-9a-f]+__")
+_SYNTHETIC_REASONING_END = re.compile(r"__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_[0-9a-fA-F]+__")
 
 
 def _split_reasoning_from_content(content: str) -> tuple[str, str | None]:

--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -390,6 +390,19 @@ def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
         ("<think>because</think>final", "final", "because"),
         ("preface <think>because</think> final", "preface  final", "because"),
         ("no tags here", "no tags here", None),
+        # LM Studio's runtime ends an inline reasoning trace with a fixed synthetic marker
+        # when response_format is set (see #1167). The value below is the real marker observed
+        # in CI; the split must work for any hex nonce, so the next case uses a different one.
+        (
+            'Paris is the capital.\n__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_f4e9a8d2c6b14d0c9e5f3a7b8c1d2e6a__{\n  "city_name": "Paris"\n}',
+            '{\n  "city_name": "Paris"\n}',
+            "Paris is the capital.\n",
+        ),
+        (
+            "reasoning...__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_0123456789abcdef__{}",
+            "{}",
+            "reasoning...",
+        ),
     ],
 )
 def test_split_reasoning_from_content(content: str, expected_content: str, expected_reasoning: str | None) -> None:

--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -392,7 +392,8 @@ def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
         ("no tags here", "no tags here", None),
         # LM Studio's runtime ends an inline reasoning trace with a fixed synthetic marker
         # when response_format is set (see #1167). The value below is the real marker observed
-        # in CI; the split must work for any hex nonce, so the next case uses a different one.
+        # in CI; the split must work for any hex nonce, so the next cases use a different
+        # lowercase nonce and an uppercase one.
         (
             'Paris is the capital.\n__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_f4e9a8d2c6b14d0c9e5f3a7b8c1d2e6a__{\n  "city_name": "Paris"\n}',
             '{\n  "city_name": "Paris"\n}',
@@ -400,6 +401,11 @@ def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
         ),
         (
             "reasoning...__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_0123456789abcdef__{}",
+            "{}",
+            "reasoning...",
+        ),
+        (
+            "reasoning...__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_DEADBEEF01234567__{}",
             "{}",
             "reasoning...",
         ),


### PR DESCRIPTION
LM Studio reasoning models return their reasoning trace inline in the response content, delimited from the JSON answer by a synthetic `__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_<hex>__` marker, when a response_format is requested. `_split_reasoning_from_content` only recognized `<think></think>` tags, so the whole string was passed to `parse_json_content`, which failed with `json_invalid`.

Split on the synthetic marker too: route the prefix to reasoning and keep the trailing JSON as content.

## Description

Fixes structured output (`response_format`) for LM Studio reasoning models.

When a reasoning model is asked for structured output, the LM Studio SDK returns the reasoning trace inline in `content`, separated from the JSON answer by a synthetic `__LM_STUDIO_INTERNAL_LSEP_SYNTHETIC_REASONING_END_<hex>__` marker. `_split_reasoning_from_content` only handled `<think></think>` tags, so the full `reasoning + marker + JSON` string reached `parse_json_content` and raised `pydantic ValidationError: Invalid JSON ... json_invalid`. This is what breaks `test_response_format[lmstudio]` and `test_response_format_dataclass[lmstudio]` on `main`.

The fix extends `_split_reasoning_from_content` to also split on the synthetic marker: the prefix becomes `reasoning`, the trailing JSON becomes `content`. It is a pure addition, so when the marker is absent the behavior is unchanged.

Verified against a real model (LM Studio `0.4.19+2`, GGUF runtime `llama.cpp@2.24.0`, `qwen/qwen3-1.7b` GGUF `Q6_K`): on `main` the call fails with the CI error, on this branch it returns `city_name='Paris'`. The `<hex>` marker only appears with the GGUF build (llama.cpp), which is what CI runs; the MLX build routes reasoning through a separate channel and does not reproduce it. A unit test locks the behavior deterministically with the exact byte payload.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1167

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: AI helped diagnose the root cause, write the fix, and add the unit test. I ran and verified it myself against a local LM Studio (GGUF Qwen3-1.7B) before opening the PR.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of LM Studio responses containing synthetic reasoning markers.
  * Correctly separates user-facing content from reasoning, including cases where a trailing JSON payload follows the marker (including empty objects).
  * Preserves surrounding text and formatting when extracting reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->