### PR TITLE
docs(contributing): add the two-tier provider acceptance rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Make your changes! Read [Adding a New Provider](#adding-a-new-provider) first if
 
 - **New features**: Add tests covering happy path and error cases
 - **Bug fixes**: Add a test that reproduces the bug
-- **Provider integrations**: Comprehensive test suite required
+- **Provider integrations**: Comprehensive test suite required, except for config-only gateways added as a registry row, which are covered by the generic registry tests (see [2a](#2a-config-only-gateways-add-a-registry-row))
 - **Target**: Minimum 85% coverage for new code
 
 
@@ -203,9 +203,11 @@ The deciding question is whether the protocol *requires* the code, judged by the
 Every listed provider sits in one of two tiers. The tier is a support promise, not a statement about code shape: a config-only provider we hold keys for stays verified.
 
 - **Verified**: we hold API keys, integration tests run in CI, and we fix breakage. These are the providers the README and docs promote.
-- **Community**: verified live by the contributor when the PR is opened, then maintained by the community. No CI keys, and excluded from the integration test matrix.
+- **Community**: verified live by the contributor when the PR is opened, then maintained by the community. No CI key, so the provider is not in the CI provider list and its integration tests skip there.
 
 New third-party gateways land as **community** by default. CI cannot use repository secrets on fork PRs, so contribution-time live verification is the only bar we can actually enforce; we do not ask contributors for ongoing proof.
+
+Promotion to verified is a maintainer action, not something a PR can do: it takes a repository secret plus an entry in `EXPECTED_PROVIDERS` in `.github/workflows/tests-integration.yaml`, which forces the provider's integration tests to run rather than skip. Open an issue if you think a provider deserves it.
 
 **Removal.** A community entry is removed when the gateway shuts down, or when users report sustained breakage that nobody steps up to fix. Cheap addition is only sustainable if removal is equally cheap, so removal PRs are routine and do not need the original contributor's sign-off.
 
@@ -220,7 +222,7 @@ Before requesting or implementing:
 - [ ] Provider's interface is compatible with any-llm's design
 - [ ] No existing issue/PR for adding this provider
 
-For a **verified**-tier request, also expect us to weigh whether the provider has a substantial user base or unique capabilities, since that tier commits us to holding keys and fixing breakage.
+A provider that needs a **code folder** must also clear a usage bar: a substantial user base or unique capabilities. A folder is the expensive category, in review attention now and in maintenance and eventual cleanup later, so it carries that bar in both tiers. Registry rows waive it, because a row costs one line to add and one line to remove. Asking for the **verified** tier raises the bar further, since it commits us to holding a key and fixing breakage.
 
 ### 2a. Config-only Gateways: Add a Registry Row
 
@@ -254,6 +256,8 @@ ExamplegwProvider = get_registry_provider_class("examplegw")
 __all__ = ["ExamplegwProvider"]
 ```
 
+The registry providers already in the tree carry a second `<name>.py` module alongside this file. That is a compatibility shim preserving the deep-import path they had before they were migrated to rows, so a new provider does not need one.
+
 Whether you also add `tests/conftest.py` model maps depends on the tier rather than on the row: a **community** provider has no CI key, so its integration tests skip and the maps would go unused, while a **verified** provider needs entries in the maps that match the capabilities it actually supports (no embedding model for a gateway that does not do embeddings). Adding the `LLMProvider` member enrolls the name in the integration test parametrization either way; with no key configured those tests skip rather than fail.
 
 **Live verification.** Run the following against the real endpoint with your own key and paste the output into the PR, with the key redacted:
@@ -281,7 +285,7 @@ If the gateway does not support one of these, set the matching flag to `False` o
 Implement the provider keeping this checklist in mind:
 
 ```
-any_llm/
+src/any_llm/
 ├── providers/
 │   ├── 📂 <your_provider>/
 │   │   ├── 📄 __init__.py
@@ -296,7 +300,7 @@ In `src/any_llm/constants.py`, add a member to `LLMProvider` for your provider.
 - [ ] Handle provider-specific errors gracefully
 - [ ] Add type hints and docstrings
 - [ ] Use official SDK when available
-- [ ] Add to `pyproject.toml` optional dependencies
+- [ ] Add an extra to `pyproject.toml` optional dependencies and add the name to the `all` group (`tests/unit/test_provider_pyproject_options.py` asserts both)
 - [ ] Export the provider class from your package's `__init__.py` <br>
 <p>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,27 +227,41 @@ For a **verified**-tier request, also expect us to weigh whether the provider ha
 Add one row to `PROVIDER_REGISTRY` in `src/any_llm/providers/registry.py`:
 
 ```python
-"mygateway": OpenAICompatibleProviderConfig(
-    name="mygateway",
-    api_base="https://api.mygateway.example/v1",
-    env_api_key_name="MYGATEWAY_API_KEY",
-    env_api_base_name="MYGATEWAY_API_BASE",
-    provider_documentation_url="https://docs.mygateway.example",
+"examplegw": OpenAICompatibleProviderConfig(
+    name="examplegw",
+    api_base="https://api.examplegw.test/v1",
+    env_api_key_name="EXAMPLEGW_API_KEY",
+    env_api_base_name="EXAMPLEGW_API_BASE",
+    provider_documentation_url="https://docs.examplegw.test",
 ),
 ```
 
+The row replaces the provider *class*, so there is no `BaseOpenAIProvider` subclass to write, no request or response code, and no dependency to add. Registering the name for everyone still touches a few files:
+
 - [ ] Add the row, setting capability flags for what the gateway actually supports. Flags default to the conservative baseline of completion, streaming, and model listing; everything else is opt-in. Do not set a flag you have not exercised against the live endpoint.
-- [ ] Add an `LLMProvider` entry in `src/any_llm/constants.py`. A row resolves through `AnyLLM.create("mygateway")` without one, but the `"mygateway:model"` string form needs the enum entry.
+- [ ] Add an `LLMProvider` member in `src/any_llm/constants.py`. A row resolves through `AnyLLM.create("examplegw")` without one, but the `"examplegw:model"` string form needs the member.
+- [ ] Add an empty extra to `pyproject.toml` (`examplegw = []`) and add the name to the `all` group. The extra stays empty because the registry uses the `openai` client, which is already a core dependency, but `tests/unit/test_provider_pyproject_options.py` asserts that every `LLMProvider` member has both, so omitting it fails CI.
+- [ ] Create `src/any_llm/providers/examplegw/__init__.py` re-exporting the generated class (full contents below).
 - [ ] Paste live verification output in the PR (see below).
 
-There is no folder, no `__init__.py`, and no `pyproject.toml` extra: the registry builds on the `openai` client, which is already a core dependency. Skip the `tests/conftest.py` model maps too, since community providers are excluded from the integration matrix.
+The package directory is required even though the row supplies all the behavior, because `tests/unit/test_provider.py` asserts a one-to-one mapping between `LLMProvider` members and directories under `src/any_llm/providers/`. The whole file is:
+
+```python
+from any_llm.providers.registry import get_registry_provider_class
+
+ExamplegwProvider = get_registry_provider_class("examplegw")
+
+__all__ = ["ExamplegwProvider"]
+```
+
+Whether you also add `tests/conftest.py` model maps depends on the tier rather than on the row: a **community** provider has no CI key, so its integration tests skip and the maps would go unused, while a **verified** provider needs entries in the maps that match the capabilities it actually supports (no embedding model for a gateway that does not do embeddings). Adding the `LLMProvider` member enrolls the name in the integration test parametrization either way; with no key configured those tests skip rather than fail.
 
 **Live verification.** Run the following against the real endpoint with your own key and paste the output into the PR, with the key redacted:
 
 ```python
 from any_llm import AnyLLM
 
-llm = AnyLLM.create("mygateway", api_key="...")
+llm = AnyLLM.create("examplegw", api_key="...")
 
 # completion
 print(llm.completion(model="<model>", messages=[{"role": "user", "content": "Say hi"}]).choices[0].message.content)
@@ -260,7 +274,7 @@ for chunk in llm.completion(model="<model>", messages=[{"role": "user", "content
 print([model.id for model in llm.list_models()][:5])
 ```
 
-If the gateway does not support model listing, set `supports_list_models=False` on the row and say so in the PR instead of pasting that call.
+If the gateway does not support one of these, set the matching flag to `False` on the row (`supports_completion_streaming=False`, `supports_list_models=False`) and say so in the PR instead of pasting that call.
 
 ### 2b. Providers That Need Code
 
@@ -305,7 +319,7 @@ Providers must inherit from the `AnyLLM` class found in `any_llm.any_llm`. All a
 - [ ] Test suite in `tests/unit/providers`
 - [ ] Minimum 85% coverage for provider code
 
-Unit tests are required either way. Integration tests depend on the tier: a **verified**-tier provider needs the `tests/conftest.py` entries below so it joins the CI matrix, while a **community**-tier provider is excluded from that matrix and instead needs the live verification output pasted in the PR, as described in [2a](#2a-config-only-gateways-add-a-registry-row).
+Unit tests are required either way. Integration tests depend on the tier: a **verified**-tier provider needs entries in the relevant `tests/conftest.py` maps below, so that it exercises the CI matrix, while a **community**-tier provider has no CI key and instead needs the live verification output pasted in the PR, as described in [2a](#2a-config-only-gateways-add-a-registry-row). Only fill in the maps for capabilities the provider actually supports.
 
 Add your test config to the following in `tests/conftest.py`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Branch naming conventions:
 - `refactor/` - Code improvements without behavior changes
 
 ### 2. Make Changes
-Make your changes! Read our [Implementation Checklist](#2-implementation-checklist) if adding a new provider
+Make your changes! Read [Adding a New Provider](#adding-a-new-provider) first if that is what you are doing, since some providers need a config row rather than code, and some need no PR at all.
 
 ### 3. Write Tests
 
@@ -171,7 +171,45 @@ git commit -m "wip"
 
 ## Adding a New Provider
 
-Adding provider support is a major contribution! Here's the complete process:
+Not every provider needs code, and some need no PR at all. Start here.
+
+### 0. Do You Need a Provider Entry?
+
+**If your endpoint speaks the OpenAI API, you are never blocked.** Point any-llm straight at it:
+
+```python
+from any_llm import AnyLLM
+
+llm = AnyLLM.create_openai_compatible(
+    name="mygateway",
+    api_base="https://mygateway.example/v1",
+    api_key="your-key",  # optional for keyless local servers
+)
+```
+
+The provider reports the name you give it rather than reporting itself as `openai`, and is used exactly like any other provider instance. See [Custom OpenAI-compatible Endpoints](docs/quickstart.md#custom-openai-compatible-endpoints). This is the right path for private gateways, self-hosted servers, and anything you do not need us to ship.
+
+Open a PR when you want the provider **listed in our docs and resolvable by name** for everyone else. Which path that PR takes depends on whether the provider needs code:
+
+| Your provider...                                                                                                     | Goes in                                            | See |
+| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --- |
+| speaks the OpenAI API and needs nothing beyond a base URL, an API key env var, and capability flags                   | a row in `src/any_llm/providers/registry.py`        | [2a](#2a-config-only-gateways-add-a-registry-row) |
+| needs custom auth, non-OpenAI request or response shapes, param translation, or model-list quirks                     | a folder under `src/any_llm/providers/`             | [2b](#2b-providers-that-need-code) |
+
+The deciding question is whether the protocol *requires* the code, judged by the reviewer. Shipping an official SDK is not by itself a reason for a folder, and adding an override that is not needed does not turn a config-only gateway into a code provider.
+
+### Provider Tiers
+
+Every listed provider sits in one of two tiers. The tier is a support promise, not a statement about code shape: a config-only provider we hold keys for stays verified.
+
+- **Verified**: we hold API keys, integration tests run in CI, and we fix breakage. These are the providers the README and docs promote.
+- **Community**: verified live by the contributor when the PR is opened, then maintained by the community. No CI keys, and excluded from the integration test matrix.
+
+New third-party gateways land as **community** by default. CI cannot use repository secrets on fork PRs, so contribution-time live verification is the only bar we can actually enforce; we do not ask contributors for ongoing proof.
+
+**Removal.** A community entry is removed when the gateway shuts down, or when users report sustained breakage that nobody steps up to fix. Cheap addition is only sustainable if removal is equally cheap, so removal PRs are routine and do not need the original contributor's sign-off.
+
+Surfacing the tier in the generated provider docs is still in progress; see [#1197](https://github.com/mozilla-ai/any-llm/issues/1197) for the remaining rollout.
 
 ### 1. Check Requirements
 
@@ -179,12 +217,52 @@ Before requesting or implementing:
 
 - [ ] Provider has an official Python SDK **OR** well-documented REST API
 - [ ] Provider is actively maintained and supported
-- [ ] Provider has substantial user base or unique capabilities
 - [ ] Provider's interface is compatible with any-llm's design
 - [ ] No existing issue/PR for adding this provider
 
+For a **verified**-tier request, also expect us to weigh whether the provider has a substantial user base or unique capabilities, since that tier commits us to holding keys and fixing breakage.
 
-### 2. Implementation Checklist
+### 2a. Config-only Gateways: Add a Registry Row
+
+Add one row to `PROVIDER_REGISTRY` in `src/any_llm/providers/registry.py`:
+
+```python
+"mygateway": OpenAICompatibleProviderConfig(
+    name="mygateway",
+    api_base="https://api.mygateway.example/v1",
+    env_api_key_name="MYGATEWAY_API_KEY",
+    env_api_base_name="MYGATEWAY_API_BASE",
+    provider_documentation_url="https://docs.mygateway.example",
+),
+```
+
+- [ ] Add the row, setting capability flags for what the gateway actually supports. Flags default to the conservative baseline of completion, streaming, and model listing; everything else is opt-in. Do not set a flag you have not exercised against the live endpoint.
+- [ ] Add an `LLMProvider` entry in `src/any_llm/constants.py`. A row resolves through `AnyLLM.create("mygateway")` without one, but the `"mygateway:model"` string form needs the enum entry.
+- [ ] Paste live verification output in the PR (see below).
+
+There is no folder, no `__init__.py`, and no `pyproject.toml` extra: the registry builds on the `openai` client, which is already a core dependency. Skip the `tests/conftest.py` model maps too, since community providers are excluded from the integration matrix.
+
+**Live verification.** Run the following against the real endpoint with your own key and paste the output into the PR, with the key redacted:
+
+```python
+from any_llm import AnyLLM
+
+llm = AnyLLM.create("mygateway", api_key="...")
+
+# completion
+print(llm.completion(model="<model>", messages=[{"role": "user", "content": "Say hi"}]).choices[0].message.content)
+
+# streaming
+for chunk in llm.completion(model="<model>", messages=[{"role": "user", "content": "Count to 3"}], stream=True):
+    print(chunk.choices[0].delta.content or "", end="")
+
+# model listing
+print([model.id for model in llm.list_models()][:5])
+```
+
+If the gateway does not support model listing, set `supports_list_models=False` on the row and say so in the PR instead of pasting that call.
+
+### 2b. Providers That Need Code
 
 Implement the provider keeping this checklist in mind:
 
@@ -199,24 +277,24 @@ any_llm/
 
 **Required Implementation**:
 
-- [ ] Create provider module in `any_llm/providers/`<br>
-In `src/any_llm/provider.py`, add a field to `ProviderName` for your provider.
+- [ ] Create provider module in `src/any_llm/providers/`<br>
+In `src/any_llm/constants.py`, add a member to `LLMProvider` for your provider.
 - [ ] Handle provider-specific errors gracefully
 - [ ] Add type hints and docstrings
 - [ ] Use official SDK when available
 - [ ] Add to `pyproject.toml` optional dependencies
-- [ ] Add provider to `any_llm/__init__.py` <br>
+- [ ] Export the provider class from your package's `__init__.py` <br>
 <p>
 
-At minimum, the `__init__.py` file should contain :
+At minimum, `src/any_llm/providers/your_provider/__init__.py` should contain:
 
 ```python
-from any_llm.your_provider.your_provider import YourProvider
+from .your_provider import YourProvider
 
 __all__ = ["YourProvider"]
 ```
 
-Providers must inherit from the `Provider` class found in `any_llm.provider`. All abstract methods must be implemented and class variables must be set.
+Providers must inherit from the `AnyLLM` class found in `any_llm.any_llm`. All abstract methods must be implemented and class variables must be set, including the `SUPPORTS_*` capability flags. When overriding a base-class method, use the `@override` decorator from `typing_extensions`.
 
 **Testing Requirements**:
 
@@ -226,6 +304,8 @@ Providers must inherit from the `Provider` class found in `any_llm.provider`. Al
 - [ ] Streaming tests (if applicable)
 - [ ] Test suite in `tests/unit/providers`
 - [ ] Minimum 85% coverage for provider code
+
+Unit tests are required either way. Integration tests depend on the tier: a **verified**-tier provider needs the `tests/conftest.py` entries below so it joins the CI matrix, while a **community**-tier provider is excluded from that matrix and instead needs the live verification output pasted in the PR, as described in [2a](#2a-config-only-gateways-add-a-registry-row).
 
 Add your test config to the following in `tests/conftest.py`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Before requesting or implementing:
 - [ ] Provider's interface is compatible with any-llm's design
 - [ ] No existing issue/PR for adding this provider
 
-A provider that needs a **code folder** must also clear a usage bar: a substantial user base or unique capabilities. A folder is the expensive category, in review attention now and in maintenance and eventual cleanup later, so it carries that bar in both tiers. Registry rows waive it, because a row costs one line to add and one line to remove. Asking for the **verified** tier raises the bar further, since it commits us to holding a key and fixing breakage.
+A provider that needs a **code folder** must also clear a usage bar: a substantial user base or unique capabilities. A folder is the expensive category, in review attention now and in maintenance and eventual cleanup later, so it carries that bar in both tiers. Registry rows waive it because a row costs one line to add and one line to remove. Asking for the **verified** tier raises the bar further, since it commits us to holding a key and fixing breakage.
 
 ### 2a. Config-only Gateways: Add a Registry Row
 
@@ -323,9 +323,9 @@ Providers must inherit from the `AnyLLM` class found in `any_llm.any_llm`. All a
 - [ ] Test suite in `tests/unit/providers`
 - [ ] Minimum 85% coverage for provider code
 
-Unit tests are required either way. Integration tests depend on the tier: a **verified**-tier provider needs entries in the relevant `tests/conftest.py` maps below, so that it exercises the CI matrix, while a **community**-tier provider has no CI key and instead needs the live verification output pasted in the PR, as described in [2a](#2a-config-only-gateways-add-a-registry-row). Only fill in the maps for capabilities the provider actually supports.
+Unit tests are required in both tiers. Integration tests depend on the tier. A **verified**-tier provider needs entries in the relevant `tests/conftest.py` maps below, so that it exercises the CI matrix, and only for the capabilities the provider actually supports. A **community**-tier provider has no CI key, so it skips those maps and pastes live verification output in the PR instead; use the commands in [2a](#2a-config-only-gateways-add-a-registry-row), substituting your provider name and dropping any operation the provider does not support.
 
-Add your test config to the following in `tests/conftest.py`:
+For verified providers, add your test config to the following in `tests/conftest.py`:
 
 | Variable                                                                                                                                           | Notes                                                                                                    |
 | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

Writes down the provider policy from #1197 in CONTRIBUTING.md, so config-only gateway PRs have a documented path and the acceptance bar is consistent from one review to the next. Docs only, no code change.

The `Adding a New Provider` section now leads with a decision step rather than assuming every provider needs a folder:

- **No PR needed.** If the endpoint speaks the OpenAI API, `AnyLLM.create_openai_compatible(...)` (added in #1198) already covers it. That is the right answer for private gateways and self-hosted servers, and it means nobody is ever blocked.
- **A registry row.** Config-only OpenAI-compatible gateways get one row in `src/any_llm/providers/registry.py` (added in #1201), with no folder, no `pyproject.toml` extra, and no `tests/conftest.py` model maps.
- **A code folder.** Reserved for providers whose protocol requires behavior: custom auth, non-OpenAI request or response shapes, param translation, or model-list quirks.

The rule is stated as the reviewer judging whether the protocol *requires* the code. Shipping an official SDK is not by itself a reason for a folder, and adding an override that is not needed does not turn a config-only gateway into a code provider.

`Provider Tiers` documents verified vs community as a support promise rather than a statement about code shape, so a config-only provider we hold keys for stays verified. Community entries are verified live by the contributor at PR time and excluded from the integration matrix; CI cannot use repository secrets on fork PRs, so contribution-time verification is the only bar that is actually enforceable. The removal policy is written down too, on the grounds that cheap addition is only sustainable if removal is equally cheap.

Section 2a gives the concrete row, flag discipline (do not set a flag you have not exercised against the live endpoint), and a copy-pasteable verification script covering completion, streaming, and `list_models`.

Two details worth flagging for review:

- **The enum caveat is real, and verified.** A registry-only row resolves through `AnyLLM.create("name")` and `get_provider_class("name")`, but the `"name:model"` string form raises `UnsupportedProviderError`, because `split_model_provider` returns `LLMProvider`. I confirmed this by injecting a row with no enum member. The checklist therefore tells contributors to add the `LLMProvider` entry as well. Widening that type is still a follow-up on #1197.
- **Tier labeling in the docs is not claimed as done.** An earlier draft said community providers are labeled in the generated docs. They are not yet, so the text points at #1197 for the remaining rollout instead.

Also repairs stale references in the existing checklist, since they sit in the section being rewritten:

- `ProviderName` in `src/any_llm/provider.py` is now `LLMProvider` in `src/any_llm/constants.py` (that file does not exist).
- Providers inherit `AnyLLM` from `any_llm.any_llm`, not a `Provider` class from `any_llm.provider`.
- The `__init__.py` snippet used a non-existent import path; it is the provider package's own `__init__.py`.
- Renaming the old `2. Implementation Checklist` heading to `2b` broke an in-page anchor further up the file, which is repointed.

Happy to split the stale-reference cleanup into its own commit if you would rather review it separately.

## PR Type

- 📚 Documentation

## Relevant issues

Completes the `Update CONTRIBUTING.md with the acceptance rule` item of #1197. Does not close the issue; the two-tier docs listing, `provider:model` routing for registry-only names, and the open questions about registry knobs and shim lifetime remain.

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

Notes on the checklist: no unit tests, since this is a documentation-only change. `tests/docs` only globs `docs/**/*.md`, so the Python snippets in CONTRIBUTING.md are not executed by the suite; I validated them by hand against the real API instead (`create_openai_compatible` signature, `AnyLLM.create` with an injected registry row, and `Model.id` for the `list_models` output). `pre-commit` and `pytest tests/docs` are clean.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Drafted by Claude through back and forth with @njbrake. The policy decisions and the reasoning are his; the prose is Claude's. The behavioral claims in the text were checked against the code rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated provider contribution guidance with clearer support tiers, eligibility criteria, and decision rules.
  - Added instructions for configuration-only gateways, custom-code providers, and providers that do not require a pull request.
  - Clarified registry updates, capability flags, enum and package registration, implementation paths, and override requirements.
  - Expanded integration-testing and live-verification expectations for each support tier.
  - Added guidance on provider removal and refreshed project structure references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->