### PR TITLE
feat(responses): support raw request body fields

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -966,6 +966,7 @@ class AnyLLM(ABC):
         prompt_cache_key: str | None = None,
         prompt_cache_retention: str | None = None,
         conversation: str | dict[str, Any] | None = None,
+        extra_body: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent] | ParsedResponse[Any]:
         """Create a response using the OpenResponses API.
@@ -1009,6 +1010,7 @@ class AnyLLM(ABC):
             prompt_cache_key: A key to use when reading from or writing to the prompt cache.
             prompt_cache_retention: How long to retain a prompt cache entry created by this request.
             conversation: The conversation to associate this response with (ID string or ConversationParam object).
+            extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
         Returns:
@@ -1062,7 +1064,10 @@ class AnyLLM(ABC):
             **kwargs,
         )
 
-        result = await self._aresponses(params)
+        provider_kwargs: dict[str, Any] = {}
+        if extra_body is not None:
+            provider_kwargs["extra_body"] = extra_body
+        result = await self._aresponses(params, **provider_kwargs)
 
         if is_structured_output_type(response_format):
             # OpenAI-SDK providers return a ParsedResponse directly (via responses.parse);

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -273,6 +273,7 @@ def responses(
     prompt_cache_key: str | None = None,
     prompt_cache_retention: str | None = None,
     conversation: str | dict[str, Any] | None = None,
+    extra_body: dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ResponseResource | Response | ParsedResponse[Any] | Iterator[ResponseStreamEvent]:
@@ -323,6 +324,7 @@ def responses(
         prompt_cache_key: A key to use when reading from or writing to the prompt cache.
         prompt_cache_retention: How long to retain a prompt cache entry created by this request.
         conversation: The conversation to associate this response with (ID string or ConversationParam object).
+        extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -377,6 +379,7 @@ def responses(
         prompt_cache_key=prompt_cache_key,
         prompt_cache_retention=prompt_cache_retention,
         conversation=conversation,
+        extra_body=extra_body,
         **kwargs,
     )
 
@@ -414,6 +417,7 @@ async def aresponses(
     prompt_cache_key: str | None = None,
     prompt_cache_retention: str | None = None,
     conversation: str | dict[str, Any] | None = None,
+    extra_body: dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ResponseResource | Response | ParsedResponse[Any] | AsyncIterator[ResponseStreamEvent]:
@@ -464,6 +468,7 @@ async def aresponses(
         prompt_cache_key: A key to use when reading from or writing to the prompt cache.
         prompt_cache_retention: How long to retain a prompt cache entry created by this request.
         conversation: The conversation to associate this response with (ID string or ConversationParam object).
+        extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -518,6 +523,7 @@ async def aresponses(
         prompt_cache_key=prompt_cache_key,
         prompt_cache_retention=prompt_cache_retention,
         conversation=conversation,
+        extra_body=extra_body,
         **kwargs,
     )
 

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -138,6 +138,31 @@ async def test_aresponses_without_response_format_returns_response(mock_openai_c
     assert not isinstance(result, ParsedResponse)
 
 
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_forwards_extra_body(mock_openai_class: MagicMock) -> None:
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_openai_response('{"city_name": "Paris"}'))
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    extra_body = {
+        "client_metadata": {"x-codex-turn-metadata": {"session_id": "session_123"}},
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "internal_chat_message_metadata_passthrough": {"turn_id": "turn_123"},
+            }
+        ],
+    }
+
+    await provider.aresponses(model="gpt-4o", input_data="hi", extra_body=extra_body)
+
+    assert mock_client.responses.create.call_args.kwargs["extra_body"] == extra_body
+
+
 @patch("any_llm.providers.openai.base.AsyncOpenAI")
 def test_responses_sync_basemodel_returns_parsed(mock_openai_class: MagicMock) -> None:
     """The synchronous wrapper must return the ParsedResponse (a Response subclass), not iterate it."""


### PR DESCRIPTION
## Description

Adds an explicit `extra_body` parameter to the sync and async Responses APIs. It is passed only to the provider call, allowing OpenAI-compatible providers to use their SDKs' raw request-body extension without weakening the typed `ResponsesParams` model.

This enables Otari to preserve Codex's `client_metadata` and per-item `internal_chat_message_metadata_passthrough` fields on the OpenAI Responses route, while safely translating unsupported extensions away for other providers.

## PR Type

- 🆕 New Feature

## Relevant issues

Related: https://github.com/mozilla-ai/otari/issues/362

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: Implementation and tests were reviewed against the repository conventions and run locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `extra_body` support to synchronous and asynchronous Responses API requests.
  - Additional OpenAI-compatible request fields can now be passed through to supported providers.

- **Bug Fixes**
  - Ensured custom request fields are correctly forwarded during asynchronous Responses API calls.

- **Tests**
  - Added coverage verifying that additional request fields reach the provider API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->