### PR TITLE
fix(tests): update fireworks integration image model to kimi-k2p6

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def provider_image_model_map(provider_model_map: dict[LLMProvider, str]) -> dict
         LLMProvider.OPENROUTER: "google/gemini-2.5-flash-lite",
         LLMProvider.COHERE: "command-a-vision-07-2025",  # command-a-03-2025 rejects image content
         LLMProvider.OLLAMA: "llava-phi3",  # Fast vision model compatible with OpenAI format
-        LLMProvider.FIREWORKS: "accounts/fireworks/models/kimi-k2p5",
+        LLMProvider.FIREWORKS: "accounts/fireworks/models/kimi-k2p6",
         LLMProvider.BEDROCK: "anthropic.claude-3-haiku-20240307-v1:0",  # Claude 3 Haiku with vision support
         LLMProvider.NEOSANTARA: "gemini-3-flash-preview",  # Vision model compatible with OpenAI format
     }


### PR DESCRIPTION
## Description

`test_completion_with_image[fireworks]` has been failing on `main`. The fireworks image model in `tests/conftest.py` was `accounts/fireworks/models/kimi-k2p5`, which Fireworks retired from serverless. It now returns:

```
openai.NotFoundError: Error code: 404 - Model not found, inaccessible, and/or not deployed
```

This swaps it to `accounts/fireworks/models/kimi-k2p6`, which I confirmed on its Fireworks model page is both serverless-supported and image-input capable. It is the direct successor to K2.5, and the sibling `kimi-k2.6` is already used for the Moonshot provider in conftest.

I also checked the dedicated VL models (`qwen2p5-vl-*`, `qwen3-vl-*`, `gemma-4-31b-it`); they are all listed as "Serverless: Not supported" now, so they were not viable replacements.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: This is a test-config-only change. I have no `FIREWORKS_API_KEY` locally, so I could not run the integration test myself; the `run-integration-tests` label was added so CI verifies it against a real key. Root-caused from the failing Integration Tests run on `main` (Fireworks 404), drafted via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)
