### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ print(response.choices[0].message.content)
 ```
 **That's it!** Change the provider name and add provider-specific keys to switch between LLM providers.
 
+> **Note:** The same OpenAI client `base_url` / `api_base` pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
 
 > **Coming from LiteLLM?** Your API keys and environment variables carry over unchanged. Install the SDK with extras for the providers you need, then update your import and model strings:
 >


### PR DESCRIPTION
## Summary

The README already shows multi-provider support including OpenAI.

This PR adds a one-line note that the same OpenAI client pattern works with multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] README renders
- [ ] Existing examples unchanged
- [ ] Note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance confirming that OpenAI client `base_url` and `api_base` settings support OpenAI-compatible multi-model gateways, with DaoXE provided as an example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->