### PR TITLE
fix(deepseek): migrate off deepseek-chat/deepseek-reasoner ahead of 2026-07-24 deprecation

### DIFF
--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -48,10 +48,13 @@ class DeepseekProvider(BaseOpenAIProvider):
             converted_params["max_tokens"] = converted_params.pop("max_completion_tokens")
 
         if params.model_id not in _LEGACY_MODEL_IDS:
+            # ``"auto"`` means "no explicit reasoning requested" (BaseOpenAIProvider._acompletion
+            # normalizes it to this provider's default before we run), so it is treated the same
+            # as ``None``/``"none"`` here -- matching every other provider's converter and keeping
+            # this self-contained even if called directly with ``"auto"``.
+            thinking_disabled = params.reasoning_effort in (None, "none", "auto")
             extra_body = converted_params.setdefault("extra_body", {})
-            extra_body.setdefault(
-                "thinking", {"type": "disabled" if params.reasoning_effort in (None, "none") else "enabled"}
-            )
+            extra_body.setdefault("thinking", {"type": "disabled" if thinking_disabled else "enabled"})
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -3,9 +3,20 @@ from typing import Any
 
 from typing_extensions import override
 
-from any_llm.providers.deepseek.utils import _inject_cached_tokens, _inject_cached_tokens_chunk, _preprocess_messages
+from any_llm.providers.deepseek.utils import (
+    _inject_cached_tokens,
+    _inject_cached_tokens_chunk,
+    _inject_reasoning_extra_content,
+    _preprocess_messages,
+)
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+
+# The two legacy API model names being discontinued 2026-07-24 in favor of deepseek-v4-flash /
+# deepseek-v4-pro. See https://api-docs.deepseek.com/updates/#date-2026-04-24. They hard-code
+# their own thinking behavior (non-thinking / thinking respectively) and don't need, and may not
+# accept, the `thinking` request toggle added below for the new model family.
+_LEGACY_MODEL_IDS = frozenset({"deepseek-chat", "deepseek-reasoner"})
 
 
 class DeepseekProvider(BaseOpenAIProvider):
@@ -23,17 +34,32 @@ class DeepseekProvider(BaseOpenAIProvider):
     @staticmethod
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
-        """DeepSeek only accepts ``max_tokens``, not ``max_completion_tokens``."""
+        """DeepSeek only accepts ``max_tokens``, not ``max_completion_tokens``.
+
+        Also maps ``reasoning_effort`` to DeepSeek's ``thinking`` toggle for the V4 model
+        family. DeepSeek's V4 models default to thinking mode ENABLED when the toggle is
+        omitted from the request (see https://api-docs.deepseek.com/guides/thinking_mode), so
+        any_llm explicitly defaults it to disabled here -- matching the legacy ``deepseek-chat``
+        behavior -- unless the caller opts in via ``reasoning_effort``. A caller-supplied
+        ``extra_body`` override is respected and not clobbered.
+        """
         converted_params = BaseOpenAIProvider._convert_completion_params(params, **kwargs)
         if "max_completion_tokens" in converted_params:
             converted_params["max_tokens"] = converted_params.pop("max_completion_tokens")
+
+        if params.model_id not in _LEGACY_MODEL_IDS:
+            extra_body = converted_params.setdefault("extra_body", {})
+            extra_body.setdefault(
+                "thinking", {"type": "disabled" if params.reasoning_effort in (None, "none") else "enabled"}
+            )
         return converted_params
 
     @staticmethod
     @override
     def _convert_completion_response(response: Any) -> ChatCompletion:
         result = BaseOpenAIProvider._convert_completion_response(response)
-        return _inject_cached_tokens(result)
+        result = _inject_cached_tokens(result)
+        return _inject_reasoning_extra_content(result)
 
     @staticmethod
     @override

--- a/src/any_llm/providers/deepseek/utils.py
+++ b/src/any_llm/providers/deepseek/utils.py
@@ -62,7 +62,8 @@ def _reinject_reasoning_content(messages: list[dict[str, Any]]) -> list[dict[str
             extra_content = message.get("extra_content")
             deepseek_extra = extra_content.get("deepseek") if isinstance(extra_content, dict) else None
             if isinstance(deepseek_extra, dict) and isinstance(deepseek_extra.get("reasoning_content"), str):
-                message = {**message, "reasoning_content": deepseek_extra["reasoning_content"]}
+                result.append({**message, "reasoning_content": deepseek_extra["reasoning_content"]})
+                continue
         result.append(message)
     return result
 

--- a/src/any_llm/providers/deepseek/utils.py
+++ b/src/any_llm/providers/deepseek/utils.py
@@ -44,6 +44,29 @@ Return the JSON object only, no other text, do not wrap it in ```json or ```.
     return modified_messages
 
 
+def _reinject_reasoning_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Restore ``reasoning_content`` on replayed assistant tool-call turns.
+
+    DeepSeek's thinking mode requires ``reasoning_content`` to be passed back verbatim on any
+    assistant turn that performed a tool call, or the API returns a 400. any_llm's shared
+    message serialization (``AnyLLM.acompletion``) strips the normalized ``reasoning`` field
+    before replaying a ``ChatCompletionMessage`` back as a request message, so we restore it
+    here from the ``extra_content["deepseek"]`` side-channel populated by
+    ``_inject_reasoning_extra_content`` when the response was first received.
+
+    Reference: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+    """
+    result = []
+    for message in messages:
+        if message.get("role") == "assistant" and message.get("tool_calls") is not None:
+            extra_content = message.get("extra_content")
+            deepseek_extra = extra_content.get("deepseek") if isinstance(extra_content, dict) else None
+            if isinstance(deepseek_extra, dict) and isinstance(deepseek_extra.get("reasoning_content"), str):
+                message = {**message, "reasoning_content": deepseek_extra["reasoning_content"]}
+        result.append(message)
+    return result
+
+
 def _preprocess_messages(params: CompletionParams) -> CompletionParams:
     """Preprocess messages"""
     if params.response_format:
@@ -51,6 +74,8 @@ def _preprocess_messages(params: CompletionParams) -> CompletionParams:
             modified_messages = _convert_structured_type_to_deepseek_json(params.response_format, params.messages)
             params.response_format = {"type": "json_object"}
             params.messages = modified_messages
+
+    params.messages = _reinject_reasoning_content(params.messages)
 
     return params
 
@@ -79,3 +104,15 @@ def _inject_cached_tokens_chunk(chunk: ChatCompletionChunk) -> ChatCompletionChu
     if cached:
         chunk.usage.prompt_tokens_details = PromptTokensDetails(cached_tokens=cached)
     return chunk
+
+
+def _inject_reasoning_extra_content(completion: ChatCompletion) -> ChatCompletion:
+    """Stash reasoning text into ``extra_content`` so it survives any_llm's outgoing message dump.
+
+    See ``_reinject_reasoning_content`` for why this round-trip is necessary.
+    """
+    for choice in completion.choices:
+        reasoning = choice.message.reasoning
+        if reasoning is not None:
+            choice.message.extra_content = {"deepseek": {"reasoning_content": reasoning.content}}
+    return completion

--- a/src/any_llm/providers/deepseek/utils.py
+++ b/src/any_llm/providers/deepseek/utils.py
@@ -55,16 +55,21 @@ def _reinject_reasoning_content(messages: list[dict[str, Any]]) -> list[dict[str
     ``_inject_reasoning_extra_content`` when the response was first received.
 
     Reference: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+
+    ``extra_content`` is an any_llm-internal side-channel and is stripped from every replayed
+    message here so it is never forwarded to DeepSeek's API: the OpenAI SDK passes unknown
+    message keys through verbatim, and only ``reasoning_content`` belongs on the wire.
     """
     result = []
     for message in messages:
+        extra_content = message.get("extra_content")
+        cleaned = {k: v for k, v in message.items() if k != "extra_content"} if extra_content is not None else message
         if message.get("role") == "assistant" and message.get("tool_calls") is not None:
-            extra_content = message.get("extra_content")
             deepseek_extra = extra_content.get("deepseek") if isinstance(extra_content, dict) else None
             if isinstance(deepseek_extra, dict) and isinstance(deepseek_extra.get("reasoning_content"), str):
-                result.append({**message, "reasoning_content": deepseek_extra["reasoning_content"]})
+                result.append({**cleaned, "reasoning_content": deepseek_extra["reasoning_content"]})
                 continue
-        result.append(message)
+        result.append(cleaned)
     return result
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,10 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.AZUREOPENAI: "gpt-4.1-nano",
         LLMProvider.CEREBRAS: "gpt-oss-120b",
         LLMProvider.COHERE: "command-a-reasoning-08-2025",
-        LLMProvider.DEEPSEEK: "deepseek-reasoner",
+        # deepseek-reasoner is discontinued 2026-07-24 in favor of deepseek-v4-flash, where
+        # thinking mode is now a request-level toggle (see DeepseekProvider._convert_completion_params)
+        # rather than a dedicated model name.
+        LLMProvider.DEEPSEEK: "deepseek-v4-flash",
         # kimi-k2-thinking and kimi-thinking-preview are discontinued; kimi-k2.6 is the
         # current reasoning-capable model (thinking mode, native multimodal).
         LLMProvider.MOONSHOT: "kimi-k2.6",
@@ -81,7 +84,10 @@ def provider_model_map() -> dict[LLMProvider, str]:
     return {
         LLMProvider.MISTRAL: "mistral-small-latest",
         LLMProvider.ANTHROPIC: "claude-haiku-4-5",
-        LLMProvider.DEEPSEEK: "deepseek-chat",
+        # deepseek-chat is discontinued 2026-07-24 in favor of deepseek-v4-flash; thinking mode
+        # defaults to disabled for it unless reasoning_effort is set (see
+        # DeepseekProvider._convert_completion_params), matching the old deepseek-chat behavior.
+        LLMProvider.DEEPSEEK: "deepseek-v4-flash",
         LLMProvider.OPENAI: "gpt-5-nano",
         # otari routes provider:model; anthropic is the only upstream the test account serves reliably.
         LLMProvider.OTARI: "anthropic:claude-haiku-4-5",

--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -46,6 +46,9 @@ async def test_completion_reasoning(
                 LLMProvider.SAMBANOVA,
                 LLMProvider.TOGETHER,
                 LLMProvider.PORTKEY,
+                # DeepSeek's V4 models default thinking mode to disabled for "auto" (matching the
+                # old deepseek-chat behavior); an explicit value is needed to enable it.
+                LLMProvider.DEEPSEEK,
             )
             else "auto",
             max_tokens=4096
@@ -106,6 +109,9 @@ async def test_completion_reasoning_streaming(
                 LLMProvider.SAMBANOVA,
                 LLMProvider.TOGETHER,
                 LLMProvider.PORTKEY,
+                # DeepSeek's V4 models default thinking mode to disabled for "auto" (matching the
+                # old deepseek-chat behavior); an explicit value is needed to enable it.
+                LLMProvider.DEEPSEEK,
             )
             else "auto",
             max_tokens=4999

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -381,8 +381,11 @@ def test_reinject_reasoning_content_on_tool_call_message() -> None:
     result = _reinject_reasoning_content(messages)
 
     assert result[1]["reasoning_content"] == "I should call get_weather."
+    # The any_llm-internal extra_content must not be forwarded to DeepSeek's API.
+    assert "extra_content" not in result[1]
     # Original message dict must not be mutated in place.
     assert "reasoning_content" not in messages[1]
+    assert "extra_content" in messages[1]
 
 
 def test_reinject_reasoning_content_skips_non_tool_call_message() -> None:
@@ -399,6 +402,8 @@ def test_reinject_reasoning_content_skips_non_tool_call_message() -> None:
     result = _reinject_reasoning_content(messages)
 
     assert "reasoning_content" not in result[1]
+    # extra_content is any_llm-internal and is stripped even when reasoning is not reinjected.
+    assert "extra_content" not in result[1]
 
 
 def test_reinject_reasoning_content_handles_missing_extra_content() -> None:

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -273,6 +273,17 @@ def test_deepseek_thinking_disabled_for_none_reasoning_effort_value() -> None:
     assert result["extra_body"]["thinking"] == {"type": "disabled"}
 
 
+def test_deepseek_thinking_disabled_for_auto_reasoning_effort_value() -> None:
+    """reasoning_effort="auto" (the default) is treated as "no reasoning requested"."""
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="auto",
+    )
+    result = DeepseekProvider._convert_completion_params(params)
+    assert result["extra_body"]["thinking"] == {"type": "disabled"}
+
+
 def test_deepseek_thinking_enabled_when_reasoning_effort_set() -> None:
     """An explicit reasoning_effort should enable thinking mode and be passed through."""
     params = CompletionParams(

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Any
 
 import pytest
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
@@ -6,7 +7,7 @@ from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenA
 from pydantic import BaseModel
 
 from any_llm.providers.deepseek.deepseek import DeepseekProvider
-from any_llm.providers.deepseek.utils import _preprocess_messages
+from any_llm.providers.deepseek.utils import _preprocess_messages, _reinject_reasoning_content
 from any_llm.types.completion import CompletionParams
 
 
@@ -248,3 +249,170 @@ def test_deepseek_no_max_tokens_when_neither_set() -> None:
     result = DeepseekProvider._convert_completion_params(params)
     assert "max_tokens" not in result
     assert "max_completion_tokens" not in result
+
+
+def test_deepseek_thinking_disabled_by_default_for_v4_model() -> None:
+    """V4 model ids without reasoning_effort should default to thinking disabled."""
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort=None,
+    )
+    result = DeepseekProvider._convert_completion_params(params)
+    assert result["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_deepseek_thinking_disabled_for_none_reasoning_effort_value() -> None:
+    """reasoning_effort="none" is also treated as "no reasoning requested"."""
+    params = CompletionParams(
+        model_id="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="none",
+    )
+    result = DeepseekProvider._convert_completion_params(params)
+    assert result["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_deepseek_thinking_enabled_when_reasoning_effort_set() -> None:
+    """An explicit reasoning_effort should enable thinking mode and be passed through."""
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="high",
+    )
+    result = DeepseekProvider._convert_completion_params(params)
+    assert result["extra_body"]["thinking"] == {"type": "enabled"}
+    assert result["reasoning_effort"] == "high"
+
+
+def test_deepseek_thinking_untouched_for_legacy_model_ids() -> None:
+    """Legacy deepseek-chat/deepseek-reasoner ids must not get the thinking toggle injected."""
+    for model_id in ("deepseek-chat", "deepseek-reasoner"):
+        params = CompletionParams(
+            model_id=model_id,
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="high",
+        )
+        result = DeepseekProvider._convert_completion_params(params)
+        assert "extra_body" not in result
+
+
+def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
+    """A caller-supplied extra_body/thinking value should not be clobbered by the default."""
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort=None,
+    )
+    result = DeepseekProvider._convert_completion_params(params, extra_body={"thinking": {"type": "enabled"}})
+    assert result["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_convert_completion_response_stashes_reasoning_into_extra_content() -> None:
+    """reasoning_content on the raw response should be mirrored into message.extra_content."""
+    response = OpenAIChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "deepseek-v4-flash",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello!",
+                        "reasoning_content": "Thinking about hello...",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        }
+    )
+
+    result = DeepseekProvider._convert_completion_response(response)
+
+    message = result.choices[0].message
+    assert message.reasoning is not None
+    assert message.reasoning.content == "Thinking about hello..."
+    assert message.extra_content == {"deepseek": {"reasoning_content": "Thinking about hello..."}}
+
+
+def test_convert_completion_response_no_extra_content_without_reasoning() -> None:
+    """No reasoning present → extra_content should not be populated."""
+    response = OpenAIChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "deepseek-v4-flash",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello!"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        }
+    )
+
+    result = DeepseekProvider._convert_completion_response(response)
+
+    assert result.choices[0].message.extra_content is None
+
+
+def test_reinject_reasoning_content_on_tool_call_message() -> None:
+    """A replayed assistant message with tool_calls should get reasoning_content restored."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+            ],
+            "extra_content": {"deepseek": {"reasoning_content": "I should call get_weather."}},
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "Sunny"},
+    ]
+
+    result = _reinject_reasoning_content(messages)
+
+    assert result[1]["reasoning_content"] == "I should call get_weather."
+    # Original message dict must not be mutated in place.
+    assert "reasoning_content" not in messages[1]
+
+
+def test_reinject_reasoning_content_skips_non_tool_call_message() -> None:
+    """Assistant messages without tool_calls should be left untouched."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "extra_content": {"deepseek": {"reasoning_content": "greeting"}},
+        },
+    ]
+
+    result = _reinject_reasoning_content(messages)
+
+    assert "reasoning_content" not in result[1]
+
+
+def test_reinject_reasoning_content_handles_missing_extra_content() -> None:
+    """A tool-call message with no extra_content should pass through unchanged."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    result = _reinject_reasoning_content(messages)
+
+    assert "reasoning_content" not in result[0]


### PR DESCRIPTION
## Description

DeepSeek is discontinuing the legacy `deepseek-chat`/`deepseek-reasoner` model names on **2026-07-24** in favor of `deepseek-v4-flash`/`deepseek-v4-pro` (source: https://api-docs.deepseek.com/updates/#date-2026-04-24). Under the new naming, thinking mode becomes a **request-level toggle** (`extra_body.thinking`) instead of being baked into the model name, and that toggle **defaults to enabled** when omitted.

A naive model-id rename in the test fixtures would have silently changed default behavior for every DeepSeek call (extra latency/cost from thinking mode turning on everywhere `provider_model_map` is used), and would have exposed a real gap: DeepSeek's docs state that tool-call turns must replay `reasoning_content` verbatim or the API returns a 400, but any-llm's shared message serialization (`AnyLLM.acompletion`) strips the normalized `reasoning` field before replay.

Changes:
- `DeepseekProvider._convert_completion_params` now maps `reasoning_effort` to DeepSeek's `thinking` toggle, defaulting to **disabled** (matching legacy `deepseek-chat` behavior) unless the caller opts in via `reasoning_effort`. Legacy model ids (`deepseek-chat`/`deepseek-reasoner`) are left untouched since they hard-code their own behavior.
- Reasoning content is now stashed into `message.extra_content["deepseek"]` on the way in and restored onto replayed assistant tool-call messages on the way out, mirroring the existing Anthropic extended-thinking round-trip pattern (`extra_content`), so tool-calling + thinking mode doesn't 400.
- `tests/conftest.py`: `provider_model_map`/`provider_reasoning_model_map` DeepSeek entries updated to `deepseek-v4-flash`.
- `tests/integration/test_reasoning.py`: added DeepSeek to the explicit `reasoning_effort` override list (its `"auto"` now resolves to thinking-disabled by design, same reason Anthropic/Gemini/etc. are already there).
- New unit tests for the thinking-toggle default/override logic and the `reasoning_content` round-trip.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1172

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 4.5 (anthropic/claude-sonnet-5)
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: I don't have a `DEEPSEEK_API_KEY` available in this environment, so I could not run the live integration tests (`test_reasoning.py`, `test_agent_loop.py`, etc.) against the real DeepSeek API. Unit tests cover the new logic with mocked/constructed data and all pass, along with `pre-commit run --all-files` (ruff + mypy) on the changed files. Please run the `run-integration-tests` label on this PR (or run locally with a real key) to validate against DeepSeek's live API before merging, per the repo's contribution guidelines.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4 “thinking mode” request toggle driven by `reasoning_effort`, defaulting to disabled when unset/`none`/`auto`.
  * Preserve DeepSeek reasoning content end-to-end, including for tool-call turns during replay.
* **Bug Fixes**
  * Restores reasoning content when messages are transformed, and avoids injecting “thinking” for legacy model IDs or when an explicit `extra_body` is provided.
* **Tests**
  * Expanded unit and integration coverage for toggle behaviour, legacy handling, and reasoning-content reinjection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->