### PR TITLE
fix(responses): preserve replayed input items

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,6 @@ result = responses(
 print(result.output_text)
 ```
 
-#### Responses Input Compatibility
-
-`input_data` accepts a string or a list of JSON objects. any-llm validates the
-outer request while passing individual Responses items through unchanged. This
-preserves manual conversation history, including prior response output and
-encrypted reasoning items required for stateless Responses API continuation.
-The provider validates the contextual semantics of those items.
-
 ### Finding the Right Model
 
 The `provider_id` should match our [supported provider names](https://docs.mozilla.ai/any-llm/providers/).

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ result = responses(
 print(result.output_text)
 ```
 
+#### Responses Input Compatibility
+
+`input_data` accepts a string or a list of JSON objects. any-llm validates the
+outer request while passing individual Responses items through unchanged. This
+preserves manual conversation history, including prior response output and
+encrypted reasoning items required for stateless Responses API continuation.
+The provider validates the contextual semantics of those items.
+
 ### Finding the Right Model
 
 The `provider_id` should match our [supported provider names](https://docs.mozilla.ai/any-llm/providers/).

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -44,6 +44,7 @@ from any_llm.types.responses import (
     ParsedResponse,
     Response,
     ResponseInput,
+    ResponseInputPayload,
     ResponsesParams,
     ResponseStreamEvent,
 )
@@ -1034,7 +1035,7 @@ class AnyLLM(ABC):
 
         params = ResponsesParams(
             model=model,
-            input=input_data,
+            input=cast("ResponseInputPayload", input_data),
             tools=prepared_tools,
             tool_choice=tool_choice,
             max_output_tokens=max_output_tokens,

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -43,7 +43,7 @@ from any_llm.types.provider import ProviderMetadata
 from any_llm.types.responses import (
     ParsedResponse,
     Response,
-    ResponseInputParam,
+    ResponseInput,
     ResponsesParams,
     ResponseStreamEvent,
 )
@@ -826,7 +826,7 @@ class AnyLLM(ABC):
     def responses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: type[ResponseFormatT],
         stream: Literal[False] | None = ...,
@@ -837,7 +837,7 @@ class AnyLLM(ABC):
     def responses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         stream: Literal[True],
         **kwargs: Any,
@@ -847,7 +847,7 @@ class AnyLLM(ABC):
     def responses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: dict[str, Any] | None = ...,
         stream: Literal[False] | None = ...,
@@ -858,7 +858,7 @@ class AnyLLM(ABC):
     def responses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: dict[str, Any] | type | None = ...,
         stream: bool | None = ...,
@@ -866,7 +866,7 @@ class AnyLLM(ABC):
     ) -> ResponseResource | Response | Iterator[ResponseStreamEvent] | ParsedResponse[Any]: ...
 
     def responses(
-        self, model: str, input_data: str | ResponseInputParam, **kwargs: Any
+        self, model: str, input_data: ResponseInput, **kwargs: Any
     ) -> ResponseResource | Response | Iterator[ResponseStreamEvent] | ParsedResponse[Any]:
         """Create a response synchronously.
 
@@ -895,7 +895,7 @@ class AnyLLM(ABC):
     async def aresponses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: type[ResponseFormatT],
         stream: Literal[False] | None = ...,
@@ -906,7 +906,7 @@ class AnyLLM(ABC):
     async def aresponses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         stream: Literal[True],
         **kwargs: Any,
@@ -916,7 +916,7 @@ class AnyLLM(ABC):
     async def aresponses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: dict[str, Any] | None = ...,
         stream: Literal[False] | None = ...,
@@ -927,7 +927,7 @@ class AnyLLM(ABC):
     async def aresponses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         response_format: dict[str, Any] | type | None = ...,
         stream: bool | None = ...,
@@ -938,7 +938,7 @@ class AnyLLM(ABC):
     async def aresponses(
         self,
         model: str,
-        input_data: str | ResponseInputParam,
+        input_data: ResponseInput,
         *,
         tools: list[dict[str, Any] | Callable[..., Any]] | Any | None = None,
         tool_choice: str | dict[str, Any] | None = None,

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -978,9 +978,9 @@ class AnyLLM(ABC):
 
         Args:
             model: Model identifier for the chosen provider (e.g., model='gpt-4.1-mini' for LLMProvider.OPENAI).
-            input_data: The input payload accepted by provider's Responses API.
-                For OpenAI-compatible providers, this is typically a list mixing
-                text, images, and tool instructions, or a dict per OpenAI spec.
+            input_data: Input text or a list of wire-format Responses items.
+                Items are passed through unchanged so prior response output and
+                reasoning items can be replayed in a stateless conversation.
             tools: Optional tools for tool calling (Python callables or OpenAI tool dicts)
             tool_choice: Controls which tools the model can call
             max_output_tokens: Maximum number of output tokens to generate

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -291,9 +291,9 @@ def responses(
             Legacy format 'provider/model' is also supported but deprecated.
         provider: **Recommended**: Provider name to use for the request (e.g., 'openai', 'mistral').
             When provided, the model parameter should contain only the model name.
-        input_data: The input payload accepted by provider's Responses API.
-            For OpenAI-compatible providers, this is typically a list mixing
-            text, images, and tool instructions, or a dict per OpenAI spec.
+        input_data: Input text or a list of wire-format Responses items.
+            Items are passed through unchanged so prior response output and
+            reasoning items can be replayed in a stateless conversation.
         tools: Optional tools for tool calling (Python callables or OpenAI tool dicts)
         tool_choice: Controls which tools the model can call
         max_output_tokens: Maximum number of output tokens to generate
@@ -435,9 +435,9 @@ async def aresponses(
             Legacy format 'provider/model' is also supported but deprecated.
         provider: **Recommended**: Provider name to use for the request (e.g., 'openai', 'mistral').
             When provided, the model parameter should contain only the model name.
-        input_data: The input payload accepted by provider's Responses API.
-            For OpenAI-compatible providers, this is typically a list mixing
-            text, images, and tool instructions, or a dict per OpenAI spec.
+        input_data: Input text or a list of wire-format Responses items.
+            Items are passed through unchanged so prior response output and
+            reasoning items can be replayed in a stateless conversation.
         tools: Optional tools for tool calling (Python callables or OpenAI tool dicts)
         tool_choice: Controls which tools the model can call
         max_output_tokens: Maximum number of output tokens to generate

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -19,7 +19,7 @@ from any_llm.types.messages import MessageResponse, MessageStreamEvent, ParsedMe
 from any_llm.types.model import Model
 from any_llm.types.moderation import ModerationResponse
 from any_llm.types.rerank import RerankResponse
-from any_llm.types.responses import ParsedResponse, Response, ResponseInputParam, ResponseStreamEvent
+from any_llm.types.responses import ParsedResponse, Response, ResponseInput, ResponseStreamEvent
 
 
 def completion(
@@ -242,7 +242,7 @@ async def acompletion(
 
 def responses(
     model: str,
-    input_data: str | ResponseInputParam,
+    input_data: ResponseInput,
     *,
     provider: str | LLMProvider | None = None,
     tools: list[dict[str, Any] | Callable[..., Any]] | None = None,
@@ -386,7 +386,7 @@ def responses(
 
 async def aresponses(
     model: str,
-    input_data: str | ResponseInputParam,
+    input_data: ResponseInput,
     *,
     provider: str | LLMProvider | None = None,
     tools: list[dict[str, Any] | Callable[..., Any]] | None = None,

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -13,9 +13,11 @@ ResponseStreamEvent = OpenAIResponseStreamEvent
 ResponseOutputMessage = OpenAIResponseOutputMessage
 ResponseInputParam = OpenAIResponseInputParam
 
-# The SDK's generated union is a static typing aid. Valid replayed history can
-# contain Responses items whose exact wire shape is not represented by it.
-ResponseInput = str | list[dict[str, Any]]
+# Public APIs retain the SDK's generated union for typed caller compatibility.
+# Runtime validation uses the wire shape so valid replayed history can contain
+# Responses items whose exact shape is not represented by that union.
+ResponseInputPayload = str | list[dict[str, Any]]
+ResponseInput = ResponseInputParam | ResponseInputPayload
 
 
 class ResponsesParams(BaseModel):
@@ -31,7 +33,7 @@ class ResponsesParams(BaseModel):
     model: str
     """Model identifier (e.g., 'mistral-small-latest')"""
 
-    input: ResponseInput
+    input: ResponseInputPayload
     """Input text or wire-format Responses items.
 
     The outer request is validated, but input items are passed through without

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -13,6 +13,10 @@ ResponseStreamEvent = OpenAIResponseStreamEvent
 ResponseOutputMessage = OpenAIResponseOutputMessage
 ResponseInputParam = OpenAIResponseInputParam
 
+# The SDK's generated union is a static typing aid. Valid replayed history can
+# contain Responses items whose exact wire shape is not represented by it.
+ResponseInput = str | list[dict[str, Any]]
+
 
 class ResponsesParams(BaseModel):
     """Normalized parameters for responses API.
@@ -27,10 +31,13 @@ class ResponsesParams(BaseModel):
     model: str
     """Model identifier (e.g., 'mistral-small-latest')"""
 
-    input: str | ResponseInputParam
-    """The input payload accepted by provider's Responses API.
-        For OpenAI-compatible providers, this is typically a list mixing
-        text, images, and tool instructions, or a dict per OpenAI spec.
+    input: ResponseInput
+    """Input text or wire-format Responses items.
+
+    The outer request is validated, but input items are passed through without
+    schema validation. The API permits replaying provider response and
+    reasoning items whose context-dependent shapes can exceed the SDK's
+    generated ``ResponseInputParam`` union.
     """
 
     instructions: str | None = None

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -1,6 +1,7 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from pydantic import ValidationError
 
 from any_llm.api import aresponses
 from any_llm.types.responses import ResponsesParams
@@ -58,3 +59,15 @@ def test_responses_params_preserves_codex_continuation_items() -> None:
     params = ResponsesParams(model="test", input=input_data)
 
     assert params.input == input_data
+
+
+def test_responses_params_rejects_non_dictionary_input_items() -> None:
+    """Responses input items must be dictionaries."""
+    with pytest.raises(ValidationError):
+        ResponsesParams(model="test", input=cast(Any, ["hello"]))
+
+
+def test_responses_params_rejects_top_level_dictionary_input() -> None:
+    """Responses input must be text or a list of dictionaries."""
+    with pytest.raises(ValidationError):
+        ResponsesParams(model="test", input=cast(Any, {"role": "user", "content": "hello"}))

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from any_llm.api import aresponses
@@ -39,3 +41,20 @@ def test_explicit_parallel_tool_calls_preserved(value: bool) -> None:
     """Explicit True/False should be kept as-is."""
     params = ResponsesParams(model="test", input="hello", parallel_tool_calls=value)
     assert params.parallel_tool_calls is value
+
+
+def test_responses_params_preserves_codex_continuation_items() -> None:
+    """Responses input accepts Codex items not yet represented by the SDK union."""
+    input_data: list[dict[str, Any]] = [
+        {"type": "reasoning", "summary": [], "encrypted_content": "opaque"},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "commentary"}],
+            "phase": "commentary",
+        },
+    ]
+
+    params = ResponsesParams(model="test", input=input_data)
+
+    assert params.input == input_data

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -64,10 +64,10 @@ def test_responses_params_preserves_codex_continuation_items() -> None:
 def test_responses_params_rejects_non_dictionary_input_items() -> None:
     """Responses input items must be dictionaries."""
     with pytest.raises(ValidationError):
-        ResponsesParams(model="test", input=cast(Any, ["hello"]))
+        ResponsesParams(model="test", input=cast("Any", ["hello"]))
 
 
 def test_responses_params_rejects_top_level_dictionary_input() -> None:
     """Responses input must be text or a list of dictionaries."""
     with pytest.raises(ValidationError):
-        ResponsesParams(model="test", input=cast(Any, {"role": "user", "content": "hello"}))
+        ResponsesParams(model="test", input=cast("Any", {"role": "user", "content": "hello"}))


### PR DESCRIPTION
## Description

Fixes `ResponsesParams` rejecting valid Responses API continuation items, such
as Codex reasoning and assistant-output items replayed as conversation history.

### Decision

`ResponseInputParam` is re-exported from `openai-python` and remains available
as a static type. It is a generated `TypedDict` union intended to describe SDK
request construction and serialization. any-llm previously embedded that union
in a Pydantic model, turning it into strict runtime validation. A replayed
Responses item whose wire shape is valid for the provider but is not represented
by every branch of that generated union then fails every branch and produces a
large Pydantic error report.

The Responses API supports manual history management. OpenAI's guidance says a
caller that manages history itself must resend prior user input and every prior
response output item. It also requires encrypted reasoning items when
continuing stateless conversations in the relevant configurations. These item
shapes are context-dependent and evolve independently of the SDK's generated
input union.

This PR changes the runtime `input` boundary to `str | list[dict[str, Any]]`.
Pydantic continues to validate the stable request envelope, while individual
Responses input items are passed through unchanged for the provider to validate.
This preserves valid response-history replay without weakening validation of the
other any-llm request fields.

The public `ResponseInput` type also retains `ResponseInputParam` alongside the
wire-format input type. Keeping the public and runtime aliases separate avoids a
source-level type-checking break for existing SDK-typed callers without putting
the generated union back into Pydantic validation.

### Documentation

- Documents the pass-through compatibility rule in the README Responses API
  section.
- Documents the runtime validation boundary on `ResponsesParams.input` and
  public Responses API docstrings.
- Keeps `ResponseInputParam` accepted by public signatures for existing callers
  that use its static type information.

### Supporting References

- [OpenAI Responses API history guidance](https://developers.openai.com/api/docs/guides/latest-model)
- [openai-python `ResponseInputParam` generated union](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_input_param.py)
- [openai-python issue #3008: replaying response output and schema mismatch](https://github.com/openai/openai-python/issues/3008)
- [OpenAI Codex issue #12669: strict validator mismatch for replayed assistant messages](https://github.com/openai/codex/issues/12669)

## PR Type

- 🐛 Bug Fix
- 📚 Documentation

## Relevant issues

None. This was found while testing a Codex Responses API continuation through
an OpenAI-compatible gateway.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## Verification

- `uv run pytest -v tests/unit`: `1547 passed, 67 skipped`
- `uv run pytest -v tests/unit/test_responses.py`: `9 passed`
- `uv run mypy src/any_llm/types/responses.py src/any_llm/any_llm.py src/any_llm/api.py tests/unit/test_responses.py`: passed
- Existing caller compatibility check using an input annotated as
  `ResponseInputParam`: passed
- `uv run pre-commit run --all-files --verbose`: all hooks passed except two
  pre-existing mypy errors in `src/any_llm/providers/cerebras/cerebras.py`
  (incompatible `messages` arguments at lines 108 and 145). The changed files
  pass the targeted type check.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: AI was used to investigate the OpenAI SDK
  and API behavior, draft the compatibility documentation, and implement the
  focused change and tests.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses API now accepts stateless replay input as either text or a list of JSON objects, including prior response output and reasoning items.
* **Bug Fixes**
  * Improved validation to reject invalid top-level inputs and non-dictionary items within replay input lists.
* **Documentation**
  * Updated Responses API documentation with details on input compatibility and how request vs replay-item validation is handled.
* **Tests**
  * Added coverage to ensure Codex-style continuation items are preserved unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->