### PR TITLE
fix(otari): map OTARI_API_KEY to the hosted-platform bearer token

### DIFF
--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -71,8 +71,9 @@ except ImportError as e:  # pragma: no cover - exercised through MISSING_PACKAGE
     _MISSING_PACKAGES_ERROR = e
 
 
-# Canonical platform-token env var exposed by otari 0.1.0; the others are kept as
-# legacy aliases for backwards compatibility.
+# Platform-token env vars, sent as Authorization: Bearer to otari's hosted gateway. otari.ai
+# documents OTARI_API_KEY (ENV_API_KEY_NAME) as this token, so it is the primary source; the
+# others are accepted aliases. The self-hosted virtual-key path uses GATEWAY_API_KEY (Otari-Key).
 OTARI_AI_TOKEN_ENV = "OTARI_AI_TOKEN"  # noqa: S105
 OTARI_PLATFORM_TOKEN_ENV = "OTARI_PLATFORM_TOKEN"  # noqa: S105
 GATEWAY_PLATFORM_TOKEN_ENV = "GATEWAY_PLATFORM_TOKEN"  # noqa: S105
@@ -179,14 +180,17 @@ class OtariProvider(BaseOpenAIProvider):
     def _resolve_env_api_base(cls) -> str | None:
         return os.getenv(cls.ENV_API_BASE_NAME) or os.getenv(LEGACY_GATEWAY_API_BASE_ENV)
 
-    @classmethod
-    def _resolve_env_api_key(cls) -> str | None:
-        return os.getenv(cls.ENV_API_KEY_NAME) or os.getenv(LEGACY_GATEWAY_API_KEY_ENV)
-
     @staticmethod
-    def _resolve_platform_token() -> str | None:
+    def _resolve_gateway_api_key() -> str | None:
+        """Resolve the self-hosted gateway virtual key (Otari-Key header)."""
+        return os.getenv(LEGACY_GATEWAY_API_KEY_ENV)
+
+    @classmethod
+    def _resolve_platform_token(cls) -> str | None:
+        """Return the hosted-platform bearer token (primarily OTARI_API_KEY), or None if unset."""
         return (
-            os.getenv(OTARI_AI_TOKEN_ENV)
+            os.getenv(cls.ENV_API_KEY_NAME)
+            or os.getenv(OTARI_AI_TOKEN_ENV)
             or os.getenv(OTARI_PLATFORM_TOKEN_ENV)
             or os.getenv(GATEWAY_PLATFORM_TOKEN_ENV)
         )
@@ -199,7 +203,10 @@ class OtariProvider(BaseOpenAIProvider):
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str:
-        return api_key or self._resolve_env_api_key() or "no-key-required"
+        # Capture only the explicit key; env credentials (platform token or self-hosted gateway
+        # key) are resolved in _init_client. otari allows keyless self-hosted access, so a missing
+        # key is not an error here.
+        return api_key or "no-key-required"
 
     @staticmethod
     def _normalize_placeholder_api_key(api_key: str | None) -> str | None:
@@ -211,36 +218,39 @@ class OtariProvider(BaseOpenAIProvider):
         default_headers = kwargs.pop("default_headers", None)
 
         resolved_api_base = self._resolve_api_base(api_base)
-        normalized_api_key = self._normalize_placeholder_api_key(api_key)
-        resolved_api_key = normalized_api_key or self._resolve_env_api_key()
+        explicit_api_key = self._normalize_placeholder_api_key(api_key)
         resolved_platform_token = self._resolve_platform_token()
+        resolved_gateway_key = self._resolve_gateway_api_key()
 
         client_kwargs: dict[str, Any] = {"default_headers": default_headers}
         if resolved_api_base:
             client_kwargs["api_base"] = resolved_api_base
 
-        # Track whether the client will authenticate with a platform token. otari
-        # defaults api_base to the hosted gateway in that case, so api_base is optional.
+        # The generic credential (explicit api_key param or OTARI_API_KEY) is otari.ai's platform
+        # token (Authorization: Bearer). In auto mode it routes to platform mode, where otari
+        # defaults api_base to its hosted gateway, so api_base is optional. The self-hosted
+        # virtual-key path (Otari-Key header) is reached via GATEWAY_API_KEY or platform_mode=False.
         using_platform_token = False
         if platform_mode is True:
-            token = normalized_api_key or resolved_platform_token
+            token = explicit_api_key or resolved_platform_token
             if not token:
                 msg = (
                     "Platform mode requires a user token (pass api_key or set "
-                    f"{OTARI_AI_TOKEN_ENV}/{OTARI_PLATFORM_TOKEN_ENV}/{GATEWAY_PLATFORM_TOKEN_ENV})"
+                    f"{self.ENV_API_KEY_NAME}/{OTARI_AI_TOKEN_ENV})"
                 )
                 raise ValueError(msg)
             client_kwargs["platform_token"] = token
             using_platform_token = True
         elif platform_mode is False:
-            client_kwargs["api_key"] = resolved_api_key
-        elif normalized_api_key:
-            client_kwargs["api_key"] = normalized_api_key
+            client_kwargs["api_key"] = explicit_api_key or resolved_gateway_key
+        elif explicit_api_key:
+            client_kwargs["platform_token"] = explicit_api_key
+            using_platform_token = True
         elif resolved_platform_token:
             client_kwargs["platform_token"] = resolved_platform_token
             using_platform_token = True
-        elif resolved_api_key:
-            client_kwargs["api_key"] = resolved_api_key
+        elif resolved_gateway_key:
+            client_kwargs["api_key"] = resolved_gateway_key
 
         if not resolved_api_base and not using_platform_token:
             msg = (

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -108,41 +108,85 @@ def test_parse_jsonl_to_requests_skips_blank_lines() -> None:
     assert requests == [{"custom_id": "r1", "body": {"model": "gpt-4"}}]
 
 
-@patch.dict(
-    "os.environ",
-    {
-        "OTARI_API_BASE": "https://otari.example.com",
-        "OTARI_API_KEY": "resolved-api-key",
-        "OTARI_PLATFORM_TOKEN": "platform-token",
-    },
-    clear=False,
-)
-def test_otari_auto_mode_prefers_explicit_api_key_over_platform_token() -> None:
-    with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
-        mock_otari_client.return_value = _mock_otari_client()
-        OtariProvider(api_key="explicit-key")
-
-    call_kwargs = mock_otari_client.call_args.kwargs
-    assert call_kwargs["api_key"] == "explicit-key"
-    assert "platform_token" not in call_kwargs
+# Every otari auth env var, blanked. Spread into a test's patch.dict and override only the
+# vars under test, so an ambient OTARI_AI_TOKEN (set in CI) can't leak into auth resolution.
+_OTARI_ENV_CLEARED = {
+    "OTARI_API_KEY": "",
+    "OTARI_AI_TOKEN": "",
+    "OTARI_PLATFORM_TOKEN": "",
+    "GATEWAY_PLATFORM_TOKEN": "",
+    "GATEWAY_API_KEY": "",
+    "OTARI_API_BASE": "",
+    "GATEWAY_API_BASE": "",
+}
 
 
-@patch.dict(
-    "os.environ",
-    {
-        "OTARI_API_BASE": "https://otari.example.com",
-        "OTARI_API_KEY": "resolved-api-key",
-        "OTARI_PLATFORM_TOKEN": "",
-    },
-    clear=False,
-)
-def test_otari_auto_mode_uses_resolved_api_key_when_no_platform_token() -> None:
+@patch.dict("os.environ", {**_OTARI_ENV_CLEARED, "OTARI_API_KEY": "tk_platform"}, clear=False)
+def test_otari_api_key_env_maps_to_platform_token_without_base() -> None:
+    """OTARI_API_KEY is otari.ai's documented platform token (Authorization: Bearer), so it
+    routes to platform mode and needs no api_base (otari defaults to its hosted gateway).
+    This is the otari.ai quickstart path."""
     with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
         mock_otari_client.return_value = _mock_otari_client()
         OtariProvider()
 
     call_kwargs = mock_otari_client.call_args.kwargs
-    assert call_kwargs["api_key"] == "resolved-api-key"
+    assert call_kwargs["platform_token"] == "tk_platform"  # noqa: S105
+    assert "api_key" not in call_kwargs
+    assert "api_base" not in call_kwargs
+
+
+@patch.dict("os.environ", {**_OTARI_ENV_CLEARED, "OTARI_PLATFORM_TOKEN": "env-platform"}, clear=False)
+def test_otari_explicit_api_key_param_maps_to_platform_token() -> None:
+    """An explicit api_key= param is the platform token too, and takes precedence over an
+    env platform-token alias."""
+    with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
+        mock_otari_client.return_value = _mock_otari_client()
+        OtariProvider(api_key="tk_explicit")
+
+    call_kwargs = mock_otari_client.call_args.kwargs
+    assert call_kwargs["platform_token"] == "tk_explicit"  # noqa: S105
+    assert "api_key" not in call_kwargs
+
+
+@patch.dict(
+    "os.environ",
+    {**_OTARI_ENV_CLEARED, "GATEWAY_API_KEY": "gw-self", "GATEWAY_API_BASE": "https://self.example.com"},
+    clear=False,
+)
+def test_otari_gateway_api_key_env_maps_to_self_hosted_api_key() -> None:
+    """GATEWAY_API_KEY is the self-hosted virtual key (Otari-Key header), distinct from the
+    platform token; it routes to the api_key slot alongside its required base."""
+    with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
+        mock_otari_client.return_value = _mock_otari_client()
+        OtariProvider()
+
+    call_kwargs = mock_otari_client.call_args.kwargs
+    assert call_kwargs["api_key"] == "gw-self"
+    assert "platform_token" not in call_kwargs
+    assert call_kwargs["api_base"] == "https://self.example.com"
+
+
+@patch.dict("os.environ", {**_OTARI_ENV_CLEARED, "OTARI_API_KEY": "tk_platform"}, clear=False)
+def test_otari_platform_mode_false_routes_key_to_self_hosted_slot() -> None:
+    """platform_mode=False forces the self-hosted path: the explicit key goes to the
+    Otari-Key api_key slot, not the platform token."""
+    with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
+        mock_otari_client.return_value = _mock_otari_client()
+        OtariProvider(api_key="gw-key", api_base="https://self.example.com", platform_mode=False)
+
+    call_kwargs = mock_otari_client.call_args.kwargs
+    assert call_kwargs["api_key"] == "gw-key"
+    assert "platform_token" not in call_kwargs
+
+
+@patch.dict("os.environ", {**_OTARI_ENV_CLEARED, "GATEWAY_API_KEY": "gw-self"}, clear=False)
+def test_otari_self_hosted_key_without_base_raises() -> None:
+    """A self-hosted gateway key with no base and no platform token still requires api_base."""
+    with patch("any_llm.providers.otari.otari.AsyncOtariClient") as mock_otari_client:
+        mock_otari_client.return_value = _mock_otari_client()
+        with pytest.raises(ValueError, match="api_base is required"):
+            OtariProvider()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`OTARI_API_KEY` is a name any-llm invented (`ENV_API_KEY_NAME`); the otari SDK never reads it. any-llm wired it to the SDK's self-hosted slot (`Otari-Key` header, which requires an `api_base`). A user following otari.ai's quickstart sets `OTARI_API_KEY=tk_…` for the hosted gateway (`Authorization: Bearer`, default `https://api.otari.ai/v1`), so any-llm raised "api_base is required" and they had to fall back to `OTARI_AI_TOKEN`.

This resolves `OTARI_API_KEY` (and the generic `api_key=` param) as the platform token, matching otari.ai's documented onboarding. The self-hosted virtual-key path now uses the SDK-native `GATEWAY_API_KEY` (+ `GATEWAY_API_BASE`) or `platform_mode=False`. `OTARI_AI_TOKEN` (the CI/integration path) is unchanged.

| Set this | otari mode | Header | Base |
|---|---|---|---|
| `OTARI_API_KEY` / `api_key=` param | platform | `Authorization: Bearer` | defaults to `api.otari.ai` |
| `OTARI_AI_TOKEN` / legacy aliases | platform | `Authorization: Bearer` | same |
| `GATEWAY_API_KEY` (+base) or `platform_mode=False` | self-hosted | `Otari-Key` | required |

**Breaking:** `OTARI_API_KEY` used for a self-hosted gateway now authenticates via `Authorization: Bearer` instead of the `Otari-Key` header; use `GATEWAY_API_KEY` for self-hosted access.

## PR Type

- 🐛 Bug Fix

## Relevant issues

N/A

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Root-caused against the otari SDK 0.2.0 source and the otari.ai quickstart, implemented via TDD (failing test reproducing the "api_base is required" symptom, then the fix).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Otari authentication handling across hosted and self-hosted configurations.
  * Explicit API keys now take precedence over configured platform-token aliases.
  * Self-hosted gateway credentials are correctly routed and validated.
  * Added clearer error handling when a gateway URL is missing.

* **Documentation**
  * Clarified environment-variable documentation for hosted-platform bearer tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->