### PR TITLE
feat(providers): label verified vs community tiers in the generated docs

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -140,7 +140,10 @@ jobs:
 
       - name: Run Integration tests (parallel with xdist)
         env:
-          # When you add a new key, also add the provider name to the EXPECTED_PROVIDERS environment variable
+          # When you add a new key, also add the provider name to the EXPECTED_PROVIDERS environment
+          # variable and to VERIFIED_PROVIDERS in src/any_llm/constants.py, which is what labels the
+          # provider verified in the generated docs. tests/unit/test_provider_tiers.py asserts the two
+          # are equal, so changing only one fails the unit suite.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}

--- a/scripts/generate_provider_table.py
+++ b/scripts/generate_provider_table.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 
 from any_llm import AnyLLM
+from any_llm.constants import ProviderTier
 from any_llm.types.provider import ProviderMetadata
 
 DOCS_DIR = Path(__file__).parent.parent / "docs"
@@ -27,6 +28,15 @@ description: Complete list of LLM providers supported by any-llm including OpenA
 
 Is your endpoint OpenAI-compatible but not listed below? You are not blocked: use [`AnyLLM.create_openai_compatible`](quickstart.md#custom-openai-compatible-endpoints). Prefer it over pointing the `openai` provider at a custom `api_base`, which misreports the provider identity as `openai`, silently sends any `OPENAI_API_KEY` in your environment to the custom endpoint, and rejects keyless local servers.
 
+## Support tiers
+
+The **Tier** column is a support promise, not a statement about how the provider is implemented:
+
+- ✅ **Verified**: we hold an API key, integration tests run against the provider in CI, and we fix breakage.
+- 🤝 **Community**: verified live by the contributor when it was added, then community-maintained. No CI key, so its integration tests skip in CI. Report breakage by opening an issue.
+
+A provider can be verified whether it ships as a code folder or as a single config row, and a config-only gateway we hold a key for is verified.
+
 """
 
 
@@ -36,8 +46,8 @@ def generate_provider_table(providers: list[ProviderMetadata]) -> str:
         return "No providers found."
 
     table_lines = [
-        "| ID | Key | Base | Responses | Completion | Streaming<br>(Completions) | Reasoning<br>(Completions) | Image <br>(Completions) | Embedding | List Models | Batch |",
-        "|----|-----|------|-----------|------------|--------------------------|--------------------------|-----------|-----------|-------------|-------|",
+        "| ID | Tier | Key | Base | Responses | Completion | Streaming<br>(Completions) | Reasoning<br>(Completions) | Image <br>(Completions) | Embedding | List Models | Batch |",
+        "|----|------|-----|------|-----------|------------|--------------------------|--------------------------|-----------|-----------|-------------|-------|",
     ]
 
     for provider in providers:
@@ -56,10 +66,12 @@ def generate_provider_table(providers: list[ProviderMetadata]) -> str:
         list_models_supported = "✅" if provider.list_models else "❌"
         batch_supported = "✅" if provider.batch_completion else "❌"
 
+        tier_label = "✅ Verified" if provider.tier is ProviderTier.VERIFIED else "🤝 Community"
+
         row = (
-            f"| {provider_id_link} | {env_key} | {env_api_base} | {responses_supported} | {completion_supported} | "
-            f"{stream_supported} | {reasoning_supported} | {image_supported} | {embedding_supported} | "
-            f"{list_models_supported} | {batch_supported} |"
+            f"| {provider_id_link} | {tier_label} | {env_key} | {env_api_base} | {responses_supported} | "
+            f"{completion_supported} | {stream_supported} | {reasoning_supported} | {image_supported} | "
+            f"{embedding_supported} | {list_models_supported} | {batch_supported} |"
         )
         table_lines.append(row)
 

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -10,7 +10,7 @@ from typing import IO, TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast, ove
 from openresponses_types import ResponseResource
 from pydantic import BaseModel
 
-from any_llm.constants import INSIDE_NOTEBOOK, LLMProvider
+from any_llm.constants import INSIDE_NOTEBOOK, LLMProvider, get_provider_tier
 from any_llm.exceptions import (
     ContentFilterFinishReasonError,
     LengthFinishReasonError,
@@ -491,6 +491,7 @@ class AnyLLM(ABC):
         """
         return ProviderMetadata(
             name=cls.PROVIDER_NAME,
+            tier=get_provider_tier(cls.PROVIDER_NAME),
             env_key=cls.ENV_API_KEY_NAME,
             env_api_base=cls.ENV_API_BASE_NAME,
             doc_url=cls.PROVIDER_DOCUMENTATION_URL,

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -13,6 +13,21 @@ REASONING_FIELD_NAMES = [
 ]
 
 
+class ProviderTier(StrEnum):
+    """How far our support promise for a provider goes.
+
+    A support promise, not a statement about code shape: a config-only registry
+    row we hold a key for is still verified.
+    """
+
+    VERIFIED = "verified"
+    """We hold an API key, integration tests run in CI, and we fix breakage."""
+
+    COMMUNITY = "community"
+    """Verified live by the contributor at PR time, then community-maintained.
+    No CI key, so its integration tests skip in CI."""
+
+
 class LLMProvider(StrEnum):
     """String enum for supported providers."""
 
@@ -80,3 +95,59 @@ class LLMProvider(StrEnum):
         except ValueError as exc:
             supported = [provider.value for provider in cls]
             raise UnsupportedProviderError(value, supported) from exc
+
+
+# The single source of truth for the verified tier: the providers CI actually
+# holds keys for. `tests/unit/test_provider_tiers.py` asserts this matches the
+# EXPECTED_PROVIDERS lists in .github/workflows/tests-integration.yaml, so the
+# advertised tier cannot drift from which keys CI really has.
+#
+# Spelled as LLMProvider members rather than strings: promotion to verified
+# requires an enum member anyway (the enum drives the integration test matrix),
+# so a typo here fails at import instead of only in the parity test.
+VERIFIED_LOCAL_PROVIDERS: frozenset[LLMProvider] = frozenset(
+    {
+        LLMProvider.OLLAMA,
+        LLMProvider.LLAMACPP,
+        LLMProvider.LLAMAFILE,
+        LLMProvider.LMSTUDIO,
+    }
+)
+"""Local servers CI stands up rather than authenticates against."""
+
+VERIFIED_PROVIDERS: frozenset[LLMProvider] = VERIFIED_LOCAL_PROVIDERS | frozenset(
+    {
+        LLMProvider.ANTHROPIC,
+        LLMProvider.AZUREOPENAI,
+        LLMProvider.BEDROCK,
+        LLMProvider.CEREBRAS,
+        LLMProvider.COHERE,
+        LLMProvider.DEEPSEEK,
+        LLMProvider.FIREWORKS,
+        LLMProvider.GEMINI,
+        LLMProvider.GROQ,
+        LLMProvider.HUGGINGFACE,
+        LLMProvider.INCEPTION,
+        LLMProvider.MISTRAL,
+        LLMProvider.MOONSHOT,
+        LLMProvider.NEBIUS,
+        LLMProvider.OPENAI,
+        LLMProvider.OPENROUTER,
+        LLMProvider.OTARI,
+        LLMProvider.PERPLEXITY,
+        LLMProvider.PORTKEY,
+        LLMProvider.TOGETHER,
+        LLMProvider.SAMBANOVA,
+        LLMProvider.VOYAGE,
+        LLMProvider.XAI,
+        LLMProvider.ZAI,
+        LLMProvider.MINIMAX,
+    }
+)
+
+
+def get_provider_tier(provider_name: str) -> ProviderTier:
+    """Return the support tier for a provider name."""
+    if provider_name.strip().lower() in VERIFIED_PROVIDERS:
+        return ProviderTier.VERIFIED
+    return ProviderTier.COMMUNITY

--- a/src/any_llm/providers/openai/custom.py
+++ b/src/any_llm/providers/openai/custom.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
+from any_llm.constants import ProviderTier
 from any_llm.providers.openai.base import BaseOpenAIProvider
+
+if TYPE_CHECKING:
+    from any_llm.types.provider import ProviderMetadata
 
 
 class OpenAICompatibleProvider(BaseOpenAIProvider):
@@ -41,6 +45,15 @@ class OpenAICompatibleProvider(BaseOpenAIProvider):
         # than the (unset) class default.
         self.API_BASE = api_base
         super().__init__(api_key=api_key, api_base=api_base, **kwargs)
+
+    @classmethod
+    @override
+    def get_provider_metadata(cls) -> ProviderMetadata:
+        # A custom endpoint is an arbitrary URL, so it is never covered by our support
+        # promise, even when the caller names it after a provider we do hold a key for.
+        # Without this, create_openai_compatible(name="openai", api_base=<anything>)
+        # would report the verified tier, because the tier is derived from the name.
+        return super().get_provider_metadata().model_copy(update={"tier": ProviderTier.COMMUNITY})
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:

--- a/src/any_llm/types/provider.py
+++ b/src/any_llm/types/provider.py
@@ -1,8 +1,13 @@
 from pydantic import BaseModel
 
+from any_llm.constants import ProviderTier
+
 
 class ProviderMetadata(BaseModel):
     name: str
+    tier: ProviderTier = ProviderTier.COMMUNITY
+    """Support tier. Defaults to community, so a provider is only advertised as
+    verified once it is listed in VERIFIED_PROVIDERS."""
     env_key: str
     env_api_base: str | None
     doc_url: str

--- a/tests/unit/test_provider_tiers.py
+++ b/tests/unit/test_provider_tiers.py
@@ -1,0 +1,99 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.constants import (
+    VERIFIED_LOCAL_PROVIDERS,
+    VERIFIED_PROVIDERS,
+    ProviderTier,
+    get_provider_tier,
+)
+from tests.constants import LOCAL_PROVIDERS
+
+WORKFLOW_PATH = Path(__file__).parent.parent.parent / ".github" / "workflows" / "tests-integration.yaml"
+
+
+def _workflow_expected_providers() -> tuple[set[str], set[str]]:
+    """Parse the two EXPECTED_PROVIDERS lists out of the integration workflow.
+
+    Returns (non_local, local) in the order the workflow declares them.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    matches = re.findall(r'expected_providers=([a-z0-9,]+)"', text)
+    assert len(matches) == 2, f"expected exactly 2 expected_providers assignments, found {len(matches)}"
+    return ({name for name in matches[0].split(",") if name}, {name for name in matches[1].split(",") if name})
+
+
+def test_verified_set_matches_workflow_non_local_keys() -> None:
+    """The advertised verified tier must match the keys CI actually holds.
+
+    If these drift, docs/providers.md promises support that CI does not exercise.
+    """
+    non_local, _ = _workflow_expected_providers()
+    assert VERIFIED_PROVIDERS - VERIFIED_LOCAL_PROVIDERS == non_local
+
+
+def test_verified_local_set_matches_workflow_local_providers() -> None:
+    _, local = _workflow_expected_providers()
+    assert VERIFIED_LOCAL_PROVIDERS == local
+
+
+def test_verified_local_providers_are_a_subset_of_verified() -> None:
+    assert VERIFIED_LOCAL_PROVIDERS <= VERIFIED_PROVIDERS
+
+
+def test_every_verified_name_is_a_real_provider() -> None:
+    """Catches a typo in VERIFIED_PROVIDERS, which would silently mark a provider community."""
+    unknown = VERIFIED_PROVIDERS - set(AnyLLM.get_supported_providers())
+    assert not unknown, f"VERIFIED_PROVIDERS names that are not providers: {unknown}"
+
+
+@pytest.mark.parametrize("name", ["openai", "anthropic", "moonshot", "ollama"])
+def test_known_verified_providers_report_verified(name: str) -> None:
+    assert get_provider_tier(name) is ProviderTier.VERIFIED
+
+
+@pytest.mark.parametrize("name", ["atlascloud", "telnyx", "qiniu", "not-a-provider-at-all"])
+def test_unlisted_providers_report_community(name: str) -> None:
+    assert get_provider_tier(name) is ProviderTier.COMMUNITY
+
+
+def test_get_provider_tier_normalizes_name() -> None:
+    assert get_provider_tier("  OpenAI ") is ProviderTier.VERIFIED
+
+
+def test_metadata_carries_the_tier() -> None:
+    metadata = {entry.name: entry for entry in AnyLLM.get_all_provider_metadata()}
+    assert metadata["openai"].tier is ProviderTier.VERIFIED
+    # moonshot is a config-only registry row that we hold a key for, so the tier
+    # is independent of code shape.
+    assert metadata["moonshot"].tier is ProviderTier.VERIFIED
+    assert metadata["atlascloud"].tier is ProviderTier.COMMUNITY
+
+
+@pytest.mark.parametrize("name", ["somegateway", "openai", "moonshot", " OpenAI "])
+def test_custom_endpoints_never_report_verified(name: str) -> None:
+    """A custom endpoint is an arbitrary URL, so it is never advertised as verified.
+
+    The tier is derived from the provider name, and create_openai_compatible lets the
+    caller pick any name, so naming an endpoint after a provider we hold a key for
+    must not inherit its tier. An earlier version of this test only used a name that
+    happened not to be verified, so it passed while the property was broken.
+    """
+    provider = AnyLLM.create_openai_compatible(name=name, api_base="https://untrusted.test/v1", api_key="k")
+    assert provider.get_provider_metadata().tier is ProviderTier.COMMUNITY
+    # The name itself is still reported, so the endpoint is not misattributed either way.
+    assert provider.get_provider_metadata().name == name
+
+
+def test_verified_local_providers_are_covered_by_the_test_suite_local_list() -> None:
+    """Guard the two separate notions of "local provider" against drifting apart.
+
+    tests/constants.py LOCAL_PROVIDERS drives test parametrization and is the wider
+    set: it also contains cascadia, which is in CI_EXCLUDED_PROVIDERS and therefore
+    has no CI run to be verified by. So every verified-local name must appear there,
+    but not the reverse.
+    """
+    assert VERIFIED_LOCAL_PROVIDERS <= {provider.value for provider in LOCAL_PROVIDERS}


### PR DESCRIPTION
## Description

Layer 2 of the #1197 stack. Surfaces the verified vs community tier in the generated provider docs.

The tier already existed in practice, as a hardcoded `EXPECTED_PROVIDERS` string in `.github/workflows/tests-integration.yaml`, but nothing exposed it to users, so the docs advertised 51 providers with no indication of which ones we actually hold keys for and fix.

Adds:

- `ProviderTier` and `VERIFIED_PROVIDERS` in `constants.py` as the canonical set (29 of 51 providers: 25 authenticated plus 4 local servers CI stands up).
- A `tier` field on `ProviderMetadata`, defaulting to `COMMUNITY` so a provider is only advertised as verified once it is listed.
- A `Tier` column in the generated table, plus a short section in `providers.md` explaining what each tier promises.

The data confirms the framing from #1197 that tier is a support promise rather than a statement about code shape: `moonshot` is a config-only registry row and reports **verified** because CI holds its key, while `atlascloud` is the same code shape and reports **community**.

A custom endpoint built with `create_openai_compatible` always reports community, since we cannot vouch for an arbitrary URL. That took a fix: the tier derives from `PROVIDER_NAME`, and the caller picks that name, so `create_openai_compatible(name="openai", api_base="https://anything")` originally reported **verified**. `OpenAICompatibleProvider` now pins the tier to community. The first version of the test only used the name `somegateway`, which happens not to be verified, so it passed while the property was broken; it is now parametrized over `openai`, `moonshot`, and a mixed-case spelling.

### Keeping the label honest

The failure mode worth guarding against is the docs promising support CI does not exercise. `tests/unit/test_provider_tiers.py` parses the workflow and asserts both `EXPECTED_PROVIDERS` lists exactly equal the canonical set, and that every verified name is a real provider so a typo cannot silently downgrade one. I verified the guard actually bites by adding a name to the set and watching the assertion fail, rather than assuming it would.

### One deliberate deviation

The plan was for the workflow to consume the canonical set directly and drop its literal list. I kept the literal list because the `expected-providers` job has no checkout and no Python setup, and importing `any_llm.constants` pulls in the full dependency tree (`__init__.py` imports pydantic, openai, and the rest), so consuming it would mean adding checkout plus install plus a dependency-resolution step to a job that currently runs in about a second and gates everything downstream. The parity test gives the same single-source-of-truth guarantee without that cost. Happy to do the full rewiring instead if you would rather pay it.

## PR Type

- 🆕 New Feature

## Relevant issues

Part of #1197, the `two-tier provider listing` half of the docs rollout item. Does not close the issue; the presentation open question (separate section vs inline label) is answered here as an inline column, which is reversible.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

Testing: 15 new tests in `tests/unit/test_provider_tiers.py` (workflow parity for both lists, local subset, every verified name is real, tier lookup and normalization, metadata carries the tier, custom endpoints default to community). `tests/unit` plus `tests/docs` green, `scripts/generate_provider_table.py` runs clean, and I eyeballed the rendered rows for a verified code provider, a verified registry row, and a community registry row.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Drafted by Claude through back and forth with @njbrake. The design decisions are his; the prose is Claude's.
