### PR TITLE
fix(ollama): map output token limits

### DIFF
--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -84,6 +84,15 @@ class OllamaProvider(AnyLLM):
         elif params.reasoning_effort is not None and params.reasoning_effort != "auto":
             converted_params["think"] = REASONING_EFFORT_TO_OLLAMA_THINK[params.reasoning_effort]
         converted_params.update(kwargs)
+
+        max_tokens = converted_params.pop("max_tokens", None)
+        max_completion_tokens = converted_params.pop("max_completion_tokens", None)
+        if converted_params.get("num_predict") is None:
+            if max_completion_tokens is not None:
+                converted_params["num_predict"] = max_completion_tokens
+            elif max_tokens is not None:
+                converted_params["num_predict"] = max_tokens
+
         converted_params["num_ctx"] = converted_params.get("num_ctx", 32000)
         return converted_params
 

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
+from any_llm.logging import logger
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
@@ -87,6 +88,12 @@ class OllamaProvider(AnyLLM):
 
         max_tokens = converted_params.pop("max_tokens", None)
         max_completion_tokens = converted_params.pop("max_completion_tokens", None)
+        if max_tokens is not None and max_completion_tokens is not None:
+            logger.warning(
+                "Ignoring max_tokens (%s) in favor of max_completion_tokens (%s).",
+                max_tokens,
+                max_completion_tokens,
+            )
         if converted_params.get("num_predict") is None:
             if max_completion_tokens is not None:
                 converted_params["num_predict"] = max_completion_tokens

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -88,17 +88,24 @@ class OllamaProvider(AnyLLM):
 
         max_tokens = converted_params.pop("max_tokens", None)
         max_completion_tokens = converted_params.pop("max_completion_tokens", None)
-        if max_tokens is not None and max_completion_tokens is not None:
-            logger.warning(
-                "Ignoring max_tokens (%s) in favor of max_completion_tokens (%s).",
-                max_tokens,
-                max_completion_tokens,
-            )
-        if converted_params.get("num_predict") is None:
-            if max_completion_tokens is not None:
-                converted_params["num_predict"] = max_completion_tokens
-            elif max_tokens is not None:
-                converted_params["num_predict"] = max_tokens
+        requested_max_tokens = max_completion_tokens if max_completion_tokens is not None else max_tokens
+        explicit_num_predict = converted_params.get("num_predict")
+        if explicit_num_predict is not None:
+            if requested_max_tokens is not None:
+                logger.warning(
+                    "Ignoring the requested output token limit (%s) because num_predict (%s) is set.",
+                    requested_max_tokens,
+                    explicit_num_predict,
+                )
+        else:
+            if max_tokens is not None and max_completion_tokens is not None:
+                logger.warning(
+                    "Ignoring max_tokens (%s) in favor of max_completion_tokens (%s).",
+                    max_tokens,
+                    max_completion_tokens,
+                )
+            if requested_max_tokens is not None:
+                converted_params["num_predict"] = requested_max_tokens
 
         converted_params["num_ctx"] = converted_params.get("num_ctx", 32000)
         return converted_params

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -12,6 +12,56 @@ from any_llm.types.completion import CompletionParams
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    ("max_tokens", "max_completion_tokens", "num_predict", "expected_num_predict"),
+    [
+        (101, None, None, 101),
+        (101, 202, None, 202),
+        (101, 202, 303, 303),
+    ],
+)
+async def test_completion_converts_output_token_limits_to_num_predict(
+    stream: bool,
+    max_tokens: int,
+    max_completion_tokens: int | None,
+    num_predict: int | None,
+    expected_num_predict: int,
+) -> None:
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    provider_kwargs = {} if num_predict is None else {"num_predict": num_predict}
+    params = CompletionParams(
+        model_id="llama3.1",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=max_tokens,
+        max_completion_tokens=max_completion_tokens,
+        stream=stream,
+    )
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter() if stream else Mock())
+
+        if stream:
+            result = await provider._acompletion(params, **provider_kwargs)
+            async for _ in result:  # type: ignore[union-attr]
+                pass
+        else:
+            with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+                await provider._acompletion(params, **provider_kwargs)
+
+        options = provider.client.chat.call_args.kwargs["options"]
+
+    assert options["num_predict"] == expected_num_predict
+    assert "max_tokens" not in options
+    assert "max_completion_tokens" not in options
+
+
+@pytest.mark.asyncio
 async def test_create_chat_completion_extracts_think_content() -> None:
     """Test that <think> content is correctly extracted into reasoning field."""
     # Create a mock Ollama response with <think> tags in content

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -16,17 +17,19 @@ from any_llm.types.completion import CompletionParams
 @pytest.mark.parametrize(
     ("max_tokens", "max_completion_tokens", "num_predict", "expected_num_predict"),
     [
+        (None, None, None, None),
         (101, None, None, 101),
+        (None, 202, None, 202),
         (101, 202, None, 202),
         (101, 202, 303, 303),
     ],
 )
 async def test_completion_converts_output_token_limits_to_num_predict(
     stream: bool,
-    max_tokens: int,
+    max_tokens: int | None,
     max_completion_tokens: int | None,
     num_predict: int | None,
-    expected_num_predict: int,
+    expected_num_predict: int | None,
 ) -> None:
     async def empty_async_iter() -> AsyncIterator[None]:
         return
@@ -56,9 +59,46 @@ async def test_completion_converts_output_token_limits_to_num_predict(
 
         options = provider.client.chat.call_args.kwargs["options"]
 
-    assert options["num_predict"] == expected_num_predict
+    if expected_num_predict is None:
+        assert "num_predict" not in options
+    else:
+        assert options["num_predict"] == expected_num_predict
     assert "max_tokens" not in options
     assert "max_completion_tokens" not in options
+
+
+@pytest.mark.parametrize(
+    ("max_tokens", "max_completion_tokens", "expect_warning"),
+    [
+        (101, 202, True),
+        (101, None, False),
+        (None, 202, False),
+    ],
+)
+def test_convert_completion_params_warns_when_both_token_limits_are_set(
+    max_tokens: int | None,
+    max_completion_tokens: int | None,
+    expect_warning: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    params = CompletionParams(
+        model_id="llama3.1",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=max_tokens,
+        max_completion_tokens=max_completion_tokens,
+    )
+
+    any_llm_logger = logging.getLogger("any_llm")
+    any_llm_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            result = OllamaProvider._convert_completion_params(params)
+    finally:
+        any_llm_logger.propagate = False
+
+    assert result["num_predict"] == (max_completion_tokens if max_completion_tokens is not None else max_tokens)
+    warned = "Ignoring max_tokens (101) in favor of max_completion_tokens (202)." in caplog.text
+    assert warned is expect_warning
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -68,17 +68,22 @@ async def test_completion_converts_output_token_limits_to_num_predict(
 
 
 @pytest.mark.parametrize(
-    ("max_tokens", "max_completion_tokens", "expect_warning"),
+    ("max_tokens", "max_completion_tokens", "num_predict", "expected_num_predict", "expected_warning"),
     [
-        (101, 202, True),
-        (101, None, False),
-        (None, 202, False),
+        (101, 202, None, 202, "Ignoring max_tokens (101) in favor of max_completion_tokens (202)."),
+        (101, 202, 303, 303, "Ignoring the requested output token limit (202) because num_predict (303) is set."),
+        (101, None, 303, 303, "Ignoring the requested output token limit (101) because num_predict (303) is set."),
+        (101, None, None, 101, None),
+        (None, 202, None, 202, None),
+        (None, None, 303, 303, None),
     ],
 )
-def test_convert_completion_params_warns_when_both_token_limits_are_set(
+def test_convert_completion_params_warns_about_ignored_token_limits(
     max_tokens: int | None,
     max_completion_tokens: int | None,
-    expect_warning: bool,
+    num_predict: int | None,
+    expected_num_predict: int,
+    expected_warning: str | None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     params = CompletionParams(
@@ -87,18 +92,22 @@ def test_convert_completion_params_warns_when_both_token_limits_are_set(
         max_tokens=max_tokens,
         max_completion_tokens=max_completion_tokens,
     )
+    provider_kwargs = {} if num_predict is None else {"num_predict": num_predict}
 
     any_llm_logger = logging.getLogger("any_llm")
+    original_propagate = any_llm_logger.propagate
     any_llm_logger.propagate = True
     try:
         with caplog.at_level(logging.WARNING, logger="any_llm"):
-            result = OllamaProvider._convert_completion_params(params)
+            result = OllamaProvider._convert_completion_params(params, **provider_kwargs)
     finally:
-        any_llm_logger.propagate = False
+        any_llm_logger.propagate = original_propagate
 
-    assert result["num_predict"] == (max_completion_tokens if max_completion_tokens is not None else max_tokens)
-    warned = "Ignoring max_tokens (101) in favor of max_completion_tokens (202)." in caplog.text
-    assert warned is expect_warning
+    assert result["num_predict"] == expected_num_predict
+    if expected_warning is None:
+        assert caplog.text == ""
+    else:
+        assert expected_warning in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes #1206 by translating the public completion token-limit aliases to Ollama's `num_predict` option. Explicit `num_predict` keeps priority, and the regression test covers both streaming and non-streaming calls.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1206

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix works.
- [ ] I have run this against a live Ollama server.
- [x] New and existing unit tests pass locally.
- [x] Documentation was updated where necessary.
- [x] I have read and followed the contribution guidelines.
- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info: Human-reviewed, with focused regression coverage and local validation.

- [x] I am an AI Agent filling out this form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama compatibility by correctly applying output token limits from `max_tokens` and `max_completion_tokens`.
  * Ensured `max_completion_tokens` takes precedence when both limits are provided.
  * Preserved explicitly configured `num_predict` values.
  * Prevented OpenAI-style token-limit fields from being forwarded to Ollama.
  * Added warnings when token limits are overridden or ignored.
  * Applied consistently to streaming and non-streaming completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->