### PR TITLE
fix: allow streaming structured output where supported

### DIFF
--- a/src/any_llm/providers/cerebras/cerebras.py
+++ b/src/any_llm/providers/cerebras/cerebras.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, cast
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
-from any_llm.exceptions import UnsupportedParameterError
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
@@ -104,10 +103,6 @@ class CerebrasProvider(AnyLLM):
         messages: list[dict[str, Any]],
         **kwargs: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
-        if kwargs.get("response_format", None) is not None:
-            msg = "stream and response_format"
-            raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
-
         cerebras_stream = await self.client.chat.completions.create(
             model=model,
             messages=messages,

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -197,9 +197,6 @@ class CohereProvider(AnyLLM):
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
         if params.response_format is not None:
             kwargs["response_format"] = self._preprocess_response_format(params.response_format)
-        if params.stream and params.response_format is not None:
-            msg = "stream and response_format"
-            raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
         if params.parallel_tool_calls is not None:
             msg = "parallel_tool_calls"
             raise UnsupportedParameterError(msg, self.PROVIDER_NAME)

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -119,6 +119,8 @@ class GroqProvider(AnyLLM):
     async def _stream_async_completion(
         self, params: CompletionParams, **kwargs: Any
     ) -> AsyncIterator[ChatCompletionChunk]:
+        # Groq does not currently support streaming structured outputs.
+        # See https://console.groq.com/docs/structured-outputs
         if params.stream and params.response_format:
             msg = "stream and response_format"
             raise UnsupportedParameterError(msg, self.PROVIDER_NAME)

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -299,10 +299,7 @@ class OtariProvider(BaseOpenAIProvider):
         response_format = params.response_format
         wants_structured = is_structured_output_type(response_format)
         completion_kwargs = self._convert_completion_params(params, **kwargs)
-        if wants_structured:
-            if params.stream:
-                msg = "stream is not supported for response_format"
-                raise ValueError(msg)
+        if wants_structured and not params.stream:
             completion_kwargs.pop("stream", None)
 
         response = await self.otari_client.completion(

--- a/tests/unit/providers/test_cerebras_provider.py
+++ b/tests/unit/providers/test_cerebras_provider.py
@@ -1,29 +1,44 @@
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.cerebras.cerebras import CerebrasProvider
 from any_llm.providers.cerebras.utils import _convert_response, _create_openai_chunk_from_cerebras_chunk
 from any_llm.types.completion import CompletionParams
 
 
 @pytest.mark.asyncio
-async def test_stream_with_response_format_raises() -> None:
-    api_key = "test-api-key"
-    model = "model-id"
-    messages = [{"role": "user", "content": "Hello"}]
+async def test_stream_with_response_format_passes_to_completion_create() -> None:
+    response_format = {"type": "json_object"}
 
-    provider = CerebrasProvider(api_key=api_key)
+    async def _stream() -> Any:
+        if False:
+            yield None
 
-    chunks = provider._stream_completion_async(
-        model=model,
-        messages=messages,
-        response_format={"type": "json_object"},
+    with patch("any_llm.providers.cerebras.cerebras.cerebras") as mock_cerebras:
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_stream())
+        mock_cerebras.AsyncCerebras.return_value = mock_client
+        provider = CerebrasProvider(api_key="test-api-key")
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="model-id",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+                response_format=response_format,
+            )
+        )
+        collected = [chunk async for chunk in result]  # type: ignore[union-attr]
+
+    assert collected == []
+    mock_client.chat.completions.create.assert_awaited_once_with(
+        model="model-id",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+        response_format=response_format,
     )
-    with pytest.raises(UnsupportedParameterError):
-        async for _ in chunks:
-            pass
 
 
 def test_convert_response_extracts_reasoning() -> None:

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -41,18 +41,31 @@ def test_preprocess_response_format() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_and_response_format_combination_raises() -> None:
+async def test_stream_with_response_format_passes_to_chat_stream() -> None:
+    response_format = {"type": "json_object"}
     provider = _mk_provider()
 
-    with pytest.raises(UnsupportedParameterError):
-        await provider._acompletion(
-            CompletionParams(
-                model_id="model-id",
-                messages=[{"role": "user", "content": "Hello"}],
-                stream=True,
-                response_format={"type": "json_object"},
-            )
+    async def _stream() -> Any:
+        if False:
+            yield None
+
+    provider.client.chat_stream = Mock(return_value=_stream())
+    result = await provider._acompletion(
+        CompletionParams(
+            model_id="model-id",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+            response_format=response_format,
         )
+    )
+    collected = [chunk async for chunk in result]
+
+    assert collected == []
+    provider.client.chat_stream.assert_called_once_with(
+        model="model-id",
+        messages=[{"role": "user", "content": "Hello"}],
+        response_format=response_format,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -267,13 +267,26 @@ async def test_otari_acompletion_returns_parsed_completion_for_structured_output
 
 
 @pytest.mark.asyncio
-async def test_otari_acompletion_rejects_stream_with_response_format() -> None:
+async def test_otari_acompletion_streams_with_response_format() -> None:
     from pydantic import BaseModel
 
     class Schema(BaseModel):
         city: str
 
-    provider = _build_provider(_mock_otari_client())
+    chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "anthropic:claude-haiku-4-5",
+        "choices": [{"index": 0, "delta": {"content": '{"city":'}, "finish_reason": None}],
+    }
+
+    async def _stream() -> Any:
+        yield chunk
+
+    mocked_client = _mock_otari_client()
+    mocked_client.completion = AsyncMock(return_value=_stream())
+    provider = _build_provider(mocked_client)
     params = CompletionParams(
         model_id="anthropic:claude-haiku-4-5",
         messages=[{"role": "user", "content": "hi"}],
@@ -281,8 +294,14 @@ async def test_otari_acompletion_rejects_stream_with_response_format() -> None:
         stream=True,
     )
 
-    with pytest.raises(ValueError, match="stream is not supported for response_format"):
-        await provider._acompletion(params)
+    result = await provider._acompletion(params)
+    collected = [item async for item in result]  # type: ignore[union-attr]
+
+    assert collected[0].choices[0].delta.content == '{"city":'
+    call_kwargs = mocked_client.completion.call_args.kwargs
+    assert call_kwargs["stream"] is True
+    assert call_kwargs["response_format"]["type"] == "json_schema"
+    assert call_kwargs["response_format"]["json_schema"]["name"] == "Schema"
 
 
 def test_otari_advertises_image_and_audio_support() -> None:


### PR DESCRIPTION
## Description

The Cohere, Cerebras, and Otari providers rejected `stream=True` whenever `response_format` was set, before the request reached their SDKs. Their current streaming APIs support structured output, so this removes those local guards and keeps each provider's existing response format conversion.

Groq still rejects this combination because its upstream API does not support streaming structured output. The guard remains, with a link to the upstream limitation.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1166

## Testing

- `uv run pytest -q --reruns 0 tests/unit/providers/test_cohere_provider.py tests/unit/providers/test_cerebras_provider.py tests/unit/providers/test_groq_provider.py tests/unit/providers/test_otari_provider.py` (101 passed)
- Pre-commit checks on all changed files (passed)
- The full unit suite reached 1357 passed and 121 skipped. The remaining 71 tests require unrelated optional provider extras that were not installed locally.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: The change was verified against the affected provider unit tests and the repository's pre-commit checks.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured response formats can now be used with streaming completions across supported providers, where the underlying service permits it.
  * Response format settings are forwarded correctly during streamed requests.

* **Bug Fixes**
  * Removed incorrect early failures when combining streaming with structured output.

* **Tests**
  * Added coverage confirming streamed structured-output requests are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->