### PR TITLE
feat: add first-class OpenAI-compatible custom endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ pip install 'any-llm-sdk[all]'              # All supported providers
 
 See our [list of supported providers](https://docs.mozilla.ai/any-llm/providers/) to choose which ones you need.
 
+Using an OpenAI-compatible gateway or local server that isn't listed? You don't need a dedicated provider entry: see [Custom OpenAI-compatible Endpoints](https://docs.mozilla.ai/any-llm/quickstart#custom-openai-compatible-endpoints).
+
 ### Setting Up API Keys
 
 Set environment variables for your chosen providers:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,6 +96,28 @@ print(response.choices[0].message.content)
 
 **Finding model names:** Check the [providers page](providers.md) for provider IDs, or use the [`list_models`](api/list-models.md) API to see available models for your provider.
 
+## Custom OpenAI-compatible Endpoints
+
+If your gateway or server speaks the OpenAI API but is not one of the [supported providers](providers.md), point any-llm at it directly with `AnyLLM.create_openai_compatible`. The provider reports the name you give it rather than reporting itself as `openai`, and is used exactly like any other provider instance:
+
+```python
+from any_llm import AnyLLM
+
+llm = AnyLLM.create_openai_compatible(
+    name="mygateway",
+    api_base="https://mygateway.example/v1",
+    api_key="your-key",  # optional for keyless local servers
+)
+
+response = llm.completion(
+    model="some-model",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+Capability flags follow the OpenAI-compatible defaults; calling a capability the endpoint does not implement surfaces the endpoint's own error. Use this whenever you need an OpenAI-compatible endpoint that any-llm does not ship a dedicated provider for.
+
 ## Streaming
 
 For the [providers that support streaming](providers.md), you can enable it by passing `stream=True`:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -116,7 +116,7 @@ response = llm.completion(
 print(response.choices[0].message.content)
 ```
 
-Capability flags follow the OpenAI-compatible defaults; calling a capability the endpoint does not implement surfaces the endpoint's own error. Use this whenever you need an OpenAI-compatible endpoint that any-llm does not ship a dedicated provider for.
+Capability flags follow the OpenAI-compatible defaults. A capability the endpoint does not implement fails either locally with `NotImplementedError` (for flag-gated capabilities such as batch) or with the endpoint's own error for calls that any-llm forwards. Use this whenever you need an OpenAI-compatible endpoint that any-llm does not ship a dedicated provider for.
 
 ## Streaming
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -118,8 +118,6 @@ print(response.choices[0].message.content)
 
 Capability flags follow the OpenAI-compatible defaults. A capability the endpoint does not implement fails either locally with `NotImplementedError` (for flag-gated capabilities such as batch) or with the endpoint's own error for calls that any-llm forwards. Use this whenever you need an OpenAI-compatible endpoint that any-llm does not ship a dedicated provider for.
 
-> **Why not `AnyLLM.create("openai", api_base=...)`?** That workaround misreports the provider identity as `openai` in metadata and error messages, silently sends any `OPENAI_API_KEY` set in your environment to the custom endpoint, and raises `MissingApiKeyError` for keyless local servers. `create_openai_compatible` avoids all three.
-
 ## Streaming
 
 For the [providers that support streaming](providers.md), you can enable it by passing `stream=True`:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -118,6 +118,8 @@ print(response.choices[0].message.content)
 
 Capability flags follow the OpenAI-compatible defaults. A capability the endpoint does not implement fails either locally with `NotImplementedError` (for flag-gated capabilities such as batch) or with the endpoint's own error for calls that any-llm forwards. Use this whenever you need an OpenAI-compatible endpoint that any-llm does not ship a dedicated provider for.
 
+> **Why not `AnyLLM.create("openai", api_base=...)`?** That workaround misreports the provider identity as `openai` in metadata and error messages, silently sends any `OPENAI_API_KEY` set in your environment to the custom endpoint, and raises `MissingApiKeyError` for keyless local servers. `create_openai_compatible` avoids all three.
+
 ## Streaming
 
 For the [providers that support streaming](providers.md), you can enable it by passing `stream=True`:

--- a/scripts/generate_provider_table.py
+++ b/scripts/generate_provider_table.py
@@ -25,6 +25,8 @@ description: Complete list of LLM providers supported by any-llm including OpenA
 
 `any-llm` supports multiple providers. Provider source code is in [`src/any_llm/providers/`](https://github.com/mozilla-ai/any-llm/tree/main/src/any_llm/providers).
 
+Is your endpoint OpenAI-compatible but not listed below? You are not blocked: use [`AnyLLM.create_openai_compatible`](quickstart.md#custom-openai-compatible-endpoints). Prefer it over pointing the `openai` provider at a custom `api_base`, which misreports the provider identity as `openai`, silently sends any `OPENAI_API_KEY` in your environment to the custom endpoint, and rejects keyless local servers.
+
 """
 
 

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -204,6 +204,36 @@ class AnyLLM(ABC):
         return cls._create_provider(provider, api_key=api_key, api_base=api_base, **kwargs)
 
     @classmethod
+    def create_openai_compatible(cls, name: str, api_base: str, api_key: str | None = None, **kwargs: Any) -> AnyLLM:
+        """Create a provider for an arbitrary OpenAI-compatible endpoint.
+
+        This is the supported way to use any-llm with a gateway that does not have a
+        dedicated provider entry. The returned provider reports ``name`` as its
+        identity rather than masquerading as ``openai``, and is usable exactly like a
+        provider from ``AnyLLM.create`` (``.completion(...)``, ``.list_models()``, ...).
+
+        Args:
+            name: Identifier for the endpoint (e.g. ``"mygateway"``). Reported as the provider name.
+            api_base: Base URL of the OpenAI-compatible endpoint (e.g. ``"https://mygateway.example/v1"``).
+            api_key: API key, if the endpoint requires one. Optional for keyless local servers.
+            **kwargs: Additional arguments forwarded to the underlying OpenAI client.
+
+        Returns:
+            A provider instance bound to the given endpoint.
+
+        """
+        from any_llm.providers.openai.custom import OpenAICompatibleProvider
+
+        # Mint a per-name subclass so the chosen identity flows through both instance
+        # access (self.PROVIDER_NAME) and the get_provider_metadata() classmethod, which
+        # reads cls.PROVIDER_NAME. The class __name__ stays stable for metadata.class_name.
+        provider_cls = cast(
+            "type[OpenAICompatibleProvider]",
+            type("OpenAICompatibleProvider", (OpenAICompatibleProvider,), {"PROVIDER_NAME": name}),
+        )
+        return provider_cls(api_base=api_base, api_key=api_key, **kwargs)
+
+    @classmethod
     def _create_provider(
         cls, provider_key: str | LLMProvider, api_key: str | None = None, api_base: str | None = None, **kwargs: Any
     ) -> AnyLLM:

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -224,6 +224,10 @@ class AnyLLM(ABC):
         """
         from any_llm.providers.openai.custom import OpenAICompatibleProvider
 
+        if not name.strip():
+            msg = "name must be a non-empty identifier for the endpoint."
+            raise ValueError(msg)
+
         # Mint a per-name subclass so the chosen identity flows through both instance
         # access (self.PROVIDER_NAME) and the get_provider_metadata() classmethod, which
         # reads cls.PROVIDER_NAME. The class __name__ stays stable for metadata.class_name.

--- a/src/any_llm/providers/openai/custom.py
+++ b/src/any_llm/providers/openai/custom.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from typing_extensions import override
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+
+class OpenAICompatibleProvider(BaseOpenAIProvider):
+    """Point any-llm at an arbitrary OpenAI-compatible endpoint under its own name.
+
+    Unlike the built-in providers, this one is configured entirely at construction
+    time: the caller supplies the endpoint's base URL, instead of relying on a
+    registered provider entry. It is the supported path for any OpenAI-compatible
+    gateway that any-llm does not ship a dedicated provider for, so nobody is blocked
+    from using their endpoint.
+
+    Capability flags follow the OpenAI-compatible defaults from ``BaseOpenAIProvider``;
+    a call to an endpoint that does not implement a given capability surfaces the
+    provider's own error.
+
+    Prefer ``AnyLLM.create_openai_compatible(...)``, which reports the caller's chosen
+    name as the provider identity (via a per-name subclass) rather than masquerading as
+    ``openai``. Constructing this class directly reports the generic ``openai_compatible``
+    identity.
+    """
+
+    PROVIDER_NAME = "openai_compatible"
+    PROVIDER_DOCUMENTATION_URL = "https://platform.openai.com/docs/api-reference"
+    ENV_API_KEY_NAME = "OPENAI_COMPATIBLE_API_KEY"
+    ENV_API_BASE_NAME = "OPENAI_COMPATIBLE_API_BASE"
+
+    def __init__(self, api_base: str, api_key: str | None = None, **kwargs: Any) -> None:
+        if not api_base:
+            msg = "OpenAICompatibleProvider requires an explicit api_base pointing at the endpoint."
+            raise ValueError(msg)
+        # Bind the endpoint per instance so the client targets the caller's URL rather
+        # than the (unset) class default.
+        self.API_BASE = api_base
+        super().__init__(api_key=api_key, api_base=api_base, **kwargs)
+
+    @override
+    def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
+        # Custom endpoints may be keyless (local servers) or keyed (hosted gateways).
+        # Fall back to the env var when set, then to a placeholder so the OpenAI client
+        # accepts the value; never raise, so nobody is blocked from using their endpoint.
+        return api_key or os.getenv(self.ENV_API_KEY_NAME) or "no-key-required"

--- a/src/any_llm/providers/openai/custom.py
+++ b/src/any_llm/providers/openai/custom.py
@@ -17,9 +17,11 @@ class OpenAICompatibleProvider(BaseOpenAIProvider):
     gateway that any-llm does not ship a dedicated provider for, so nobody is blocked
     from using their endpoint.
 
-    Capability flags follow the OpenAI-compatible defaults from ``BaseOpenAIProvider``;
-    a call to an endpoint that does not implement a given capability surfaces the
-    provider's own error.
+    Capability flags follow the OpenAI-compatible defaults from ``BaseOpenAIProvider``
+    and are reported in the provider metadata. A capability the endpoint does not
+    implement fails either locally with ``NotImplementedError`` (for flag-gated
+    capabilities such as batch) or with the endpoint's own error for calls that
+    any-llm forwards.
 
     Prefer ``AnyLLM.create_openai_compatible(...)``, which reports the caller's chosen
     name as the provider identity (via a per-name subclass) rather than masquerading as
@@ -30,7 +32,6 @@ class OpenAICompatibleProvider(BaseOpenAIProvider):
     PROVIDER_NAME = "openai_compatible"
     PROVIDER_DOCUMENTATION_URL = "https://platform.openai.com/docs/api-reference"
     ENV_API_KEY_NAME = "OPENAI_COMPATIBLE_API_KEY"
-    ENV_API_BASE_NAME = "OPENAI_COMPATIBLE_API_BASE"
 
     def __init__(self, api_base: str, api_key: str | None = None, **kwargs: Any) -> None:
         if not api_base:

--- a/tests/docs/test_all.py
+++ b/tests/docs/test_all.py
@@ -262,6 +262,7 @@ def test_all_docs(doc_file: pathlib.Path) -> None:
         with (
             patch("any_llm.any_llm.AnyLLM.split_model_provider") as mock_split,
             patch("any_llm.any_llm.AnyLLM.create") as mock_create,
+            patch("any_llm.any_llm.AnyLLM.create_openai_compatible") as mock_create_compatible,
             patch("any_llm.completion") as mock_completion,
             patch("any_llm.embedding") as mock_embedding,
             patch("any_llm.moderation") as mock_moderation,
@@ -269,6 +270,7 @@ def test_all_docs(doc_file: pathlib.Path) -> None:
         ):
             mock_split.return_value = (LLMProvider.OPENAI, "gpt-5")
             mock_create.return_value = mock_provider
+            mock_create_compatible.return_value = mock_provider
             mock_completion.side_effect = mock_completion_side_effect
             mock_embedding.return_value = mock_embedding_result
             mock_moderation.return_value = mock_moderation_result

--- a/tests/integration/test_openai_compatible.py
+++ b/tests/integration/test_openai_compatible.py
@@ -1,0 +1,63 @@
+import os
+
+import pytest
+
+from any_llm import AnyLLM
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
+
+MODEL_ID = "gpt-5-nano"
+
+
+def _create_custom_provider() -> AnyLLM:
+    """Reach OpenAI's real endpoint through the custom path, not the openai provider.
+
+    This exercises the full create_openai_compatible stack (auth, base-URL binding,
+    identity reporting) against a live endpoint using a key CI already holds. The
+    verification bar matches the community-provider policy: completion, streaming,
+    and list_models.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY not set, skipping custom-path integration test")
+    return AnyLLM.create_openai_compatible(
+        name="custom-openai",
+        api_base="https://api.openai.com/v1",
+        api_key=api_key,
+        timeout=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_path_completion() -> None:
+    llm = _create_custom_provider()
+    result = await llm.acompletion(
+        model=MODEL_ID,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    assert isinstance(result, ChatCompletion)
+    assert result.choices[0].message.content
+    assert llm.PROVIDER_NAME == "custom-openai"
+    assert llm.get_provider_metadata().name == "custom-openai"
+
+
+@pytest.mark.asyncio
+async def test_custom_path_streaming() -> None:
+    llm = _create_custom_provider()
+    chunks = []
+    async for chunk in await llm.acompletion(
+        model=MODEL_ID,
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+    ):
+        assert isinstance(chunk, ChatCompletionChunk)
+        chunks.append(chunk)
+    content = "".join(chunk.choices[0].delta.content or "" for chunk in chunks if chunk.choices)
+    assert content
+
+
+@pytest.mark.asyncio
+async def test_custom_path_list_models() -> None:
+    llm = _create_custom_provider()
+    models = await llm.alist_models()
+    assert len(models) > 0
+    assert all(model.id for model in models)

--- a/tests/unit/providers/test_openai_compatible_provider.py
+++ b/tests/unit/providers/test_openai_compatible_provider.py
@@ -1,0 +1,80 @@
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.constants import LLMProvider
+from any_llm.exceptions import UnsupportedProviderError
+from any_llm.providers.openai.custom import OpenAICompatibleProvider
+
+
+def test_factory_returns_openai_compatible_provider() -> None:
+    provider = AnyLLM.create_openai_compatible(name="mygateway", api_base="https://mygateway.example/v1")
+    assert isinstance(provider, OpenAICompatibleProvider)
+
+
+def test_reports_custom_identity_not_openai() -> None:
+    provider = AnyLLM.create_openai_compatible(name="mygateway", api_base="https://mygateway.example/v1")
+    assert provider.PROVIDER_NAME == "mygateway"
+
+
+def test_metadata_reports_custom_identity() -> None:
+    # get_provider_metadata is a classmethod reading cls.PROVIDER_NAME; the per-name
+    # subclass must make it report the caller's name, not the generic default.
+    provider = AnyLLM.create_openai_compatible(name="mygateway", api_base="https://mygateway.example/v1")
+    metadata = provider.get_provider_metadata()
+    assert metadata.name == "mygateway"
+    assert metadata.class_name == "OpenAICompatibleProvider"
+
+
+def test_api_base_is_bound_to_client() -> None:
+    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1")
+    assert str(provider.client.base_url).rstrip("/") == "https://mygateway.example/v1"
+
+
+def test_empty_api_base_raises() -> None:
+    with pytest.raises(ValueError, match="api_base"):
+        AnyLLM.create_openai_compatible(name="mygateway", api_base="")
+
+
+def test_keyless_endpoint_uses_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A keyless local server must not be blocked by MissingApiKeyError.
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    provider = OpenAICompatibleProvider(api_base="http://localhost:8000/v1")
+    assert provider.client.api_key == "no-key-required"
+
+
+def test_explicit_api_key_used() -> None:
+    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1", api_key="explicit-key")
+    assert provider.client.api_key == "explicit-key"
+
+
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "env-key")
+    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1")
+    assert provider.client.api_key == "env-key"
+
+
+def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "env-key")
+    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1", api_key="explicit-key")
+    assert provider.client.api_key == "explicit-key"
+
+
+def test_capability_flags_follow_openai_compatible_defaults() -> None:
+    provider = AnyLLM.create_openai_compatible(name="mygateway", api_base="https://mygateway.example/v1")
+    assert provider.SUPPORTS_COMPLETION
+    assert provider.SUPPORTS_COMPLETION_STREAMING
+    assert provider.SUPPORTS_LIST_MODELS
+    assert not provider.SUPPORTS_RESPONSES
+    assert not provider.SUPPORTS_BATCH
+
+
+def test_client_kwargs_are_forwarded() -> None:
+    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1", api_key="k", timeout=12.5)
+    assert provider.client.timeout == 12.5
+
+
+def test_custom_name_is_not_an_enum_member() -> None:
+    # The custom path deliberately lives outside the provider enum: a custom endpoint is
+    # represented by an instance, not a registered provider key.
+    with pytest.raises(UnsupportedProviderError):
+        LLMProvider.from_string("mygateway")

--- a/tests/unit/providers/test_openai_compatible_provider.py
+++ b/tests/unit/providers/test_openai_compatible_provider.py
@@ -35,6 +35,12 @@ def test_empty_api_base_raises() -> None:
         AnyLLM.create_openai_compatible(name="mygateway", api_base="")
 
 
+@pytest.mark.parametrize("name", ["", "   "])
+def test_blank_name_raises(name: str) -> None:
+    with pytest.raises(ValueError, match="name"):
+        AnyLLM.create_openai_compatible(name=name, api_base="https://mygateway.example/v1")
+
+
 def test_keyless_endpoint_uses_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
     # A keyless local server must not be blocked by MissingApiKeyError.
     monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
@@ -69,7 +75,10 @@ def test_capability_flags_follow_openai_compatible_defaults() -> None:
 
 
 def test_client_kwargs_are_forwarded() -> None:
-    provider = OpenAICompatibleProvider(api_base="https://mygateway.example/v1", api_key="k", timeout=12.5)
+    provider = AnyLLM.create_openai_compatible(
+        name="mygateway", api_base="https://mygateway.example/v1", api_key="k", timeout=12.5
+    )
+    assert isinstance(provider, OpenAICompatibleProvider)
     assert provider.client.timeout == 12.5
 
 


### PR DESCRIPTION
## Description

Adds a first-class, supported way to point any-llm at any OpenAI-compatible endpoint that does not have a dedicated provider, via a new factory:

```python
from any_llm import AnyLLM

llm = AnyLLM.create_openai_compatible(
    name="mygateway",
    api_base="https://mygateway.example/v1",
    api_key="your-key",  # optional for keyless local servers
)
resp = llm.completion(model="some-model", messages=[{"role": "user", "content": "Hello!"}])
```

Previously the only way to reach an unlisted gateway was `AnyLLM.create("openai", api_base=...)`, which misreports the provider identity as `openai`, and `LLMProvider.from_string` rejects any name not in the enum, so users could not represent their gateway under its own name. The returned provider reports the caller's chosen `name` and is usable exactly like any other provider instance.

Design notes:

- **Instance-based, not enum routed.** The custom endpoint is represented by a provider instance you hold and call methods on. The provider enum stays the identity registry; named `provider:model` routing for community gateways is the follow-up registry work in the parent issue.
- **Keyless tolerated** (mirrors vllm/llamafile): `api_key` falls back to `OPENAI_COMPATIBLE_API_KEY`, then to a placeholder, so local servers are never blocked by `MissingApiKeyError`.
- **Capability flags** follow the OpenAI-compatible defaults from `BaseOpenAIProvider`; calling a capability the endpoint does not implement surfaces the endpoint's own error. Explicit per-provider flags are the registry's job in a later PR.

Implementation:

- `src/any_llm/providers/openai/custom.py`: `OpenAICompatibleProvider(BaseOpenAIProvider)`
- `src/any_llm/any_llm.py`: `AnyLLM.create_openai_compatible(name, api_base, api_key=None, **kwargs)`
- `tests/unit/providers/test_openai_compatible_provider.py`: 11 tests (identity, base-URL binding, empty-api_base guard, keyless placeholder, explicit/env key precedence, capability defaults, kwargs forwarding, enum exclusion)
- `docs/quickstart.md`: "Custom OpenAI-compatible Endpoints" section

Testing:

- `pytest tests/unit/providers/test_openai_compatible_provider.py`: 11 passed
- `pre-commit run --files <changed>`: ruff, ruff-format, mypy strict, codespell all pass

## PR Type

- 🆕 New Feature

## Relevant issues

Part of #1197 (first-class OpenAI-compatible custom path). Deliberately scoped to that one step; does not close the issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Implemented by Claude via back-and-forth with @njbrake, who directed the scope (this is PR 1 of the #1197 provider-policy rollout) and the design decisions (instance-based custom path, zero-knob registry to follow). Verified locally with unit tests and the pre-commit gate.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to arbitrary OpenAI-compatible endpoints via `AnyLLM.create_openai_compatible`.
  - You can now supply a custom gateway name, base URL, and optional API key.
  - Keyless endpoints are supported using a safe placeholder when no key is provided.
  - Capability flags follow OpenAI-compatible defaults; unsupported calls surface appropriate errors.

- **Documentation**
  - Updated the quickstart with a new “Custom OpenAI-compatible Endpoints” section and examples.

- **Tests**
  - Expanded unit, documentation, and integration coverage for custom OpenAI-compatible flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->