### PR TITLE
feat: add config registry for OpenAI-compatible gateway providers

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -241,7 +241,15 @@ class AnyLLM(ABC):
     def _create_provider(
         cls, provider_key: str | LLMProvider, api_key: str | None = None, api_base: str | None = None, **kwargs: Any
     ) -> AnyLLM:
-        """Dynamically load and create an instance of a provider based on the naming convention."""
+        """Dynamically load and create an instance of a provider.
+
+        Registry rows (config-only OpenAI-compatible gateways) resolve first;
+        everything else falls through to the folder-per-provider naming convention.
+        """
+        registry_class = cls._get_registry_provider_class(provider_key)
+        if registry_class is not None:
+            return registry_class(api_key=api_key, api_base=api_base, **kwargs)
+
         provider_key = LLMProvider.from_string(provider_key).value
 
         provider_class_name = f"{provider_key.capitalize()}Provider"
@@ -259,6 +267,20 @@ class AnyLLM(ABC):
 
         return provider_class(api_key=api_key, api_base=api_base, **kwargs)
 
+    @staticmethod
+    def _get_registry_provider_class(provider_key: str | LLMProvider) -> type[AnyLLM] | None:
+        """Resolve a provider key against the config registry, or None if not registered.
+
+        Imported lazily because the registry builds on BaseOpenAIProvider, which
+        imports this module.
+        """
+        from any_llm.providers.registry import get_registry_config, get_registry_provider_class
+
+        key = provider_key.value if isinstance(provider_key, LLMProvider) else provider_key
+        if get_registry_config(key) is None:
+            return None
+        return get_registry_provider_class(key)
+
     @classmethod
     def get_provider_class(cls, provider_key: str | LLMProvider) -> type[AnyLLM]:
         """Get the provider class without instantiating it.
@@ -270,6 +292,10 @@ class AnyLLM(ABC):
             The provider class
 
         """
+        registry_class = cls._get_registry_provider_class(provider_key)
+        if registry_class is not None:
+            return registry_class
+
         provider_key = LLMProvider.from_string(provider_key).value
 
         provider_class_name = f"{provider_key.capitalize()}Provider"

--- a/src/any_llm/providers/atlascloud/atlascloud.py
+++ b/src/any_llm/providers/atlascloud/atlascloud.py
@@ -1,30 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: Atlas Cloud migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class AtlascloudProvider(BaseOpenAIProvider):
-    """Provider for Atlas Cloud (https://www.atlascloud.ai).
+from any_llm.providers.registry import get_registry_provider_class
 
-    Atlas Cloud is an OpenAI-compatible inference platform serving DeepSeek, Qwen,
-    Kimi, GLM and MiniMax models. It exposes the standard chat completions and model
-    listing endpoints under https://api.atlascloud.ai/v1, so this provider only needs
-    to set configuration defaults and capability flags on top of BaseOpenAIProvider.
-    """
+AtlascloudProvider = get_registry_provider_class("atlascloud")
 
-    API_BASE = "https://api.atlascloud.ai/v1"
-    ENV_API_KEY_NAME = "ATLASCLOUD_API_KEY"
-    ENV_API_BASE_NAME = "ATLASCLOUD_API_BASE"
-    PROVIDER_NAME = "atlascloud"
-    PROVIDER_DOCUMENTATION_URL = "https://www.atlascloud.ai/docs"
-
-    SUPPORTS_COMPLETION = True
-    SUPPORTS_COMPLETION_STREAMING = True
-    SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_COMPLETION_IMAGE = False
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_EMBEDDING = False
-    SUPPORTS_MODERATION = False
-    SUPPORTS_LIST_MODELS = True
-    SUPPORTS_BATCH = False
-    SUPPORTS_IMAGE_GENERATION = False
-    SUPPORTS_RERANK = False
-    SUPPORTS_RESPONSES = False
+__all__ = ["AtlascloudProvider"]

--- a/src/any_llm/providers/dashscope/dashscope.py
+++ b/src/any_llm/providers/dashscope/dashscope.py
@@ -1,11 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class DashscopeProvider(BaseOpenAIProvider):
-    API_BASE = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-    ENV_API_KEY_NAME = "DASHSCOPE_API_KEY"
-    ENV_API_BASE_NAME = "DASHSCOPE_API_BASE"
-    PROVIDER_NAME = "dashscope"
-    PROVIDER_DOCUMENTATION_URL = "https://bailian.console.aliyun.com/cn-beijing/?tab=api#/api"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_REASONING = False
+DashscopeProvider = get_registry_provider_class("dashscope")
+
+__all__ = ["DashscopeProvider"]

--- a/src/any_llm/providers/databricks/databricks.py
+++ b/src/any_llm/providers/databricks/databricks.py
@@ -1,15 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class DatabricksProvider(BaseOpenAIProvider):
-    """Databricks Provider using the new response conversion utilities."""
+from any_llm.providers.registry import get_registry_provider_class
 
-    ENV_API_KEY_NAME = "DATABRICKS_TOKEN"
-    ENV_API_BASE_NAME = "DATABRICKS_HOST"
-    PROVIDER_NAME = "databricks"
-    PROVIDER_DOCUMENTATION_URL = "https://docs.databricks.com/"
+DatabricksProvider = get_registry_provider_class("databricks")
 
-    SUPPORTS_COMPLETION_IMAGE = False
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_LIST_MODELS = False
-    SUPPORTS_COMPLETION_REASONING = True
+__all__ = ["DatabricksProvider"]

--- a/src/any_llm/providers/deepinfra/deepinfra.py
+++ b/src/any_llm/providers/deepinfra/deepinfra.py
@@ -1,12 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class DeepinfraProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.deepinfra.com/v1/openai"
-    ENV_API_KEY_NAME = "DEEPINFRA_API_KEY"
-    ENV_API_BASE_NAME = "DEEPINFRA_API_BASE"
-    PROVIDER_NAME = "deepinfra"
-    PROVIDER_DOCUMENTATION_URL = "https://deepinfra.com/docs/openai_api"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_COMPLETION_PDF = False
+DeepinfraProvider = get_registry_provider_class("deepinfra")
+
+__all__ = ["DeepinfraProvider"]

--- a/src/any_llm/providers/moonshot/moonshot.py
+++ b/src/any_llm/providers/moonshot/moonshot.py
@@ -1,14 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class MoonshotProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.moonshot.ai/v1"
-    ENV_API_KEY_NAME = "MOONSHOT_API_KEY"
-    ENV_API_BASE_NAME = "MOONSHOT_API_BASE"
-    PROVIDER_NAME = "moonshot"
-    PROVIDER_DOCUMENTATION_URL = "https://platform.moonshot.ai/"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_EMBEDDING = False  # Moonshot doesn't host an embedding model
-    SUPPORTS_COMPLETION_IMAGE = False
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_COMPLETION_REASONING = True
+MoonshotProvider = get_registry_provider_class("moonshot")
+
+__all__ = ["MoonshotProvider"]

--- a/src/any_llm/providers/mzai/mzai.py
+++ b/src/any_llm/providers/mzai/mzai.py
@@ -1,12 +1,11 @@
-from any_llm.providers.openai import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class MzaiProvider(BaseOpenAIProvider):
-    API_BASE = "https://platform-api.any-llm.ai/api/v1"
-    ENV_API_KEY_NAME = "ANY_LLM_KEY"
-    ENV_API_BASE_NAME = "ANY_LLM_PLATFORM_URL"
-    PROVIDER_NAME = "mzai"
-    PROVIDER_DOCUMENTATION_URL = "https://any-llm.ai"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_COMPLETION_REASONING = True
+MzaiProvider = get_registry_provider_class("mzai")
+
+__all__ = ["MzaiProvider"]

--- a/src/any_llm/providers/nebius/nebius.py
+++ b/src/any_llm/providers/nebius/nebius.py
@@ -1,12 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class NebiusProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.studio.nebius.ai/v1"
-    ENV_API_KEY_NAME = "NEBIUS_API_KEY"
-    ENV_API_BASE_NAME = "NEBIUS_API_BASE"
-    PROVIDER_NAME = "nebius"
-    PROVIDER_DOCUMENTATION_URL = "https://studio.nebius.ai/"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_COMPLETION_REASONING = True
+NebiusProvider = get_registry_provider_class("nebius")
+
+__all__ = ["NebiusProvider"]

--- a/src/any_llm/providers/neosantara/neosantara.py
+++ b/src/any_llm/providers/neosantara/neosantara.py
@@ -1,14 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class NeosantaraProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.neosantara.xyz/v1"
-    ENV_API_KEY_NAME = "NEOSANTARA_API_KEY"
-    ENV_API_BASE_NAME = "NEOSANTARA_API_BASE"
-    PROVIDER_NAME = "neosantara"
-    PROVIDER_DOCUMENTATION_URL = "https://docs.neosantara.xyz"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_RESPONSES = True
-    SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_IMAGE_GENERATION = True
-    SUPPORTS_BATCH = True
+NeosantaraProvider = get_registry_provider_class("neosantara")
+
+__all__ = ["NeosantaraProvider"]

--- a/src/any_llm/providers/perplexity/perplexity.py
+++ b/src/any_llm/providers/perplexity/perplexity.py
@@ -1,19 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class PerplexityProvider(BaseOpenAIProvider):
-    """Perplexity provider for accessing LLMs through Perplexity's OpenAI-compatible API."""
+from any_llm.providers.registry import get_registry_provider_class
 
-    API_BASE = "https://api.perplexity.ai"
-    ENV_API_KEY_NAME = "PERPLEXITY_API_KEY"
-    ENV_API_BASE_NAME = "PERPLEXITY_BASE_URL"
-    PROVIDER_NAME = "perplexity"
-    PROVIDER_DOCUMENTATION_URL = "https://docs.perplexity.ai/"
+PerplexityProvider = get_registry_provider_class("perplexity")
 
-    SUPPORTS_COMPLETION_STREAMING = True
-    SUPPORTS_COMPLETION = True
-    SUPPORTS_RESPONSES = False
-    SUPPORTS_COMPLETION_REASONING = False
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_EMBEDDING = False
-    SUPPORTS_LIST_MODELS = False
+__all__ = ["PerplexityProvider"]

--- a/src/any_llm/providers/qiniu/qiniu.py
+++ b/src/any_llm/providers/qiniu/qiniu.py
@@ -1,12 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class QiniuProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.qnaigc.com/v1"
-    ENV_API_KEY_NAME = "QINIU_API_KEY"
-    ENV_API_BASE_NAME = "QINIU_API_BASE"
-    PROVIDER_NAME = "qiniu"
-    PROVIDER_DOCUMENTATION_URL = "https://developer.qiniu.com/aitokenapi"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_COMPLETION_REASONING = True
+QiniuProvider = get_registry_provider_class("qiniu")
+
+__all__ = ["QiniuProvider"]

--- a/src/any_llm/providers/registry.py
+++ b/src/any_llm/providers/registry.py
@@ -1,0 +1,108 @@
+"""Config registry for OpenAI-compatible gateway providers.
+
+Config-only providers (no method overrides, only class attributes on top of
+``BaseOpenAIProvider``) are described here as data rows instead of code folders.
+The loader in ``AnyLLM`` checks this registry before falling through to the
+folder-per-provider import convention, so a registry row resolves through
+``AnyLLM.create(...)``, ``AnyLLM.get_provider_class(...)`` and the metadata
+APIs like any folder-based provider.
+
+Adding a community gateway means adding one row (plus live verification
+evidence in the PR). Removing a dead gateway means deleting its row. See the
+provider policy in https://github.com/mozilla-ai/any-llm/issues/1197.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+
+@dataclass(frozen=True)
+class OpenAICompatibleProviderConfig:
+    """Everything a config-only OpenAI-compatible provider needs, as data.
+
+    Capability flags default to the conservative gateway baseline (completion,
+    streaming and model listing only); rows opt in to anything beyond that.
+    A gateway that needs behavior (custom auth, request/response translation,
+    param remaps) does not belong in the registry and keeps a code folder.
+    """
+
+    name: str
+    api_base: str
+    env_api_key_name: str
+    provider_documentation_url: str
+    env_api_base_name: str | None = None
+    supports_completion: bool = True
+    supports_completion_streaming: bool = True
+    supports_completion_reasoning: bool = False
+    supports_completion_image: bool = False
+    supports_completion_pdf: bool = False
+    supports_embedding: bool = False
+    supports_moderation: bool = False
+    supports_list_models: bool = True
+    supports_responses: bool = False
+    supports_batch: bool = False
+    supports_image_generation: bool = False
+    supports_rerank: bool = False
+
+
+PROVIDER_REGISTRY: dict[str, OpenAICompatibleProviderConfig] = {
+    "atlascloud": OpenAICompatibleProviderConfig(
+        name="atlascloud",
+        api_base="https://api.atlascloud.ai/v1",
+        env_api_key_name="ATLASCLOUD_API_KEY",
+        env_api_base_name="ATLASCLOUD_API_BASE",
+        provider_documentation_url="https://www.atlascloud.ai/docs",
+        supports_completion_reasoning=True,
+    ),
+}
+
+_class_cache: dict[str, type[BaseOpenAIProvider]] = {}
+
+
+def get_registry_config(name: str) -> OpenAICompatibleProviderConfig | None:
+    """Return the registry row for ``name``, or None if it is not registered."""
+    return PROVIDER_REGISTRY.get(name.strip().lower())
+
+
+def get_registry_provider_class(name: str) -> type[BaseOpenAIProvider]:
+    """Return the provider class for a registry row, minting it on first use.
+
+    Classes are cached per row so repeated lookups return the same class object
+    (identity checks like ``get_provider_class(name) is AtlascloudProvider``
+    keep working). Raises KeyError for names that are not in the registry.
+    """
+    key = name.strip().lower()
+    config = PROVIDER_REGISTRY[key]
+    if key not in _class_cache:
+        _class_cache[key] = _build_provider_class(config)
+    return _class_cache[key]
+
+
+def _build_provider_class(config: OpenAICompatibleProviderConfig) -> type[BaseOpenAIProvider]:
+    attrs: dict[str, Any] = {
+        "PROVIDER_NAME": config.name,
+        "PROVIDER_DOCUMENTATION_URL": config.provider_documentation_url,
+        "ENV_API_KEY_NAME": config.env_api_key_name,
+        "ENV_API_BASE_NAME": config.env_api_base_name,
+        "API_BASE": config.api_base,
+        "SUPPORTS_COMPLETION": config.supports_completion,
+        "SUPPORTS_COMPLETION_STREAMING": config.supports_completion_streaming,
+        "SUPPORTS_COMPLETION_REASONING": config.supports_completion_reasoning,
+        "SUPPORTS_COMPLETION_IMAGE": config.supports_completion_image,
+        "SUPPORTS_COMPLETION_PDF": config.supports_completion_pdf,
+        "SUPPORTS_EMBEDDING": config.supports_embedding,
+        "SUPPORTS_MODERATION": config.supports_moderation,
+        "SUPPORTS_LIST_MODELS": config.supports_list_models,
+        "SUPPORTS_RESPONSES": config.supports_responses,
+        "SUPPORTS_BATCH": config.supports_batch,
+        "SUPPORTS_IMAGE_GENERATION": config.supports_image_generation,
+        "SUPPORTS_RERANK": config.supports_rerank,
+    }
+    # The class name follows the same convention as folder-based providers so
+    # metadata.class_name is stable across a migration.
+    class_name = f"{config.name.capitalize()}Provider"
+    return cast("type[BaseOpenAIProvider]", type(class_name, (BaseOpenAIProvider,), attrs))

--- a/src/any_llm/providers/registry.py
+++ b/src/any_llm/providers/registry.py
@@ -31,9 +31,11 @@ class OpenAICompatibleProviderConfig:
     """
 
     name: str
-    api_base: str
     env_api_key_name: str
     provider_documentation_url: str
+    api_base: str | None = None
+    """Static default endpoint. None for providers whose base URL only comes from
+    the env var or an explicit api_base argument (e.g. databricks)."""
     env_api_base_name: str | None = None
     supports_completion: bool = True
     supports_completion_streaming: bool = True
@@ -49,6 +51,9 @@ class OpenAICompatibleProviderConfig:
     supports_rerank: bool = False
 
 
+# Rows replicate each migrated provider's effective flags, including values the
+# folder-based class inherited from BaseOpenAIProvider defaults (for example
+# moderation). Flag corrections are their own change, not part of a migration.
 PROVIDER_REGISTRY: dict[str, OpenAICompatibleProviderConfig] = {
     "atlascloud": OpenAICompatibleProviderConfig(
         name="atlascloud",
@@ -57,6 +62,115 @@ PROVIDER_REGISTRY: dict[str, OpenAICompatibleProviderConfig] = {
         env_api_base_name="ATLASCLOUD_API_BASE",
         provider_documentation_url="https://www.atlascloud.ai/docs",
         supports_completion_reasoning=True,
+    ),
+    "dashscope": OpenAICompatibleProviderConfig(
+        name="dashscope",
+        api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        env_api_key_name="DASHSCOPE_API_KEY",
+        env_api_base_name="DASHSCOPE_API_BASE",
+        provider_documentation_url="https://bailian.console.aliyun.com/cn-beijing/?tab=api#/api",
+        supports_completion_image=True,
+        supports_completion_pdf=True,
+        supports_embedding=True,
+        supports_moderation=True,
+    ),
+    "databricks": OpenAICompatibleProviderConfig(
+        name="databricks",
+        env_api_key_name="DATABRICKS_TOKEN",
+        env_api_base_name="DATABRICKS_HOST",
+        provider_documentation_url="https://docs.databricks.com/",
+        supports_completion_reasoning=True,
+        supports_embedding=True,
+        supports_moderation=True,
+        supports_list_models=False,
+    ),
+    "deepinfra": OpenAICompatibleProviderConfig(
+        name="deepinfra",
+        api_base="https://api.deepinfra.com/v1/openai",
+        env_api_key_name="DEEPINFRA_API_KEY",
+        env_api_base_name="DEEPINFRA_API_BASE",
+        provider_documentation_url="https://deepinfra.com/docs/openai_api",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_embedding=True,
+        supports_moderation=True,
+    ),
+    "moonshot": OpenAICompatibleProviderConfig(
+        name="moonshot",
+        api_base="https://api.moonshot.ai/v1",
+        env_api_key_name="MOONSHOT_API_KEY",
+        env_api_base_name="MOONSHOT_API_BASE",
+        provider_documentation_url="https://platform.moonshot.ai/",
+        supports_completion_reasoning=True,
+        supports_moderation=True,
+    ),
+    "mzai": OpenAICompatibleProviderConfig(
+        name="mzai",
+        api_base="https://platform-api.any-llm.ai/api/v1",
+        env_api_key_name="ANY_LLM_KEY",
+        env_api_base_name="ANY_LLM_PLATFORM_URL",
+        provider_documentation_url="https://any-llm.ai",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_embedding=True,
+        supports_moderation=True,
+    ),
+    "nebius": OpenAICompatibleProviderConfig(
+        name="nebius",
+        api_base="https://api.studio.nebius.ai/v1",
+        env_api_key_name="NEBIUS_API_KEY",
+        env_api_base_name="NEBIUS_API_BASE",
+        provider_documentation_url="https://studio.nebius.ai/",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_embedding=True,
+        supports_moderation=True,
+    ),
+    "neosantara": OpenAICompatibleProviderConfig(
+        name="neosantara",
+        api_base="https://api.neosantara.xyz/v1",
+        env_api_key_name="NEOSANTARA_API_KEY",
+        env_api_base_name="NEOSANTARA_API_BASE",
+        provider_documentation_url="https://docs.neosantara.xyz",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_completion_pdf=True,
+        supports_embedding=True,
+        supports_moderation=True,
+        supports_responses=True,
+        supports_batch=True,
+        supports_image_generation=True,
+    ),
+    "perplexity": OpenAICompatibleProviderConfig(
+        name="perplexity",
+        api_base="https://api.perplexity.ai",
+        env_api_key_name="PERPLEXITY_API_KEY",
+        env_api_base_name="PERPLEXITY_BASE_URL",
+        provider_documentation_url="https://docs.perplexity.ai/",
+        supports_completion_image=True,
+        supports_moderation=True,
+        supports_list_models=False,
+    ),
+    "qiniu": OpenAICompatibleProviderConfig(
+        name="qiniu",
+        api_base="https://api.qnaigc.com/v1",
+        env_api_key_name="QINIU_API_KEY",
+        env_api_base_name="QINIU_API_BASE",
+        provider_documentation_url="https://developer.qiniu.com/aitokenapi",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_embedding=True,
+        supports_moderation=True,
+    ),
+    "telnyx": OpenAICompatibleProviderConfig(
+        name="telnyx",
+        api_base="https://api.telnyx.com/v2/ai",
+        env_api_key_name="TELNYX_API_KEY",
+        env_api_base_name="TELNYX_API_BASE",
+        provider_documentation_url="https://developers.telnyx.com/docs/inference/getting-started",
+        supports_completion_reasoning=True,
+        supports_completion_image=True,
+        supports_moderation=True,
     ),
 }
 

--- a/src/any_llm/providers/telnyx/telnyx.py
+++ b/src/any_llm/providers/telnyx/telnyx.py
@@ -1,13 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: this provider migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class TelnyxProvider(BaseOpenAIProvider):
-    API_BASE = "https://api.telnyx.com/v2/ai"
-    ENV_API_KEY_NAME = "TELNYX_API_KEY"
-    ENV_API_BASE_NAME = "TELNYX_API_BASE"
-    PROVIDER_NAME = "telnyx"
-    PROVIDER_DOCUMENTATION_URL = "https://developers.telnyx.com/docs/inference/getting-started"
+from any_llm.providers.registry import get_registry_provider_class
 
-    SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_EMBEDDING = False
+TelnyxProvider = get_registry_provider_class("telnyx")
+
+__all__ = ["TelnyxProvider"]

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,116 @@
+from collections.abc import Generator
+
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.constants import LLMProvider
+from any_llm.exceptions import UnsupportedProviderError
+from any_llm.providers import registry
+from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.providers.registry import (
+    OpenAICompatibleProviderConfig,
+    get_registry_config,
+    get_registry_provider_class,
+)
+
+
+@pytest.fixture
+def community_row(monkeypatch: pytest.MonkeyPatch) -> Generator[OpenAICompatibleProviderConfig, None, None]:
+    """Inject a registry row for a gateway that has no enum entry and no folder."""
+    config = OpenAICompatibleProviderConfig(
+        name="testgateway",
+        api_base="https://testgateway.example/v1",
+        env_api_key_name="TESTGATEWAY_API_KEY",
+        provider_documentation_url="https://testgateway.example/docs",
+    )
+    monkeypatch.setitem(registry.PROVIDER_REGISTRY, "testgateway", config)
+    yield config
+    registry._class_cache.pop("testgateway", None)
+
+
+def test_config_lookup_normalizes_name() -> None:
+    assert get_registry_config(" AtlasCloud ") is get_registry_config("atlascloud")
+
+
+def test_config_lookup_unknown_name_returns_none() -> None:
+    assert get_registry_config("not-registered") is None
+
+
+def test_provider_class_is_cached() -> None:
+    assert get_registry_provider_class("atlascloud") is get_registry_provider_class("atlascloud")
+
+
+def test_provider_class_unknown_name_raises() -> None:
+    with pytest.raises(KeyError):
+        get_registry_provider_class("not-registered")
+
+
+def test_loader_resolves_registry_row() -> None:
+    cls = AnyLLM.get_provider_class("atlascloud")
+    assert cls is get_registry_provider_class("atlascloud")
+    assert issubclass(cls, BaseOpenAIProvider)
+
+
+def test_loader_resolves_enum_member_via_registry() -> None:
+    assert AnyLLM.get_provider_class(LLMProvider.ATLASCLOUD) is get_registry_provider_class("atlascloud")
+
+
+def test_create_returns_registry_provider_instance() -> None:
+    provider = AnyLLM.create("atlascloud", api_key="test-key")
+    assert isinstance(provider, BaseOpenAIProvider)
+    assert provider.PROVIDER_NAME == "atlascloud"
+    assert str(provider.client.base_url).rstrip("/") == "https://api.atlascloud.ai/v1"
+
+
+def test_metadata_matches_row() -> None:
+    metadata = AnyLLM.get_provider_class("atlascloud").get_provider_metadata()
+    assert metadata.name == "atlascloud"
+    assert metadata.class_name == "AtlascloudProvider"
+    assert metadata.env_key == "ATLASCLOUD_API_KEY"
+    assert metadata.env_api_base == "ATLASCLOUD_API_BASE"
+    assert metadata.doc_url == "https://www.atlascloud.ai/docs"
+    assert metadata.reasoning
+    assert not metadata.image
+
+
+def test_migrated_provider_appears_in_all_provider_metadata() -> None:
+    all_metadata = AnyLLM.get_all_provider_metadata()
+    assert any(m.name == "atlascloud" for m in all_metadata)
+
+
+def test_registry_only_name_resolves_without_enum_entry(community_row: OpenAICompatibleProviderConfig) -> None:
+    provider = AnyLLM.create("testgateway", api_key="k")
+    assert isinstance(provider, BaseOpenAIProvider)
+    assert provider.PROVIDER_NAME == "testgateway"
+    assert str(provider.client.base_url).rstrip("/") == "https://testgateway.example/v1"
+    with pytest.raises(UnsupportedProviderError):
+        LLMProvider.from_string("testgateway")
+
+
+def test_row_defaults_are_conservative(community_row: OpenAICompatibleProviderConfig) -> None:
+    cls = get_registry_provider_class("testgateway")
+    assert cls.SUPPORTS_COMPLETION
+    assert cls.SUPPORTS_COMPLETION_STREAMING
+    assert cls.SUPPORTS_LIST_MODELS
+    assert not cls.SUPPORTS_COMPLETION_REASONING
+    assert not cls.SUPPORTS_COMPLETION_IMAGE
+    assert not cls.SUPPORTS_COMPLETION_PDF
+    assert not cls.SUPPORTS_EMBEDDING
+    assert not cls.SUPPORTS_MODERATION
+    assert not cls.SUPPORTS_RESPONSES
+    assert not cls.SUPPORTS_BATCH
+    assert not cls.SUPPORTS_IMAGE_GENERATION
+    assert not cls.SUPPORTS_RERANK
+
+
+def test_unregistered_name_still_raises_unsupported_provider() -> None:
+    with pytest.raises(UnsupportedProviderError):
+        AnyLLM.create("not-a-provider", api_key="k")
+
+
+def test_import_shim_returns_registry_class() -> None:
+    from any_llm.providers.atlascloud import AtlascloudProvider
+    from any_llm.providers.atlascloud.atlascloud import AtlascloudProvider as DeepAtlascloudProvider
+
+    assert AtlascloudProvider is get_registry_provider_class("atlascloud")
+    assert DeepAtlascloudProvider is AtlascloudProvider


### PR DESCRIPTION
## Description

Adds the config registry from the #1197 provider policy and migrates all config-only OpenAI-compatible providers to it: gateway providers become data rows instead of code folders.

```python
"atlascloud": OpenAICompatibleProviderConfig(
    name="atlascloud",
    api_base="https://api.atlascloud.ai/v1",
    env_api_key_name="ATLASCLOUD_API_KEY",
    env_api_base_name="ATLASCLOUD_API_BASE",
    provider_documentation_url="https://www.atlascloud.ai/docs",
    supports_completion_reasoning=True,
),
```

The loader (`AnyLLM._create_provider` and `AnyLLM.get_provider_class`) checks the registry before falling through to the existing folder-per-provider import convention. A row mints a cached `BaseOpenAIProvider` subclass whose class name follows the `{Name}Provider` convention, so `metadata.class_name` and class identity are stable across a migration.

Migrated providers (the full config-only set from #1197): atlascloud, dashscope, databricks, deepinfra, moonshot, mzai, nebius, neosantara, perplexity, qiniu, telnyx. Each folder shrinks to an import shim, and every existing per-provider unit test passes without modification, demonstrating the compatibility contract: `LLMProvider.<NAME>` enum entries, `AnyLLM.create("<name>")`, `<name>:model` strings, `get_provider_class` identity, metadata, env var resolution, and both deep-import paths all behave as before.

Design notes:

- **Rows replicate effective flags.** Each row carries the flags the folder class actually exposed, including values inherited from `BaseOpenAIProvider` defaults (for example moderation). Flag corrections are deliberately out of scope; migrations must be behavior-neutral.
- **`api_base` is optional in the row schema** for databricks, whose base URL only comes from `DATABRICKS_HOST` or an explicit argument, mirroring the folder class it replaces.
- **Community rows already route.** A registry name with no enum entry resolves through `AnyLLM.create(name)` and `get_provider_class(name)` (covered by tests using an injected row). `provider:model` string routing for registry-only names is deliberately not wired yet; `split_model_provider` returns `LLMProvider` and widening that type is its own change.
- **Conservative flag defaults for new rows.** Rows default to completion, streaming, and list_models only; everything else is opt-in per row. Capability flags are part of the row because `BaseOpenAIProvider` raises from the `SUPPORTS_*` attributes.
- **Zero-knob for now.** Any gateway needing custom auth, param remaps, or response translation keeps a code folder. Whether the registry grows one or two knobs to absorb the middle tier (~8 providers) stays an open question in #1197.

Follow-ups (tracked in #1197): two-tier docs listing, CONTRIBUTING acceptance rule, string routing plus docs presentation for community rows, and eventually retiring the import shims.

Testing:

- `pytest tests/unit`: 1570 passed, 92 skipped, including every migrated provider's existing test file unchanged (atlascloud, dashscope, databricks, deepinfra, moonshot, neosantara, perplexity, qiniu, telnyx; mzai and nebius had no test files)
- New `tests/unit/test_registry.py`: 13 tests (lookup normalization, class caching, loader precedence, enum and string resolution, metadata fidelity, community-row routing, conservative defaults, unknown-name errors, shim identity)
- `pytest tests/docs`: 4 passed
- `scripts/generate_provider_table.py` runs clean against the registry-backed metadata
- `pre-commit` (ruff, ruff-format, mypy strict, codespell) clean on changed files

## PR Type

- 🆕 New Feature

## Relevant issues

Part of #1197 (config registry and migration steps). Does not close the issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass local
