### PR TITLE
fix(gemini): map candidate.finish_reason to the OpenAI vocabulary

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -287,6 +287,46 @@ def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
     return None
 
 
+_FINISH_REASON_MAP: dict[types.FinishReason, Literal["stop", "length", "content_filter"]] = {
+    types.FinishReason.STOP: "stop",
+    types.FinishReason.MAX_TOKENS: "length",
+    types.FinishReason.SAFETY: "content_filter",
+    types.FinishReason.RECITATION: "content_filter",
+    types.FinishReason.PROHIBITED_CONTENT: "content_filter",
+    types.FinishReason.BLOCKLIST: "content_filter",
+    types.FinishReason.SPII: "content_filter",
+    types.FinishReason.IMAGE_SAFETY: "content_filter",
+    types.FinishReason.IMAGE_PROHIBITED_CONTENT: "content_filter",
+    types.FinishReason.IMAGE_RECITATION: "content_filter",
+}
+
+
+def _map_finish_reason(
+    finish_reason: types.FinishReason | None,
+) -> Literal["stop", "length", "content_filter"] | None:
+    """Map a Gemini finish reason onto the OpenAI vocabulary.
+
+    Returns None for reasons without an OpenAI counterpart so that each call site can
+    choose its own fallback: a terminal "stop" for complete responses, or None for
+    stream chunks, where forcing a terminal reason would mislabel non-final chunks.
+    """
+    return _FINISH_REASON_MAP.get(finish_reason) if finish_reason is not None else None
+
+
+def _resolve_finish_reason(
+    mapped_finish_reason: Literal["stop", "length", "content_filter"] | None,
+    has_tool_calls: bool,
+) -> Literal["stop", "length", "content_filter", "tool_calls"] | None:
+    """Combine the mapped finish reason with tool call presence.
+
+    Truncation and filtering take priority over "tool_calls": a response cut short mid
+    tool call must not look like a completed tool call round.
+    """
+    if has_tool_calls and mapped_finish_reason not in ("length", "content_filter"):
+        return "tool_calls"
+    return mapped_finish_reason
+
+
 def _convert_response_to_response_dict(response: types.GenerateContentResponse) -> dict[str, Any]:
     response_dict = {
         "id": "google_genai_response",
@@ -296,18 +336,16 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
     }
 
     choices: list[dict[str, Any]] = []
-    if (
-        response.candidates
-        and len(response.candidates) > 0
-        and response.candidates[0].content
-        and response.candidates[0].content.parts
-        and len(response.candidates[0].content.parts) > 0
-    ):
+    if response.candidates:
+        candidate = response.candidates[0]
+        mapped_finish_reason = _map_finish_reason(candidate.finish_reason)
+
         reasoning = None
         tool_calls_list: list[dict[str, Any]] = []
         text_content = None
+        parts = candidate.content.parts if candidate.content else None
 
-        for part in response.candidates[0].content.parts:
+        for part in parts or []:
             if getattr(part, "thought", None):
                 reasoning = part.text
             elif function_call := getattr(part, "function_call", None):
@@ -333,29 +371,19 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
             elif getattr(part, "text", None):
                 text_content = part.text
 
-        if tool_calls_list:
+        # Truncated or filtered responses produce a choice even without content or tool
+        # calls, e.g. a thinking model that spent the whole max_output_tokens budget on
+        # reasoning, so callers see the terminal reason instead of an empty choices list.
+        if tool_calls_list or text_content or mapped_finish_reason in ("length", "content_filter"):
             choices.append(
                 {
                     "message": {
                         "role": "assistant",
-                        "content": None,
+                        "content": None if tool_calls_list else text_content,
                         "reasoning": reasoning,
-                        "tool_calls": tool_calls_list,
+                        "tool_calls": tool_calls_list or None,
                     },
-                    "finish_reason": "tool_calls",
-                    "index": 0,
-                }
-            )
-        elif text_content:
-            choices.append(
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": text_content,
-                        "reasoning": reasoning,
-                        "tool_calls": None,
-                    },
-                    "finish_reason": "stop",
+                    "finish_reason": _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list)) or "stop",
                     "index": 0,
                 }
             )
@@ -407,8 +435,6 @@ def _create_openai_chunk_from_google_chunk(
 
     assert response.candidates
     candidate = response.candidates[0]
-    assert candidate.content
-    assert candidate.content.parts
 
     if tool_call_counter is None:
         tool_call_counter = [0]
@@ -417,7 +443,11 @@ def _create_openai_chunk_from_google_chunk(
     reasoning_content = ""
     tool_calls_list: list[ChoiceDeltaToolCall] = []
 
-    for part in candidate.content.parts:
+    # Content can be absent on terminal chunks, e.g. when the response is truncated or
+    # filtered before any part is produced; the finish reason must still be surfaced.
+    parts = candidate.content.parts if candidate.content else None
+
+    for part in parts or []:
         if part.thought:
             reasoning_content += part.text or ""
         elif function_call := part.function_call:
@@ -448,12 +478,8 @@ def _create_openai_chunk_from_google_chunk(
         elif part.text:
             content += part.text
 
-    # Determine finish_reason based on what we found
-    finish_reason: Literal["stop", "length", "tool_calls", "content_filter", "function_call"] | None = None
-    if tool_calls_list:
-        finish_reason = "tool_calls"
-    elif candidate.finish_reason and candidate.finish_reason.value == "STOP":
-        finish_reason = "stop"
+    # Unmapped reasons stay None so non-final chunks are not forced to a terminal reason.
+    finish_reason = _resolve_finish_reason(_map_finish_reason(candidate.finish_reason), bool(tool_calls_list))
 
     delta = ChoiceDelta(
         content=content or None,

--- a/tests/integration/test_finish_reason.py
+++ b/tests/integration/test_finish_reason.py
@@ -1,0 +1,36 @@
+"""Integration test for issue #1196: Gemini truncation must surface as LengthFinishReasonError.
+
+A small ``max_tokens`` budget forces Gemini to stop mid-generation with
+``finishReason=MAX_TOKENS``. With a pydantic ``response_format`` this must raise
+``LengthFinishReasonError`` so callers can retry with a larger budget, instead of a
+misleading malformed-JSON ``ValidationError`` from parsing the truncated output.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from any_llm import AnyLLM, LLMProvider
+from any_llm.exceptions import LengthFinishReasonError, MissingApiKeyError
+
+
+class Assessment(BaseModel):
+    explanation: str
+    result: bool
+
+
+@pytest.mark.asyncio
+async def test_gemini_truncated_structured_output_raises_length_error(
+    provider_model_map: dict[LLMProvider, str],
+) -> None:
+    try:
+        llm = AnyLLM.create(LLMProvider.GEMINI)
+    except MissingApiKeyError:
+        pytest.skip("Gemini API key not provided, skipping")
+
+    with pytest.raises(LengthFinishReasonError):
+        await llm.acompletion(
+            model=provider_model_map[LLMProvider.GEMINI],
+            messages=[{"role": "user", "content": "Assess: water is wet. Explain in great detail."}],
+            response_format=Assessment,
+            max_tokens=20,
+        )

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -6,8 +6,14 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from google.genai import types
+from pydantic import BaseModel
 
-from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
+from any_llm.exceptions import (
+    ContentFilterFinishReasonError,
+    InvalidRequestError,
+    LengthFinishReasonError,
+    UnsupportedParameterError,
+)
 from any_llm.providers.gemini import GeminiProvider
 from any_llm.providers.gemini.base import REASONING_EFFORT_TO_THINKING_BUDGETS, GoogleProvider
 from any_llm.providers.gemini.utils import (
@@ -15,11 +21,29 @@ from any_llm.providers.gemini.utils import (
     _convert_response_to_response_dict,
     _convert_tool_spec,
     _create_openai_chunk_from_google_chunk,
+    _map_finish_reason,
 )
 from any_llm.types.completion import ChatCompletion, CompletionParams, PromptTokensDetails, ReasoningEffort
 
 TEST_IMAGE_BYTES = b"test-image-bytes"
 TEST_PDF_BYTES = b"%PDF-1.4\ntest"
+
+
+class StructuredAnswer(BaseModel):
+    answer: str
+
+
+def _make_gemini_response(
+    parts: list[types.Part] | None, finish_reason: types.FinishReason | None
+) -> types.GenerateContentResponse:
+    return types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(parts=parts, role="model") if parts is not None else None,
+                finish_reason=finish_reason,
+            )
+        ]
+    )
 
 
 @contextmanager
@@ -625,6 +649,104 @@ def test_convert_response_multiple_parallel_tool_calls() -> None:
     assert len(set(tool_call_ids)) == 3
 
 
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "expected_mapped_reason"),
+    [
+        (types.FinishReason.STOP, "stop"),
+        (types.FinishReason.MAX_TOKENS, "length"),
+        (types.FinishReason.SAFETY, "content_filter"),
+        (types.FinishReason.RECITATION, "content_filter"),
+        (types.FinishReason.PROHIBITED_CONTENT, "content_filter"),
+        (types.FinishReason.BLOCKLIST, "content_filter"),
+        (types.FinishReason.SPII, "content_filter"),
+        (types.FinishReason.IMAGE_SAFETY, "content_filter"),
+        (types.FinishReason.IMAGE_PROHIBITED_CONTENT, "content_filter"),
+        (types.FinishReason.IMAGE_RECITATION, "content_filter"),
+        (types.FinishReason.OTHER, None),
+        (None, None),
+    ],
+)
+def test_map_finish_reason(gemini_finish_reason: types.FinishReason | None, expected_mapped_reason: str | None) -> None:
+    assert _map_finish_reason(gemini_finish_reason) == expected_mapped_reason
+
+
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "expected_finish_reason"),
+    [
+        (types.FinishReason.STOP, "stop"),
+        (types.FinishReason.MAX_TOKENS, "length"),
+        (types.FinishReason.SAFETY, "content_filter"),
+        (types.FinishReason.OTHER, "stop"),
+        (None, "stop"),
+    ],
+)
+def test_convert_response_maps_finish_reason(
+    gemini_finish_reason: types.FinishReason | None, expected_finish_reason: str
+) -> None:
+    response = _make_gemini_response([types.Part(text="Hello")], gemini_finish_reason)
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    assert len(response_dict["choices"]) == 1
+    choice = response_dict["choices"][0]
+    assert choice["finish_reason"] == expected_finish_reason
+    assert choice["message"]["content"] == "Hello"
+
+
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "expected_finish_reason"),
+    [
+        (types.FinishReason.MAX_TOKENS, "length"),
+        (types.FinishReason.SAFETY, "content_filter"),
+        (types.FinishReason.STOP, "tool_calls"),
+        (None, "tool_calls"),
+    ],
+)
+def test_convert_response_truncation_and_filtering_override_tool_calls(
+    gemini_finish_reason: types.FinishReason | None, expected_finish_reason: str
+) -> None:
+    response = _make_gemini_response(
+        [types.Part(function_call=types.FunctionCall(name="search_web", args={"query": "test"}))],
+        gemini_finish_reason,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    assert len(response_dict["choices"]) == 1
+    choice = response_dict["choices"][0]
+    assert choice["finish_reason"] == expected_finish_reason
+    assert len(choice["message"]["tool_calls"]) == 1
+
+
+def test_convert_response_emits_choice_for_reasoning_only_truncation() -> None:
+    """A thinking model can spend the whole max_output_tokens budget on reasoning; the terminal
+    reason must still be visible to callers instead of an empty choices list."""
+    response = _make_gemini_response([types.Part(text="internal reasoning", thought=True)], types.FinishReason.MAX_TOKENS)
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    assert len(response_dict["choices"]) == 1
+    choice = response_dict["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] is None
+    assert choice["message"]["reasoning"] == "internal reasoning"
+
+
+def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
+    response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
+
+    assert len(response_dict["choices"]) == 1
+    choice = response_dict["choices"][0]
+    assert choice["finish_reason"] == "content_filter"
+    assert choice["message"]["content"] is None
+
+
+def test_convert_response_without_content_and_terminal_reason_has_no_choices() -> None:
+    response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.STOP))
+
+    assert response_dict["choices"] == []
+
+
 def test_convert_tool_spec_basic_mapping() -> None:
     openai_tools = [
         {
@@ -821,8 +943,7 @@ async def test_streaming_completion_includes_usage_data() -> None:
     mock_response.candidates[0].content.parts[0].text = "Hello"
     mock_response.candidates[0].content.parts[0].thought = None
     mock_response.candidates[0].content.parts[0].function_call = None
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
 
     mock_response.usage_metadata = Mock()
@@ -881,8 +1002,7 @@ def test_streaming_completion_with_tool_call() -> None:
     mock_part.text = None
 
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -916,8 +1036,7 @@ def test_streaming_completion_with_tool_call_preserves_thought_signature() -> No
     mock_part.thought_signature = original_bytes
 
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -948,8 +1067,7 @@ def test_streaming_completion_with_tool_call_no_thought_signature() -> None:
     mock_part.thought_signature = None
 
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -987,8 +1105,7 @@ def test_streaming_completion_with_multiple_tool_calls() -> None:
     mock_part_2.text = None
 
     mock_response.candidates[0].content.parts = [mock_part_1, mock_part_2]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -1017,8 +1134,7 @@ def _make_single_tool_call_chunk(name: str, args: dict[str, Any]) -> Mock:
     mock_part.text = None
 
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
     return mock_response
@@ -1087,8 +1203,7 @@ def test_streaming_completion_multiple_tool_calls_within_chunk_after_prior_chunk
     mock_part_2.text = None
 
     mock_response.candidates[0].content.parts = [mock_part_1, mock_part_2]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -1528,8 +1643,7 @@ def test_streaming_completion_with_reasoning_content() -> None:
     mock_text_part.function_call = None
 
     mock_response.candidates[0].content.parts = [mock_thought_part, mock_text_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -1555,8 +1669,7 @@ def test_streaming_completion_with_function_call_none() -> None:
     mock_part.text = "Just text content"
 
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
     mock_response.usage_metadata = None
 
@@ -1628,8 +1741,7 @@ def test_streaming_chunk_extracts_cached_tokens() -> None:
     mock_part.function_call = None
     mock_part.text = "Hello!"
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
 
     mock_response.usage_metadata = Mock()
@@ -1658,8 +1770,7 @@ def test_streaming_chunk_without_cached_tokens() -> None:
     mock_part.function_call = None
     mock_part.text = "Hello!"
     mock_response.candidates[0].content.parts = [mock_part]
-    mock_response.candidates[0].finish_reason = Mock()
-    mock_response.candidates[0].finish_reason.value = "STOP"
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-2.5-flash"
 
     mock_response.usage_metadata = Mock()
@@ -1816,3 +1927,86 @@ def test_timeout_in_client_args_does_not_override_explicit_http_options() -> Non
         mock_client.assert_called_once()
         call_kwargs = mock_client.call_args[1]
         assert call_kwargs["http_options"].timeout == 10_000
+
+
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "expected_finish_reason"),
+    [
+        (types.FinishReason.STOP, "stop"),
+        (types.FinishReason.MAX_TOKENS, "length"),
+        (types.FinishReason.SAFETY, "content_filter"),
+        (types.FinishReason.OTHER, None),
+        (None, None),
+    ],
+)
+def test_streaming_chunk_maps_finish_reason(
+    gemini_finish_reason: types.FinishReason | None, expected_finish_reason: str | None
+) -> None:
+    chunk = _create_openai_chunk_from_google_chunk(_make_gemini_response([types.Part(text="Hello")], gemini_finish_reason))
+
+    assert chunk.choices[0].finish_reason == expected_finish_reason
+    assert chunk.choices[0].delta.content == "Hello"
+
+
+def test_streaming_chunk_emits_finish_reason_for_filtered_chunk_without_content() -> None:
+    chunk = _create_openai_chunk_from_google_chunk(_make_gemini_response(None, types.FinishReason.SAFETY))
+
+    assert chunk.choices[0].finish_reason == "content_filter"
+    assert chunk.choices[0].delta.content is None
+
+
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "expected_finish_reason"),
+    [
+        (types.FinishReason.MAX_TOKENS, "length"),
+        (types.FinishReason.SAFETY, "content_filter"),
+        (types.FinishReason.STOP, "tool_calls"),
+        (None, "tool_calls"),
+    ],
+)
+def test_streaming_chunk_truncation_and_filtering_override_tool_calls(
+    gemini_finish_reason: types.FinishReason | None, expected_finish_reason: str
+) -> None:
+    response = _make_gemini_response(
+        [types.Part(function_call=types.FunctionCall(name="search_web", args={"query": "test"}))],
+        gemini_finish_reason,
+    )
+
+    chunk = _create_openai_chunk_from_google_chunk(response)
+
+    assert chunk.choices[0].finish_reason == expected_finish_reason
+    assert chunk.choices[0].delta.tool_calls is not None
+
+
+@pytest.mark.asyncio
+async def test_acompletion_raises_length_error_for_truncated_structured_output() -> None:
+    """Regression test for #1196: Gemini truncation must raise LengthFinishReasonError instead of
+    surfacing as a malformed JSON ValidationError from structured output parsing."""
+    truncated_response = _make_gemini_response([types.Part(text='{"answer": "trunca')], types.FinishReason.MAX_TOKENS)
+
+    with patch("any_llm.providers.gemini.gemini.genai.Client") as mock_genai:
+        mock_genai.return_value.aio.models.generate_content = AsyncMock(return_value=truncated_response)
+        provider = GeminiProvider(api_key="test-api-key")
+
+        with pytest.raises(LengthFinishReasonError):
+            await provider.acompletion(
+                model="gemini-2.5-flash",
+                messages=[{"role": "user", "content": "Hello"}],
+                response_format=StructuredAnswer,
+            )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_raises_content_filter_error_for_filtered_structured_output() -> None:
+    filtered_response = _make_gemini_response(None, types.FinishReason.SAFETY)
+
+    with patch("any_llm.providers.gemini.gemini.genai.Client") as mock_genai:
+        mock_genai.return_value.aio.models.generate_content = AsyncMock(return_value=filtered_response)
+        provider = GeminiProvider(api_key="test-api-key")
+
+        with pytest.raises(ContentFilterFinishReasonError):
+            await provider.acompletion(
+                model="gemini-2.5-flash",
+                messages=[{"role": "user", "content": "Hello"}],
+                response_format=StructuredAnswer,
+            )

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -721,7 +721,9 @@ def test_convert_response_truncation_and_filtering_override_tool_calls(
 def test_convert_response_emits_choice_for_reasoning_only_truncation() -> None:
     """A thinking model can spend the whole max_output_tokens budget on reasoning; the terminal
     reason must still be visible to callers instead of an empty choices list."""
-    response = _make_gemini_response([types.Part(text="internal reasoning", thought=True)], types.FinishReason.MAX_TOKENS)
+    response = _make_gemini_response(
+        [types.Part(text="internal reasoning", thought=True)], types.FinishReason.MAX_TOKENS
+    )
 
     response_dict = _convert_response_to_response_dict(response)
 
@@ -1942,7 +1944,9 @@ def test_timeout_in_client_args_does_not_override_explicit_http_options() -> Non
 def test_streaming_chunk_maps_finish_reason(
     gemini_finish_reason: types.FinishReason | None, expected_finish_reason: str | None
 ) -> None:
-    chunk = _create_openai_chunk_from_google_chunk(_make_gemini_response([types.Part(text="Hello")], gemini_finish_reason))
+    chunk = _create_openai_chunk_from_google_chunk(
+        _make_gemini_response([types.Part(text="Hello")], gemini_finish_reason)
+    )
 
     assert chunk.choices[0].finish_reason == expected_finish_reason
     assert chunk.choices[0].delta.content == "Hello"


### PR DESCRIPTION
## Description

The Gemini converters discarded `candidate.finish_reason`: the non-streaming path hardcoded `"tool_calls"`/`"stop"`, and the streaming path only special-cased `STOP`. As a result the #881 exceptions (`LengthFinishReasonError`, `ContentFilterFinishReasonError`) could never fire for Gemini, and truncated structured output surfaced as a misleading malformed-JSON `ValidationError` (see #1196 for a production repro).

Following the approach endorsed in the issue comments:

- **Both converters** now map `candidate.finish_reason` via a shared `_map_finish_reason` helper: `MAX_TOKENS -> "length"`; `SAFETY`, `RECITATION`, `PROHIBITED_CONTENT`, `BLOCKLIST`, `SPII`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `IMAGE_RECITATION` -> `"content_filter"`; `STOP -> "stop"`. Unmapped reasons fall back to `"stop"` for complete responses and stay `None` for stream chunks, so non-terminal chunks are not forced to a terminal reason.
- **Truncation/filtering take priority over `"tool_calls"`** in both paths (shared `_resolve_finish_reason` helper), so a response cut short mid tool call does not look like a completed tool-call round.
- **A choice is emitted even when Gemini returns no content** (e.g. a thinking model spends the whole `max_output_tokens` budget on reasoning), so the #881 guard fires instead of returning empty `choices`. The streaming converter previously `assert`ed on `candidate.content`, so the same empty-content terminal chunk would have crashed there; it now handles it too.
- `vertexai` inherits both converters from `GoogleProvider`, so it picks up the fix automatically.

**Tests:**
- End-to-end regressions through `acompletion` with a pydantic `response_format` asserting `LengthFinishReasonError` and `ContentFilterFinishReasonError` (mocked client, `tests/unit`).
- Converter-level unit tests: exhaustive mapping table for `_map_finish_reason`, representative rows through both converters, the tool-call priority rule, and the empty-content edge cases.
- A real-API integration test (`tests/integration/test_finish_reason.py`) reproducing the issue: small `max_tokens` + pydantic `response_format` must raise `LengthFinishReasonError`. Verified it fails on `main` (malformed-JSON `ValidationError`, 6/6 attempts) and passes with the fix. A live `ContentFilterFinishReasonError` test was deliberately left out: reliably tripping Gemini's safety filter requires keeping prohibited content in the repo and is inherently flaky as Google tunes the filters, so that path is covered at the unit level.

Ran locally: `pre-commit run --all-files` clean, `pytest tests/unit` green (1603 passed), and the full Gemini integration suite with a real key (25 passed, 5 pre-existing "gemini does not support responses" skips).

@njbrake pinging you as offered in the issue, review welcome!

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1196

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Fable 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Implementation, tests, and this PR text were AI-generated under human direction and review; the integration test was validated against the real Gemini API in both directions (fails on main, passes with the fix).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini finish-reason handling for truncation, content filtering, tool calls and normal completion.
  * Preserved response choices when truncated or filtered responses contain no text or tool calls.
  * Structured outputs now raise the appropriate length or content-filter error instead of a parsing error.
  * Improved reliability of streaming responses when terminal content is missing.

* **Tests**
  * Added coverage for Gemini finish-reason mappings, streaming responses and structured-output error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->