### PR TITLE
fix(messages): request usage on streaming so the bridge meters tokens

### DIFF
--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -180,7 +180,12 @@ class AzureProvider(AnyLLM):
         if params.response_format:
             azure_response_format = _convert_response_format(params.response_format)
 
-        call_kwargs = params.model_dump(exclude_none=True, exclude={"model_id", "messages", "response_format"})
+        # stream_options is an OpenAI-only knob (the Messages bridge sets it to
+        # request streaming usage); the Azure AI Inference SDK does not model it
+        # and forwards unknown kwargs to the transport, which rejects it.
+        call_kwargs = params.model_dump(
+            exclude_none=True, exclude={"model_id", "messages", "response_format", "stream_options"}
+        )
         if azure_response_format:
             call_kwargs["response_format"] = azure_response_format
 

--- a/src/any_llm/providers/groq/groq.py
+++ b/src/any_llm/providers/groq/groq.py
@@ -71,8 +71,10 @@ class GroqProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for Groq API."""
-        # Groq does not support providing reasoning effort
-        converted_params = params.model_dump(exclude_none=True, exclude={"model_id", "messages"})
+        # Groq does not support providing reasoning effort.
+        # stream_options is an OpenAI-only knob (the Messages bridge sets it to
+        # request streaming usage); the Groq SDK rejects it, so drop it here.
+        converted_params = params.model_dump(exclude_none=True, exclude={"model_id", "messages", "stream_options"})
         if converted_params.get("reasoning_effort") in ("auto", "none"):
             converted_params.pop("reasoning_effort")
         converted_params.update(kwargs)

--- a/src/any_llm/providers/watsonx/watsonx.py
+++ b/src/any_llm/providers/watsonx/watsonx.py
@@ -66,9 +66,13 @@ class WatsonxProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for Watsonx API."""
-        # Watsonx does not support providing reasoning effort
+        # Watsonx does not support providing reasoning effort.
+        # stream_options is an OpenAI-only knob (the Messages bridge sets it to
+        # request streaming usage); Watsonx merges the params dict straight into
+        # its chat payload, so drop it here as the OpenAI-incompatible providers
+        # already do, rather than forward an unsupported field.
         converted_params = params.model_dump(
-            exclude_none=True, exclude={"model_id", "messages", "response_format", "stream"}
+            exclude_none=True, exclude={"model_id", "messages", "response_format", "stream", "stream_options"}
         )
         if converted_params.get("reasoning_effort") in ("auto", "none"):
             converted_params.pop("reasoning_effort")

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -59,13 +59,16 @@ class XaiProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for xAI API."""
-        # xAI does not support providing reasoning effort
+        # xAI does not support providing reasoning effort.
+        # stream_options is an OpenAI-only knob (the Messages bridge sets it to
+        # request streaming usage); the xAI SDK rejects it, so drop it here.
         converted_params = params.model_dump(
             exclude_none=True,
             exclude={
                 "model_id",
                 "messages",
                 "stream",
+                "stream_options",
                 "response_format",
                 "tools",
                 "tool_choice",

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -70,6 +70,15 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
         result["stop"] = params.stop_sequences
     if params.stream is not None:
         result["stream"] = params.stream
+        if params.stream:
+            # OpenAI-compatible backends omit token usage from streamed chunks
+            # unless asked for it, so the streamed Messages bridge would report
+            # zero tokens. Request the trailing usage-only chunk that the
+            # streaming wrapper flushes into the closing ``message_delta``.
+            # Providers that don't support ``stream_options`` strip it in their
+            # own param conversion, and the native Anthropic provider never
+            # reaches this bridge (it overrides ``_amessages``).
+            result["stream_options"] = {"include_usage": True}
 
     if params.output_format is not None:
         if is_structured_output_type(params.output_format):

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -227,3 +227,17 @@ def test_azure_no_api_key_no_credential_raises() -> None:
     with mock_azure_provider():
         with pytest.raises(MissingApiKeyError):
             AzureProvider(api_base=custom_endpoint)
+
+
+def test_convert_completion_params_drops_stream_options() -> None:
+    """stream_options is an OpenAI-only knob (set by the Messages bridge for
+    streaming usage); the Azure AI Inference SDK does not model it and forwards
+    unknown kwargs to the transport, which rejects them, so it must be dropped."""
+    params = CompletionParams(
+        model_id="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    result = AzureProvider._convert_completion_params(params)
+    assert "stream_options" not in result

--- a/tests/unit/providers/test_groq_provider.py
+++ b/tests/unit/providers/test_groq_provider.py
@@ -108,6 +108,23 @@ async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
         assert "reasoning_effort" not in call_kwargs
 
 
+def test_stream_options_filtered_out() -> None:
+    """stream_options is an OpenAI-only knob (set by the Messages bridge for
+    streaming usage); the Groq SDK rejects it, so it must be dropped."""
+    pytest.importorskip("groq")
+    from any_llm.providers.groq.groq import GroqProvider
+
+    result = GroqProvider._convert_completion_params(
+        CompletionParams(
+            model_id="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+    )
+    assert "stream_options" not in result
+
+
 def test_to_chat_completion_extracts_cached_tokens() -> None:
     """Test that cached tokens from Groq usage are extracted into prompt_tokens_details."""
     from groq.types.chat import ChatCompletion as GroqChatCompletion

--- a/tests/unit/providers/test_watsonx_provider.py
+++ b/tests/unit/providers/test_watsonx_provider.py
@@ -176,6 +176,20 @@ def test_convert_completion_params_filters_reasoning_effort(reasoning_effort: st
     assert "reasoning_effort" not in result
 
 
+def test_convert_completion_params_drops_stream_options() -> None:
+    """stream_options is an OpenAI-only knob (set by the Messages bridge for
+    streaming usage). Watsonx merges the params dict straight into its chat
+    payload, so it must be dropped rather than forwarded as an unsupported field."""
+    params = CompletionParams(
+        model_id="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    result = WatsonxProvider._convert_completion_params(params)
+    assert "stream_options" not in result
+
+
 def test_convert_streaming_chunk_with_tool_calls() -> None:
     """Test streaming chunk conversion with tool calls."""
     chunk = {

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -146,3 +146,19 @@ async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
         )
         _, call_kwargs = mock_xai.return_value.chat.create.call_args
         assert "reasoning_effort" not in call_kwargs
+
+
+def test_stream_options_filtered_out() -> None:
+    """stream_options is an OpenAI-only knob (set by the Messages bridge for
+    streaming usage); the xAI SDK rejects it, so it must be dropped."""
+    from any_llm.providers.xai.xai import XaiProvider
+
+    result = XaiProvider._convert_completion_params(
+        CompletionParams(
+            model_id="model",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+    )
+    assert "stream_options" not in result

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -9,7 +9,10 @@ import pytest
 from any_llm.any_llm import AnyLLM
 from any_llm.api import amessages
 from any_llm.types.completion import (
+    ChatCompletion,
     ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
     ChoiceDelta,
     ChunkChoice,
     CompletionUsage,
@@ -442,8 +445,6 @@ async def test_default_amessages_streaming_requests_include_usage() -> None:
 @pytest.mark.asyncio
 async def test_default_amessages_non_streaming_omits_include_usage() -> None:
     """A non-streaming bridge call has no usage-only chunk to request."""
-    from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice
-
     mock_completion = ChatCompletion(
         id="c",
         model="gpt-4",

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -406,6 +406,73 @@ async def test_default_amessages_streaming() -> None:
 
 
 @pytest.mark.asyncio
+async def test_default_amessages_streaming_requests_include_usage() -> None:
+    """Streaming through the bridge must ask the backend for usage, otherwise
+    OpenAI-compatible providers emit no usage-only chunk and the trailing-chunk
+    capture has nothing to report."""
+
+    async def mock_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            model="gpt-4",
+            created=0,
+            object="chat.completion.chunk",
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+        )
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_stream())
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage))
+    async for _ in result:  # drive the generator so _acompletion is invoked
+        pass
+
+    completion_params = mock_provider._acompletion.call_args.args[0]
+    assert completion_params.stream is True
+    assert completion_params.stream_options == {"include_usage": True}
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_non_streaming_omits_include_usage() -> None:
+    """A non-streaming bridge call has no usage-only chunk to request."""
+    from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice
+
+    mock_completion = ChatCompletion(
+        id="c",
+        model="gpt-4",
+        created=0,
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+                finish_reason="stop",
+            )
+        ],
+    )
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=mock_completion)
+
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=False,
+    )
+    await AnyLLM._amessages(mock_provider, params)
+
+    completion_params = mock_provider._acompletion.call_args.args[0]
+    assert completion_params.stream_options is None
+
+
+@pytest.mark.asyncio
 async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
     """Usage (incl. cache) from a trailing usage-only chunk after finish_reason is reported in message_delta."""
 

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -493,6 +493,45 @@ def test_optional_params_not_included_when_none() -> None:
     assert "tools" not in result
 
 
+def test_stream_requests_include_usage() -> None:
+    """Streaming requests ask the backend for usage, otherwise OpenAI-compatible
+    providers omit it and the streamed bridge reports zero tokens."""
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=1024,
+        stream=True,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["stream"] is True
+    assert result["stream_options"] == {"include_usage": True}
+
+
+def test_non_stream_omits_stream_options() -> None:
+    """A non-streaming request has no usage-only chunk to request."""
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=1024,
+        stream=False,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["stream"] is False
+    assert "stream_options" not in result
+
+
+def test_unset_stream_omits_stream_options() -> None:
+    """When stream is unset, neither stream nor stream_options is included."""
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=1024,
+    )
+    result = messages_params_to_completion_params(params)
+    assert "stream" not in result
+    assert "stream_options" not in result
+
+
 def test_temperature_and_top_p_passed_through() -> None:
     """Test that temperature and top_p are passed when set."""
     params = MessagesParams(


### PR DESCRIPTION
## Description

Streaming through the Messages to Completions bridge did not set `stream_options.include_usage`, so OpenAI-compatible backends omitted token usage from their streamed chunks. The recent trailing-usage-chunk fix (#1151) then had no usage-only chunk to flush, so streamed `amessages` against those providers reported zero input and output tokens (and no cache). Native Anthropic was unaffected, since it overrides `_amessages` and streams usage directly.

This requests `stream_options.include_usage` in the streaming branch of `messages_params_to_completion_params`, so the backend emits the trailing usage-only chunk that the stream wrapper flushes into the closing `message_delta`. It completes the chain #1151 started: #1151 captures the trailing chunk, this makes sure the trailing chunk is actually produced.

Safe across providers:

- Providers that do not support `stream_options` (Cerebras, Ollama, Together, Cohere, Mistral) already strip it in their own `_convert_completion_params`.
- The native Anthropic provider never reaches this bridge (it overrides `_amessages`), so its SDK never sees a `stream_options` kwarg.

Downstream context: this is the root cause of the zero-metering behavior reported in mozilla-ai/otari#256 (streamed `/v1/messages` recorded zero tokens and zero cost while non-streaming messages and streaming chat completions metered fine). The old any-llm gateway solved the same class of bug for chat completions in #974; this brings the messages path in line.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Complements #1151. Root cause of mozilla-ai/otari#256.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary <!-- internal behavior fix; no public docs affected -->
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Drafted by Claude via back-and-forth with @njbrake. The investigation (tracing the bug across #1151, #974, and the pinned 1.17.0), the diagnosis, and the decisions are his; the code and this prose are Claude's. On the "discuss with the human, not the AI" policy: respected. @njbrake will reply to review questions himself.

- [x] I am an AI Agent filling out this form (check box if true)

### Testing

Full unit suite passes (1490 passed, 64 skipped), plus ruff and mypy strict clean over `src` and the touched tests. New tests:

- `test_messages_compat.py`: `stream_options.include_usage` is present when streaming, absent when not streaming and when `stream` is unset.
- `test_messages.py`: the `CompletionParams` handed to `_acompletion` actually carries `include_usage` on the streaming path and omits it on the non-streaming path. This is the coverage the trailing-chunk fix lacked (its tests hand-fed usage chunks, so they could not catch that usage was never requested).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed completion token-usage reporting by requesting a final usage-only chunk when streaming is enabled.
  * Filtered OpenAI-specific `stream_options` from provider requests where unsupported (Watsonx, Groq, xAI, and Azure).
* **Tests**
  * Added unit tests validating streaming vs non-streaming forwarding behaviour for the messages→completion bridge.
  * Added dedicated unit tests ensuring Watsonx, Groq, xAI, and Azure conversions drop `stream_options`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->