### PR TITLE
feat: add Telnyx provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all = [
-  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud]"
+  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud,telnyx]"
 ]
 
 platform = [
@@ -138,6 +138,7 @@ vllm = []
 zai = []
 dashscope = []
 deepinfra = []
+telnyx = []
 
 [project.urls]
 Documentation = "https://docs.mozilla.ai/any-llm/"

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -63,6 +63,7 @@ class LLMProvider(StrEnum):
     DASHSCOPE = "dashscope"
     DEEPINFRA = "deepinfra"
     ZAI = "zai"
+    TELNYX = "telnyx"
 
     @classmethod
     def from_string(cls, value: "str | LLMProvider") -> "LLMProvider":

--- a/src/any_llm/providers/telnyx/__init__.py
+++ b/src/any_llm/providers/telnyx/__init__.py
@@ -1,0 +1,3 @@
+from .telnyx import TelnyxProvider
+
+__all__ = ["TelnyxProvider"]

--- a/src/any_llm/providers/telnyx/telnyx.py
+++ b/src/any_llm/providers/telnyx/telnyx.py
@@ -1,0 +1,12 @@
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+
+class TelnyxProvider(BaseOpenAIProvider):
+    API_BASE = "https://api.telnyx.com/v2/ai"
+    ENV_API_KEY_NAME = "TELNYX_API_KEY"
+    ENV_API_BASE_NAME = "TELNYX_API_BASE"
+    PROVIDER_NAME = "telnyx"
+    PROVIDER_DOCUMENTATION_URL = "https://developers.telnyx.com/docs/inference/getting-started"
+
+    SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_COMPLETION_PDF = False

--- a/src/any_llm/providers/telnyx/telnyx.py
+++ b/src/any_llm/providers/telnyx/telnyx.py
@@ -10,3 +10,4 @@ class TelnyxProvider(BaseOpenAIProvider):
 
     SUPPORTS_COMPLETION_REASONING = True
     SUPPORTS_COMPLETION_PDF = False
+    SUPPORTS_EMBEDDING = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.MINIMAX: "MiniMax-M2",
         LLMProvider.ZAI: "glm-4.5-flash",
         LLMProvider.DEEPINFRA: "deepseek-ai/DeepSeek-R1",
+        LLMProvider.TELNYX: "moonshotai/Kimi-K2.6",
     }
 
 
@@ -119,6 +120,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.MINIMAX: "MiniMax-M2",
         LLMProvider.ZAI: "glm-4-32b-0414-128k",
         LLMProvider.DEEPINFRA: "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        LLMProvider.TELNYX: "meta-llama/Meta-Llama-3.1-8B-Instruct",
     }
 
 

--- a/tests/unit/providers/test_telnyx_provider.py
+++ b/tests/unit/providers/test_telnyx_provider.py
@@ -19,6 +19,7 @@ def test_telnyx_supports_flags() -> None:
     assert provider.SUPPORTS_COMPLETION_STREAMING is True
     assert provider.SUPPORTS_COMPLETION_REASONING is True
     assert provider.SUPPORTS_COMPLETION_PDF is False
+    assert provider.SUPPORTS_EMBEDDING is False
     assert provider.SUPPORTS_LIST_MODELS is True
 
 

--- a/tests/unit/providers/test_telnyx_provider.py
+++ b/tests/unit/providers/test_telnyx_provider.py
@@ -1,0 +1,52 @@
+from any_llm import AnyLLM
+from any_llm.providers.telnyx.telnyx import TelnyxProvider
+from any_llm.types.completion import CompletionParams
+
+
+def test_provider_basics() -> None:
+    """Test provider instantiation and basic attributes."""
+    provider = TelnyxProvider(api_key="dummy_key")
+    assert provider.PROVIDER_NAME == "telnyx"
+    assert provider.ENV_API_KEY_NAME == "TELNYX_API_KEY"
+    assert provider.ENV_API_BASE_NAME == "TELNYX_API_BASE"
+    assert provider.API_BASE == "https://api.telnyx.com/v2/ai"
+
+
+def test_telnyx_supports_flags() -> None:
+    """Test that TelnyxProvider has correct feature support flags."""
+    provider = TelnyxProvider(api_key="dummy_key")
+    assert provider.SUPPORTS_COMPLETION is True
+    assert provider.SUPPORTS_COMPLETION_STREAMING is True
+    assert provider.SUPPORTS_COMPLETION_REASONING is True
+    assert provider.SUPPORTS_COMPLETION_PDF is False
+    assert provider.SUPPORTS_LIST_MODELS is True
+
+
+def test_factory_integration() -> None:
+    """Test that the provider factory can create and discover the provider."""
+    provider = AnyLLM.create("telnyx", api_key="sk-1")
+    assert isinstance(provider, TelnyxProvider)
+    assert provider.PROVIDER_NAME == "telnyx"
+    assert "telnyx" in AnyLLM.get_supported_providers()
+
+
+def test_telnyx_convert_completion_params_renames_max_tokens() -> None:
+    """max_tokens should be remapped to max_completion_tokens by the base provider."""
+    params = CompletionParams(
+        model_id="moonshotai/Kimi-K2.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+    result = TelnyxProvider._convert_completion_params(params)
+    assert result["max_completion_tokens"] == 100
+    assert "max_tokens" not in result
+
+
+def test_provider_metadata() -> None:
+    """Test provider metadata is correctly configured."""
+    metadata = TelnyxProvider.get_provider_metadata()
+    assert metadata.name == "telnyx"
+    assert metadata.env_key == "TELNYX_API_KEY"
+    assert metadata.env_api_base == "TELNYX_API_BASE"
+    assert metadata.doc_url == "https://developers.telnyx.com/docs/inference/getting-started"
+    assert metadata.completion is True


### PR DESCRIPTION
## Description

Adds **Telnyx** as a model provider. Telnyx Inference is an OpenAI-compatible Chat Completions endpoint (`api.telnyx.com/v2/ai`) hosting open-source LLMs on Telnyx GPU infrastructure, including `moonshotai/Kimi-K2.6` (1T params, 256K context), `zai-org/GLM-5.2` (754B, 1M context), and `MiniMaxAI/MiniMax-M3-MXFP8` (428B, 1M context).

Because Telnyx speaks the standard `/chat/completions` wire with Bearer auth, the existing `BaseOpenAIProvider` handles it natively. This is the same shape as `NebiusProvider` and `DeepinfraProvider`: a small subclass setting `API_BASE`, `ENV_API_KEY_NAME`, and feature flags.

### Files

| File | Change |
|---|---|
| `src/any_llm/providers/telnyx/telnyx.py` | `TelnyxProvider(BaseOpenAIProvider)`. Sets `SUPPORTS_COMPLETION_REASONING = True`, `SUPPORTS_COMPLETION_PDF = False`, and `SUPPORTS_EMBEDDING = False` (Telnyx Inference exposes no embedding models today). |
| `src/any_llm/providers/telnyx/__init__.py` | Exports. |
| `src/any_llm/constants.py` | `TELNYX = "telnyx"` in the `LLMProvider` enum. |
| `pyproject.toml` | `telnyx = []` extra, added to the `all` group. |
| `tests/conftest.py` | `TELNYX` entries in `provider_model_map` (`meta-llama/Meta-Llama-3.1-8B-Instruct`) and `provider_reasoning_model_map` (`moonshotai/Kimi-K2.6`), so the parametrized integration suite resolves a default model. Omitted from `embedding_provider_model_map` since embeddings aren't supported. |
| `tests/unit/providers/test_telnyx_provider.py` | 5 unit tests (basics, flags, factory, params, metadata). |

## PR Type

- 🆕 New Feature

## Relevant issues

None.

## How I tested it

- `uv sync --all-extras -U` installs cleanly.
- `uv run python -c "from any_llm.providers.telnyx import TelnyxProvider"` imports successfully.
- `uv run ruff check` and `uv run ruff format --check` pass.
- `uv run pytest tests/unit/providers/test_telnyx_provider.py` -> 5/5 pass.
- `uv run pytest tests/unit/test_provider_pyproject_options.py` passes (confirms Telnyx is in both the extras and the `all` group).
- Verified the live Telnyx `/v2/ai/chat/completions` endpoint returns the standard OpenAI-compatible response shape and honors both `max_tokens` and `max_completion_tokens` (output capped, `finish_reason: length`) before writing the provider.
- Confirmed Telnyx Inference exposes no embedding or moderation models, so `SUPPORTS_EMBEDDING` is `False` and `TELNYX` is intentionally omitted from `embedding_provider_model_map`.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: N/A
- AI Developer Tool used: N/A
- Any other info you'd like to share: N/A

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
