### PR TITLE
feat(exceptions): carry structured HTTP metadata and classify by status code

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -304,3 +304,30 @@ except RateLimitError as e:
     print(f"Provider: {e.provider_name}")
     print(f"Original exception: {type(e.original_exception)}")
 ```
+
+### Structured Error Metadata
+
+Unified exceptions also carry the structured HTTP fields the provider reported, so
+you can classify a failure without unwrapping `original_exception` and coupling to a
+specific SDK's attribute layout:
+
+| Attribute | Meaning |
+| --- | --- |
+| `status_code` | HTTP status the provider returned |
+| `code` | Provider-specific error code from the response body |
+| `param` | Request field the provider flagged as the cause |
+| `error_type` | Provider-specific error category, such as `"invalid_request_error"` |
+
+```python
+from any_llm.exceptions import InvalidRequestError
+
+try:
+    response = completion(model="gpt-4", provider="openai", messages=messages)
+except InvalidRequestError as e:
+    if e.status_code == 400 and e.param == "reasoning_effort":
+        print("Retry with reasoning_effort set to 'none'")
+```
+
+These fields are populated best-effort from whatever the provider SDK exposed. Any
+field a provider does not report is `None`, and a non-HTTP failure such as a timeout
+or connection error reports `status_code=None`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -333,26 +333,5 @@ attribute on the exception, or the parsed response body. Coverage varies by prov
 so treat every field as optional. Anything `any-llm` cannot recover is `None`,
 including `status_code` for a non-HTTP failure such as a timeout or connection error.
 
-### How the Exception Type Is Chosen
-
-`status_code` decides the type wherever it is unambiguous, because it is what the
-provider actually returned:
-
-| Status | Type |
-| --- | --- |
-| 401, 403 | `AuthenticationError` |
-| 402 | `InsufficientFundsError` |
-| 404 | `ModelNotFoundError` |
-| 429 | `RateLimitError` |
-| 502 | `UpstreamProviderError` |
-| 504 | `GatewayTimeoutError` |
-| other 5xx | `ProviderError` |
-
-A 400 or 422 means the request was rejected but not why, so the error message
-decides between the specific causes that carry no status of their own
-(`ContextLengthExceededError`, `ContentFilterError`, or a provider that reports a bad
-key as a 400), falling back to `InvalidRequestError`. When there is no status at all,
-the message decides on its own.
-
-One consequence worth noting: a 5xx is always a provider fault, even when its body
-happens to mention something like a content policy.
+`status_code` also drives which exception type you get. See
+[Exceptions](api/exceptions.md) for the full status-to-type mapping.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -328,6 +328,7 @@ except InvalidRequestError as e:
         print("Retry with reasoning_effort set to 'none'")
 ```
 
-These fields are populated best-effort from whatever the provider SDK exposed. Any
-field a provider does not report is `None`, and a non-HTTP failure such as a timeout
-or connection error reports `status_code=None`.
+These fields are populated best-effort from the shapes provider SDKs expose: an
+attribute on the exception, or the parsed response body. Coverage varies by provider,
+so treat every field as optional. Anything `any-llm` cannot recover is `None`,
+including `status_code` for a non-HTTP failure such as a timeout or connection error.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -332,3 +332,27 @@ These fields are populated best-effort from the shapes provider SDKs expose: an
 attribute on the exception, or the parsed response body. Coverage varies by provider,
 so treat every field as optional. Anything `any-llm` cannot recover is `None`,
 including `status_code` for a non-HTTP failure such as a timeout or connection error.
+
+### How the Exception Type Is Chosen
+
+`status_code` decides the type wherever it is unambiguous, because it is what the
+provider actually returned:
+
+| Status | Type |
+| --- | --- |
+| 401, 403 | `AuthenticationError` |
+| 402 | `InsufficientFundsError` |
+| 404 | `ModelNotFoundError` |
+| 429 | `RateLimitError` |
+| 502 | `UpstreamProviderError` |
+| 504 | `GatewayTimeoutError` |
+| other 5xx | `ProviderError` |
+
+A 400 or 422 means the request was rejected but not why, so the error message
+decides between the specific causes that carry no status of their own
+(`ContextLengthExceededError`, `ContentFilterError`, or a provider that reports a bad
+key as a 400), falling back to `InvalidRequestError`. When there is no status at all,
+the message decides on its own.
+
+One consequence worth noting: a 5xx is always a provider fault, even when its body
+happens to mention something like a content policy.

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -26,6 +26,7 @@ from any_llm.types import completion as completion_types
 from any_llm.types import messages as messages_types
 from any_llm.types import provider as provider_types
 from any_llm.types import responses as responses_types
+from any_llm.utils.exception_handler import _REJECTED_REQUEST_STATUSES, _STATUS_ERROR_CLASSES
 
 DOCS_API_DIR = Path(__file__).parent.parent / "docs" / "api"
 
@@ -1164,12 +1165,18 @@ def generate_exceptions_page() -> str:
 |-----------|------|-------------|
 | `message` | `str` | Human-readable error message. |
 | `original_exception` | `Exception \\| None` | The original SDK exception that triggered this error. |
-| `provider_name` | `str \\| None` | Name of the provider that raised the error (if available). |"""
+| `provider_name` | `str \\| None` | Name of the provider that raised the error (if available). |
+| `status_code` | `int \\| None` | HTTP status the provider returned. |
+| `code` | `str \\| None` | Provider-specific error code from the response body. |
+| `param` | `str \\| None` | Request field the provider flagged as the cause. |
+| `error_type` | `str \\| None` | Provider-specific error category, such as `"invalid_request_error"`. |"""
     )
     parts.append("")
     parts.append(
         'The string representation includes the provider name when available: `"[openai] Rate limit exceeded"`.'
     )
+    parts.append("")
+    parts.append("Coverage of the four HTTP metadata fields varies by provider, so treat every one as optional.")
 
     # Provider errors (simple ones)
     simple_errors = [
@@ -1282,15 +1289,48 @@ class UnsupportedParameterError(AnyLLMError):
 | Input too long | `ContextLengthExceededError` | Exceeding the model's context window |
 | Malformed request parameters | `InvalidRequestError` | Invalid parameter values |
 | Content blocked by safety filter | `ContentFilterError` | Harmful or policy-violating content |
-| Provider internal / network error | `ProviderError` | 5xx responses, timeouts, connection errors |"""
+| Out of credits or quota | `InsufficientFundsError` | 402 responses |
+| Bad gateway upstream of the provider | `UpstreamProviderError` | 502 responses |
+| Provider timed out at its gateway | `GatewayTimeoutError` | 504 responses |
+| Provider internal / network error | `ProviderError` | Other 5xx responses, timeouts, connection errors |"""
     )
     parts.append("")
     parts.append(
         '{% hint style="warning" %}\n'
-        "Note that `ModelNotFoundError` and `InvalidRequestError` are **separate** subclasses of `AnyLLMError`. "
-        "A model-not-found error will not be caught by `except InvalidRequestError`. "
-        "Catch `ModelNotFoundError` explicitly if you need to handle it.\n"
+        "Every exception above is a **separate** subclass of `AnyLLMError`, not of each other. "
+        "A model-not-found error will not be caught by `except InvalidRequestError`, and "
+        "`InsufficientFundsError`, `UpstreamProviderError`, and `GatewayTimeoutError` will not be caught by "
+        "`except ProviderError`. Catch `AnyLLMError` if you want all of them.\n"
         "{% endhint %}"
+    )
+
+    # How the type is chosen
+    status_rows = [f"| {status} | `{cls.__name__}` |" for status, cls in sorted(_STATUS_ERROR_CLASSES.items())]
+    rejected = " or ".join(str(status) for status in sorted(_REJECTED_REQUEST_STATUSES))
+
+    parts.append("")
+    parts.append("## How the Exception Type Is Chosen")
+    parts.append("")
+    parts.append(
+        "`status_code` decides the type wherever it is unambiguous, because it is what the provider actually returned:"
+    )
+    parts.append("")
+    parts.append("| Status | Exception |")
+    parts.append("|--------|-----------|")
+    parts.extend(status_rows)
+    parts.append("| other 5xx | `ProviderError` |")
+    parts.append("")
+    parts.append(
+        f"A {rejected} means the request was rejected but not why, so the error message decides between the "
+        "specific causes that carry no status of their own (`ContextLengthExceededError`, `ContentFilterError`, "
+        "or a provider that reports a bad key as a 400), falling back to `InvalidRequestError`. When there is no "
+        "status at all, or the status is not one of those listed above (for example 409 or 413), the message "
+        "decides on its own."
+    )
+    parts.append("")
+    parts.append(
+        "One consequence worth noting: a 5xx is always a provider fault, even when its body happens to mention "
+        "something like a content policy."
     )
 
     # Usage

--- a/src/any_llm/exceptions.py
+++ b/src/any_llm/exceptions.py
@@ -15,10 +15,24 @@ class AnyLLMError(Exception):
     All custom exceptions in any-llm inherit from this class. It preserves
     the original exception for debugging while providing a unified interface.
 
+    The structured HTTP fields are populated best-effort by
+    :func:`any_llm.utils.exception_handler.convert_exception` from whatever the
+    provider SDK exposed, so a consumer can classify a failure without reaching
+    into ``original_exception`` and coupling to a specific SDK's attribute
+    layout. Any field a provider does not report stays ``None``, and a non-HTTP
+    failure (timeout, connection error) reports ``status_code=None``.
+
     Attributes:
         message: Human-readable error message
         original_exception: The original SDK exception that triggered this error
         provider_name: Name of the provider that raised the error (if available)
+        status_code: HTTP status the provider returned, when the failure was an
+            HTTP error
+        code: Provider-specific error code from the response body
+        param: Request field the provider flagged as the cause
+        error_type: Provider-specific error category (OpenAI's ``type``, e.g.
+            ``"invalid_request_error"``). Named ``error_type`` to avoid
+            shadowing the builtin on the exception instance.
 
     """
 
@@ -29,11 +43,20 @@ class AnyLLMError(Exception):
         message: str | None = None,
         original_exception: Exception | None = None,
         provider_name: str | None = None,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        param: str | None = None,
+        error_type: str | None = None,
     ) -> None:
         self.message = message or self.default_message
         super().__init__(self.message)
         self.original_exception = original_exception
         self.provider_name = provider_name
+        self.status_code = status_code
+        self.code = code
+        self.param = param
+        self.error_type = error_type
 
     @override
     def __str__(self) -> str:
@@ -60,8 +83,21 @@ class RateLimitError(AnyLLMError):
         original_exception: Exception | None = None,
         provider_name: str | None = None,
         retry_after: str | None = None,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        param: str | None = None,
+        error_type: str | None = None,
     ) -> None:
-        super().__init__(message, original_exception, provider_name)
+        super().__init__(
+            message,
+            original_exception,
+            provider_name,
+            status_code=status_code,
+            code=code,
+            param=param,
+            error_type=error_type,
+        )
         self.retry_after = retry_after
 
 

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -140,6 +140,29 @@ def _extract_error_metadata(exception: Exception) -> _ErrorMetadata:
     )
 
 
+def _extract_retry_after(exception: Exception) -> str | None:
+    """Read the ``Retry-After`` header off the exception's attached response.
+
+    Returned verbatim, because the header is either a number of seconds or an
+    HTTP-date and normalizing it would throw away the caller's ability to tell
+    the two apart. ``httpx.Headers`` lookups are case-insensitive, but a plain
+    dict is not, so both spellings are tried.
+    """
+    headers = getattr(getattr(exception, "response", None), "headers", None)
+    get_header = getattr(headers, "get", None)
+    if not callable(get_header):
+        return None
+
+    for name in ("retry-after", "Retry-After"):
+        value = get_header(name)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+
+    return None
+
+
 def convert_exception(
     exception: Exception,
     provider_name: str,
@@ -150,7 +173,9 @@ def convert_exception(
     and message content, converting it to the appropriate AnyLLMError subclass.
     Structured HTTP metadata the SDK exposed (``status_code``, ``code``,
     ``param``, ``type``) is carried onto the unified exception so consumers can
-    classify a failure without unwrapping ``original_exception``.
+    classify a failure without unwrapping ``original_exception``, and a
+    :class:`~any_llm.exceptions.RateLimitError` additionally carries the
+    ``Retry-After`` header when the provider sent one.
 
     Args:
         exception: The original exception from the SDK
@@ -172,7 +197,7 @@ def convert_exception(
             break
 
     metadata = _extract_error_metadata(exception)
-    return error_class(
+    error = error_class(
         message=str(exception),
         original_exception=exception,
         provider_name=provider_name,
@@ -181,6 +206,12 @@ def convert_exception(
         param=metadata.param,
         error_type=metadata.error_type,
     )
+    # Assigned after construction rather than passed in: retry_after exists only
+    # on RateLimitError, and the shared construction site above is typed against
+    # the base class. isinstance keeps the attribute access type-checked.
+    if isinstance(error, RateLimitError):
+        error.retry_after = _extract_retry_after(exception)
+    return error
 
 
 def _handle_exception(exception: Exception, provider_name: str) -> None:

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -44,10 +44,12 @@ _DEPRECATION_WARNING = (
 _ERROR_PATTERNS: tuple[tuple[str, type[AnyLLMError]], ...] = (
     (r"ratelimit|rate_limit|too many requests|rate limit|quota exceeded", RateLimitError),
     (
-        r"auth|permission|invalid api key|invalid key|unauthorized|authentication|"
-        r"permission denied|access denied|forbidden|invalid_api_key|api key not found|api key invalid|"
-        r"api key not valid|incorrect api key|not valid.*api key|"
-        r"api key.*invalid|invalid.*api key",
+        (
+            r"auth|permission|invalid api key|invalid key|unauthorized|authentication|"
+            r"permission denied|access denied|forbidden|invalid_api_key|api key not found|api key invalid|"
+            r"api key not valid|incorrect api key|not valid.*api key|"
+            r"api key.*invalid|invalid.*api key"
+        ),
         AuthenticationError,
     ),
     (r"context.*length|length.*context|token limit|maximum.*length", ContextLengthExceededError),

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -4,7 +4,7 @@ import functools
 import os
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from pydantic import ValidationError
 
@@ -38,6 +38,108 @@ _DEPRECATION_WARNING = (
 )
 
 
+# Message/type-name patterns tried in order; the first match wins, so more
+# specific patterns must stay ahead of broader ones (for example the API-key
+# patterns before the bare "invalid"). Anything unmatched becomes a ProviderError.
+_ERROR_PATTERNS: tuple[tuple[str, type[AnyLLMError]], ...] = (
+    (r"ratelimit|rate_limit|too many requests|rate limit|quota exceeded", RateLimitError),
+    (
+        r"auth|permission|invalid api key|invalid key|unauthorized|authentication|"
+        r"permission denied|access denied|forbidden|invalid_api_key|api key not found|api key invalid|"
+        r"api key not valid|incorrect api key|not valid.*api key|"
+        r"api key.*invalid|invalid.*api key",
+        AuthenticationError,
+    ),
+    (r"context.*length|length.*context|token limit|maximum.*length", ContextLengthExceededError),
+    (r"notfound|not_found|model not found|does not exist|model.*not.*found", ModelNotFoundError),
+    (
+        r"content.*(filter|policy)|(filter|policy).*content|safety|moderation|blocked|harmful content",
+        ContentFilterError,
+    ),
+    (r"invalid|badrequest|validation", InvalidRequestError),
+    (r"insufficient.*funds|payment.*required|budget.*exceeded", InsufficientFundsError),
+    (r"bad.*gateway|upstream.*error|upstream.*provider", UpstreamProviderError),
+    (r"gateway.*timeout", GatewayTimeoutError),
+    (r"timeout|connection|network|server|internal|service|service unavailable", ProviderError),
+)
+
+
+class _ErrorMetadata(NamedTuple):
+    """Structured HTTP fields recovered from a provider SDK exception."""
+
+    status_code: int | None
+    code: str | None
+    param: str | None
+    error_type: str | None
+
+
+def _extract_status_code(exception: Exception) -> int | None:
+    """Read the HTTP status off the exception, or off its attached response."""
+    status_code = getattr(exception, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+
+    response = getattr(exception, "response", None)
+    if response is not None:
+        response_status = getattr(response, "status_code", None)
+        if isinstance(response_status, int):
+            return response_status
+
+    return None
+
+
+def _error_body_dicts(exception: Exception) -> tuple[dict[str, Any], ...]:
+    """Dicts to read structured error fields from, in precedence order.
+
+    The OpenAI client unwraps a ``{"error": {...}}`` response body before
+    constructing the exception, so the fields usually sit at the top level of
+    ``body``. Other SDKs keep the nesting, and there the inner ``error`` dict is
+    the authoritative detail while the outer dict is only an envelope: Anthropic
+    sends a literal ``{"type": "error", "error": {"type": "invalid_request_error"}}``,
+    so the nested dict has to win to avoid reporting ``error_type="error"``.
+    """
+    body = getattr(exception, "body", None)
+    if not isinstance(body, dict):
+        return ()
+
+    nested = body.get("error")
+    if isinstance(nested, dict):
+        return (nested, body)
+    return (body,)
+
+
+def _extract_string_field(exception: Exception, name: str, bodies: tuple[dict[str, Any], ...]) -> str | None:
+    """Read a string field off the exception, falling back to the response body."""
+    value = getattr(exception, name, None)
+    if isinstance(value, str):
+        return value
+
+    for body in bodies:
+        body_value = body.get(name)
+        if isinstance(body_value, str):
+            return body_value
+
+    return None
+
+
+def _extract_error_metadata(exception: Exception) -> _ErrorMetadata:
+    """Pull structured HTTP metadata off a provider SDK exception, best-effort.
+
+    Provider-agnostic and non-raising: every field is optional, and a provider
+    that does not report one (or a non-HTTP failure such as a timeout) simply
+    yields ``None`` for it. ``getattr`` is used deliberately here because the
+    incoming exception is an arbitrary third-party SDK type whose attributes are
+    not statically known.
+    """
+    bodies = _error_body_dicts(exception)
+    return _ErrorMetadata(
+        status_code=_extract_status_code(exception),
+        code=_extract_string_field(exception, "code", bodies),
+        param=_extract_string_field(exception, "param", bodies),
+        error_type=_extract_string_field(exception, "type", bodies),
+    )
+
+
 def convert_exception(
     exception: Exception,
     provider_name: str,
@@ -46,6 +148,9 @@ def convert_exception(
 
     This function attempts to classify the exception based on its type name
     and message content, converting it to the appropriate AnyLLMError subclass.
+    Structured HTTP metadata the SDK exposed (``status_code``, ``code``,
+    ``param``, ``type``) is carried onto the unified exception so consumers can
+    classify a failure without unwrapping ``original_exception``.
 
     Args:
         exception: The original exception from the SDK
@@ -58,95 +163,23 @@ def convert_exception(
     if isinstance(exception, AnyLLMError):
         return exception
 
-    original_message = str(exception)
     exc_text = f"{type(exception).__name__.lower()} {str(exception).lower()}"
 
-    if re.search(r"ratelimit|rate_limit|too many requests|rate limit|quota exceeded", exc_text):
-        return RateLimitError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
+    error_class: type[AnyLLMError] = ProviderError
+    for pattern, candidate in _ERROR_PATTERNS:
+        if re.search(pattern, exc_text):
+            error_class = candidate
+            break
 
-    if re.search(
-        r"auth|permission|invalid api key|invalid key|unauthorized|authentication|"
-        r"permission denied|access denied|forbidden|invalid_api_key|api key not found|api key invalid|"
-        r"api key not valid|incorrect api key|not valid.*api key|"
-        r"api key.*invalid|invalid.*api key",
-        exc_text,
-    ):
-        return AuthenticationError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"context.*length|length.*context|token limit|maximum.*length", exc_text):
-        return ContextLengthExceededError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"notfound|not_found|model not found|does not exist|model.*not.*found", exc_text):
-        return ModelNotFoundError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(
-        r"content.*(filter|policy)|(filter|policy).*content|safety|moderation|blocked|harmful content",
-        exc_text,
-    ):
-        return ContentFilterError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"invalid|badrequest|validation", exc_text):
-        return InvalidRequestError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"insufficient.*funds|payment.*required|budget.*exceeded", exc_text):
-        return InsufficientFundsError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"bad.*gateway|upstream.*error|upstream.*provider", exc_text):
-        return UpstreamProviderError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(r"gateway.*timeout", exc_text):
-        return GatewayTimeoutError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    if re.search(
-        r"timeout|connection|network|server|internal|service|service unavailable",
-        exc_text,
-    ):
-        return ProviderError(
-            message=original_message,
-            original_exception=exception,
-            provider_name=provider_name,
-        )
-
-    return ProviderError(
-        message=original_message,
+    metadata = _extract_error_metadata(exception)
+    return error_class(
+        message=str(exception),
         original_exception=exception,
         provider_name=provider_name,
+        status_code=metadata.status_code,
+        code=metadata.code,
+        param=metadata.param,
+        error_type=metadata.error_type,
     )
 
 

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -63,6 +63,65 @@ _ERROR_PATTERNS: tuple[tuple[str, type[AnyLLMError]], ...] = (
     (r"timeout|connection|network|server|internal|service|service unavailable", ProviderError),
 )
 
+# Statuses that identify the failure on their own. Checked before the message
+# patterns, because the status is what the provider actually returned while a
+# message match is a guess: a 500 whose body happens to mention "policy" is a
+# provider outage, not a content-filter rejection. The 402/502/504 entries also
+# align the code with what those exception docstrings already claim.
+_STATUS_ERROR_CLASSES: dict[int, type[AnyLLMError]] = {
+    401: AuthenticationError,
+    402: InsufficientFundsError,
+    403: AuthenticationError,
+    404: ModelNotFoundError,
+    429: RateLimitError,
+    502: UpstreamProviderError,
+    504: GatewayTimeoutError,
+}
+
+# "The request was rejected", where the status says that much but only the
+# message says why. ContextLengthExceededError and ContentFilterError have no
+# status of their own (OpenAI returns 400 for both), and some providers report a
+# bad API key as a 400, so the patterns still decide here. InvalidRequestError
+# is the floor when nothing more specific matches.
+_REJECTED_REQUEST_STATUSES = frozenset({400, 422})
+
+
+def _classify_by_message(exc_text: str) -> type[AnyLLMError]:
+    """First matching pattern in the ordered table, else ProviderError."""
+    for pattern, error_class in _ERROR_PATTERNS:
+        if re.search(pattern, exc_text):
+            return error_class
+    return ProviderError
+
+
+def _classify(exc_text: str, status_code: int | None) -> type[AnyLLMError]:
+    """Pick the unified exception class for a failure.
+
+    Prefers the HTTP status where it is unambiguous and falls back to the
+    message patterns otherwise, so a provider that returns an unhelpful body
+    still classifies correctly and a message coincidence cannot override a
+    status the provider actually sent.
+    """
+    if status_code is None:
+        return _classify_by_message(exc_text)
+
+    keyed = _STATUS_ERROR_CLASSES.get(status_code)
+    if keyed is not None:
+        return keyed
+
+    if status_code in _REJECTED_REQUEST_STATUSES:
+        by_message = _classify_by_message(exc_text)
+        # ProviderError is the table's "nothing matched" outcome. A rejected
+        # request is the caller's problem, not a provider fault.
+        return InvalidRequestError if by_message is ProviderError else by_message
+
+    if status_code >= 500:
+        return ProviderError
+
+    # Any other status (3xx, 409, 413, ...) carries no agreed meaning here, so
+    # the message patterns stay in charge.
+    return _classify_by_message(exc_text)
+
 
 class _ErrorMetadata(NamedTuple):
     """Structured HTTP fields recovered from a provider SDK exception."""
@@ -169,12 +228,12 @@ def convert_exception(
 ) -> AnyLLMError:
     """Convert a provider-specific exception to an AnyLLMError.
 
-    This function attempts to classify the exception based on its type name
-    and message content, converting it to the appropriate AnyLLMError subclass.
-    Structured HTTP metadata the SDK exposed (``status_code``, ``code``,
-    ``param``, ``type``) is carried onto the unified exception so consumers can
-    classify a failure without unwrapping ``original_exception``, and a
-    :class:`~any_llm.exceptions.RateLimitError` additionally carries the
+    Classifies by the HTTP status the provider returned where that is
+    unambiguous, falling back to the exception's type name and message content
+    otherwise. Structured HTTP metadata the SDK exposed (``status_code``,
+    ``code``, ``param``, ``type``) is carried onto the unified exception so
+    consumers can classify a failure without unwrapping ``original_exception``,
+    and a :class:`~any_llm.exceptions.RateLimitError` additionally carries the
     ``Retry-After`` header when the provider sent one.
 
     Args:
@@ -189,14 +248,9 @@ def convert_exception(
         return exception
 
     exc_text = f"{type(exception).__name__.lower()} {str(exception).lower()}"
-
-    error_class: type[AnyLLMError] = ProviderError
-    for pattern, candidate in _ERROR_PATTERNS:
-        if re.search(pattern, exc_text):
-            error_class = candidate
-            break
-
     metadata = _extract_error_metadata(exception)
+    error_class = _classify(exc_text, metadata.status_code)
+
     error = error_class(
         message=str(exception),
         original_exception=exception,

--- a/tests/unit/providers/test_anthropic_exceptions.py
+++ b/tests/unit/providers/test_anthropic_exceptions.py
@@ -111,3 +111,28 @@ def test_api_error_with_500_status() -> None:
     assert isinstance(result, ProviderError)
     assert result.provider_name == "anthropic"
     assert result.original_exception is original
+
+
+def test_status_code_and_type_are_preserved_on_the_unified_error() -> None:
+    """Anthropic reports status_code and type; it has no param/code equivalent.
+
+    The SDK sets ``type`` from the nested ``body["error"]["type"]``, and the
+    fields it does not report stay None rather than raising.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {}
+
+    original = AnthropicBadRequestError(
+        message="Invalid request",
+        response=mock_response,
+        body={"type": "error", "error": {"type": "invalid_request_error", "message": "Invalid request"}},
+    )
+
+    result = convert_exception(original, "anthropic")
+
+    assert isinstance(result, InvalidRequestError)
+    assert result.status_code == 400
+    assert result.error_type == "invalid_request_error"
+    assert result.param is None
+    assert result.code is None

--- a/tests/unit/providers/test_openai_exceptions.py
+++ b/tests/unit/providers/test_openai_exceptions.py
@@ -111,3 +111,59 @@ def test_api_error_with_500_status() -> None:
     assert isinstance(result, ProviderError)
     assert result.provider_name == "openai"
     assert result.original_exception is original
+
+
+def test_status_code_and_param_are_preserved_on_the_unified_error() -> None:
+    """A consumer can classify a rejection without unwrapping original_exception.
+
+    The OpenAI client unwraps the ``{"error": {...}}`` response body before
+    constructing the exception, so the SDK populates ``param``/``code``/``type``
+    as attributes. This is the reasoning_effort case from mozilla-ai/otari#331:
+    a gateway needs status_code plus param to surface the actionable remedy.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.headers = {}
+
+    original = OpenAIBadRequestError(
+        message=(
+            "Function tools with reasoning_effort are not supported for gpt-5.6-sol in "
+            "/v1/chat/completions. To use function tools, use /v1/responses or set "
+            "reasoning_effort to 'none'."
+        ),
+        response=mock_response,
+        body={
+            "message": "Function tools with reasoning_effort are not supported",
+            "type": "invalid_request_error",
+            "param": "reasoning_effort",
+            "code": None,
+        },
+    )
+
+    result = convert_exception(original, "openai")
+
+    assert isinstance(result, InvalidRequestError)
+    assert result.status_code == 400
+    assert result.param == "reasoning_effort"
+    assert result.error_type == "invalid_request_error"
+    assert result.code is None
+
+
+def test_rate_limit_metadata_is_preserved_on_the_unified_error() -> None:
+    """RateLimitError overrides __init__, so it has to forward the new fields."""
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.headers = {}
+
+    original = OpenAIRateLimitError(
+        message="Rate limit exceeded",
+        response=mock_response,
+        body={"message": "Rate limit exceeded", "type": "rate_limit_error", "code": "rate_limit_exceeded"},
+    )
+
+    result = convert_exception(original, "openai")
+
+    assert isinstance(result, RateLimitError)
+    assert result.status_code == 429
+    assert result.code == "rate_limit_exceeded"
+    assert result.error_type == "rate_limit_error"

--- a/tests/unit/providers/test_openai_exceptions.py
+++ b/tests/unit/providers/test_openai_exceptions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 openai = pytest.importorskip("openai")
@@ -167,3 +168,28 @@ def test_rate_limit_metadata_is_preserved_on_the_unified_error() -> None:
     assert result.status_code == 429
     assert result.code == "rate_limit_exceeded"
     assert result.error_type == "rate_limit_error"
+
+
+def test_retry_after_is_read_from_a_real_httpx_response() -> None:
+    """Pins the case-insensitive httpx.Headers lookup, not just a dict.
+
+    The SDK attaches a real httpx.Response, so the header arrives however the
+    provider capitalized it on the wire.
+    """
+    response = httpx.Response(
+        429,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        headers={"Retry-After": "30"},
+    )
+
+    original = OpenAIRateLimitError(
+        message="Rate limit exceeded",
+        response=response,
+        body={"message": "Rate limit exceeded", "type": "rate_limit_error"},
+    )
+
+    result = convert_exception(original, "openai")
+
+    assert isinstance(result, RateLimitError)
+    assert result.status_code == 429
+    assert result.retry_after == "30"

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -277,6 +277,58 @@ def test_convert_exception_leaves_metadata_none_for_non_http_failure() -> None:
     assert result.error_type is None
 
 
+def test_convert_exception_carries_retry_after_from_response_headers() -> None:
+    """RateLimitError.retry_after is filled from the Retry-After header."""
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    error.response.headers = {"retry-after": "30"}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after == "30"
+
+
+def test_convert_exception_reads_retry_after_case_insensitively() -> None:
+    """A plain dict is case-sensitive, so the canonical header spelling is tried too."""
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    error.response.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after == "Wed, 21 Oct 2026 07:28:00 GMT"
+
+
+def test_convert_exception_stringifies_numeric_retry_after() -> None:
+    """A header store holding an int still yields the declared str type."""
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    error.response.headers = {"retry-after": 30}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after == "30"
+
+
+def test_convert_exception_retry_after_is_none_without_the_header() -> None:
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    error.response.headers = {}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after is None
+
+
+def test_convert_exception_retry_after_is_none_without_usable_headers() -> None:
+    """A response with no headers mapping at all does not raise."""
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after is None
+
+
+def test_convert_exception_ignores_retry_after_on_non_rate_limit_errors() -> None:
+    """Only RateLimitError declares retry_after, so nothing else grows the field."""
+    error = _ResponseStatusError(400, "Invalid request")
+    error.response.headers = {"retry-after": "30"}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, InvalidRequestError)
+    assert not hasattr(result, "retry_after")
+
+
 def test_convert_exception_carries_metadata_onto_rate_limit_error() -> None:
     """RateLimitError overrides ``__init__``, so it must forward the new fields."""
     error = _StatusError(429, "Rate limit exceeded", code="rate_limit_exceeded", type="rate_limit_error")

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -16,7 +16,12 @@ from any_llm.exceptions import (
     RateLimitError,
     UpstreamProviderError,
 )
-from any_llm.utils.exception_handler import _ERROR_PATTERNS, _handle_exception, convert_exception
+from any_llm.utils.exception_handler import (
+    _ERROR_PATTERNS,
+    _STATUS_ERROR_CLASSES,
+    _handle_exception,
+    convert_exception,
+)
 
 
 class _StatusError(Exception):
@@ -389,16 +394,20 @@ def test_convert_exception_classification_order_is_pinned(message: str, expected
     assert type(convert_exception(Exception(message), "openai")) is expected
 
 
-def test_every_pattern_class_accepts_the_metadata_keywords() -> None:
-    """Every class in the table must accept the structured metadata keywords.
+def test_every_classified_class_accepts_the_metadata_keywords() -> None:
+    """Every class either table can select must accept the structured metadata keywords.
 
     convert_exception constructs through a ``type[AnyLLMError]`` variable, so
     mypy checks the call against the base signature only. A subclass with an
     incompatible ``__init__`` (MissingApiKeyError, BatchNotCompleteError) would
     pass the type check and raise TypeError inside the exception handler,
-    masking the provider's original error.
+    masking the provider's original error. Both the message table and the status
+    table feed that construction site, so both are covered here.
     """
-    for _pattern, error_class in _ERROR_PATTERNS:
+    classified = {error_class for _pattern, error_class in _ERROR_PATTERNS}
+    classified.update(_STATUS_ERROR_CLASSES.values())
+    classified.update({InvalidRequestError, ProviderError})
+    for error_class in classified:
         error = error_class(
             message="boom",
             original_exception=ValueError("boom"),

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -312,6 +312,20 @@ def test_convert_exception_retry_after_is_none_without_the_header() -> None:
     assert result.retry_after is None
 
 
+@pytest.mark.parametrize("value", [True, 30.5, object()])
+def test_convert_exception_rejects_unusable_retry_after_values(value: object) -> None:
+    """Only a string or a plain int is a usable retry hint.
+
+    bool is excluded deliberately even though it is an int subclass: ``True``
+    would stringify to ``"True"``, which is not a delay a caller can act on.
+    """
+    error = _ResponseStatusError(429, "Rate limit exceeded")
+    error.response.headers = {"retry-after": value}  # type: ignore[attr-defined]
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.retry_after is None
+
+
 def test_convert_exception_retry_after_is_none_without_usable_headers() -> None:
     """A response with no headers mapping at all does not raise."""
     error = _ResponseStatusError(429, "Rate limit exceeded")

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -412,3 +412,86 @@ def test_every_pattern_class_accepts_the_metadata_keywords() -> None:
         assert error.code == "unsupported_parameter"
         assert error.param == "reasoning_effort"
         assert error.error_type == "invalid_request_error"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (401, AuthenticationError),
+        (402, InsufficientFundsError),
+        (403, AuthenticationError),
+        (404, ModelNotFoundError),
+        (429, RateLimitError),
+        (502, UpstreamProviderError),
+        (504, GatewayTimeoutError),
+    ],
+)
+def test_unambiguous_status_wins_over_an_unhelpful_message(status_code: int, expected: type[AnyLLMError]) -> None:
+    """A provider that returns a generic body still classifies from its status.
+
+    Before, "Something went wrong" matched no pattern and fell through to
+    ProviderError regardless of the status, so a 429 or a 401 was indistinguishable
+    from an outage.
+    """
+    assert type(convert_exception(_StatusError(status_code, "Something went wrong"), "openai")) is expected
+
+
+@pytest.mark.parametrize("status_code", [401, 402, 404, 429, 502, 504])
+def test_unambiguous_status_wins_over_a_contradicting_message(status_code: int) -> None:
+    """The status is what the provider sent; a message coincidence cannot override it."""
+    error = _StatusError(status_code, "The response was filtered due to the content policy")
+    assert not isinstance(convert_exception(error, "openai"), ContentFilterError)
+
+
+@pytest.mark.parametrize("status_code", [500, 503, 529])
+def test_server_errors_are_provider_errors_regardless_of_message(status_code: int) -> None:
+    """The misclassification called out in #1190: a 5xx whose body mentions
+    "policy" is a provider fault, not a content-filter rejection."""
+    error = _StatusError(status_code, "Internal error while applying the content policy")
+    assert type(convert_exception(error, "openai")) is ProviderError
+
+
+@pytest.mark.parametrize("status_code", [400, 422])
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("This model's maximum context length is 8192 tokens", ContextLengthExceededError),
+        ("The response was filtered due to the content policy", ContentFilterError),
+        ("Incorrect API key provided", AuthenticationError),
+        ("The model gpt-9 does not exist", ModelNotFoundError),
+        ("Budget exceeded for this project", InsufficientFundsError),
+    ],
+)
+def test_rejected_request_keeps_the_specific_cause_from_the_message(
+    status_code: int, message: str, expected: type[AnyLLMError]
+) -> None:
+    """400/422 says the request was rejected but not why.
+
+    ContextLengthExceededError and ContentFilterError have no status of their own
+    (OpenAI returns 400 for both) and some providers report a bad key as a 400, so
+    the patterns still decide here. Keying 400 straight to InvalidRequestError would
+    make those classes unreachable for any provider that reports a status.
+    """
+    assert type(convert_exception(_StatusError(status_code, message), "openai")) is expected
+
+
+@pytest.mark.parametrize("status_code", [400, 422])
+def test_rejected_request_falls_back_to_invalid_request(status_code: int) -> None:
+    """With no specific cause in the message, a rejected request is the caller's
+    problem, so it lands on InvalidRequestError rather than ProviderError."""
+    error = _StatusError(status_code, "Something went wrong")
+    assert type(convert_exception(error, "openai")) is InvalidRequestError
+
+
+@pytest.mark.parametrize("status_code", [409, 413, 418, 302])
+def test_unmapped_status_defers_to_the_message_patterns(status_code: int) -> None:
+    """A status with no agreed meaning here leaves the patterns in charge."""
+    error = _StatusError(status_code, "This model's maximum context length is 8192 tokens")
+    assert type(convert_exception(error, "openai")) is ContextLengthExceededError
+
+
+def test_status_free_failures_still_use_the_message_patterns() -> None:
+    """The status-free path is unchanged, so a timeout or an SDK error carrying no
+    status classifies exactly as it did before."""
+    assert type(convert_exception(Exception("Rate limit reached"), "openai")) is RateLimitError
+    assert type(convert_exception(TimeoutError("request timed out"), "openai")) is ProviderError

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -5,14 +5,18 @@ from pydantic import BaseModel, ValidationError
 
 from any_llm.exceptions import (
     AnyLLMError,
+    AuthenticationError,
+    ContentFilterError,
+    ContextLengthExceededError,
     GatewayTimeoutError,
     InsufficientFundsError,
     InvalidRequestError,
+    ModelNotFoundError,
     ProviderError,
     RateLimitError,
     UpstreamProviderError,
 )
-from any_llm.utils.exception_handler import _handle_exception, convert_exception
+from any_llm.utils.exception_handler import _ERROR_PATTERNS, _handle_exception, convert_exception
 
 
 class _StatusError(Exception):
@@ -291,3 +295,54 @@ def test_convert_exception_preserves_already_unified_error_untouched() -> None:
     assert result is original
     assert result.status_code == 400
     assert result.param == "reasoning_effort"
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Rate limit exceeded", RateLimitError),
+        ("Unauthorized", AuthenticationError),
+        ("This model's maximum context length is 8192 tokens", ContextLengthExceededError),
+        ("The model gpt-9 does not exist", ModelNotFoundError),
+        ("Your request was blocked by the content policy", ContentFilterError),
+        ("Invalid value for temperature", InvalidRequestError),
+        ("Payment required", InsufficientFundsError),
+        ("Bad gateway", UpstreamProviderError),
+        ("Gateway timeout", GatewayTimeoutError),
+        ("Connection reset by peer", ProviderError),
+        ("Wibble wobble", ProviderError),
+    ],
+)
+def test_convert_exception_classification_order_is_pinned(message: str, expected: type[AnyLLMError]) -> None:
+    """One representative message per entry in the ordered pattern table.
+
+    The table is matched first-hit-wins, so a reordering or a broadened pattern
+    silently re-routes failures to a different exception type. Pinning every
+    entry (including the unmatched fallback) makes that visible.
+    """
+    assert type(convert_exception(Exception(message), "openai")) is expected
+
+
+def test_every_pattern_class_accepts_the_metadata_keywords() -> None:
+    """Every class in the table must accept the structured metadata keywords.
+
+    convert_exception constructs through a ``type[AnyLLMError]`` variable, so
+    mypy checks the call against the base signature only. A subclass with an
+    incompatible ``__init__`` (MissingApiKeyError, BatchNotCompleteError) would
+    pass the type check and raise TypeError inside the exception handler,
+    masking the provider's original error.
+    """
+    for _pattern, error_class in _ERROR_PATTERNS:
+        error = error_class(
+            message="boom",
+            original_exception=ValueError("boom"),
+            provider_name="openai",
+            status_code=400,
+            code="unsupported_parameter",
+            param="reasoning_effort",
+            error_type="invalid_request_error",
+        )
+        assert error.status_code == 400
+        assert error.code == "unsupported_parameter"
+        assert error.param == "reasoning_effort"
+        assert error.error_type == "invalid_request_error"

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,8 +1,50 @@
+from typing import Any
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from any_llm.exceptions import GatewayTimeoutError, InsufficientFundsError, UpstreamProviderError
+from any_llm.exceptions import (
+    AnyLLMError,
+    GatewayTimeoutError,
+    InsufficientFundsError,
+    InvalidRequestError,
+    ProviderError,
+    RateLimitError,
+    UpstreamProviderError,
+)
 from any_llm.utils.exception_handler import _handle_exception, convert_exception
+
+
+class _StatusError(Exception):
+    """Provider error exposing an HTTP status directly, like openai's APIStatusError."""
+
+    def __init__(self, status_code: int, message: str = "boom", **fields: Any) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        for name, value in fields.items():
+            setattr(self, name, value)
+
+
+class _ResponseStatusError(Exception):
+    """Provider error carrying the status only on an attached response object."""
+
+    def __init__(self, status_code: int, message: str = "boom") -> None:
+        super().__init__(message)
+
+        class _Response:
+            pass
+
+        response = _Response()
+        response.status_code = status_code  # type: ignore[attr-defined]
+        self.response = response
+
+
+class _BodyError(Exception):
+    """Provider error carrying structured fields only in a response body."""
+
+    def __init__(self, body: Any, message: str = "boom") -> None:
+        super().__init__(message)
+        self.body = body
 
 
 def test_validation_error_bubbles_up_unchanged() -> None:
@@ -101,3 +143,151 @@ def test_convert_exception_invalid_api_key_word_boundary() -> None:
     original = Exception("Invalid API key provided")
     result = convert_exception(original, "openai")
     assert isinstance(result, AuthenticationError)
+
+
+def test_any_llm_error_metadata_defaults_to_none() -> None:
+    """An exception constructed without metadata still exposes the fields."""
+    error = AnyLLMError("something failed")
+    assert error.status_code is None
+    assert error.code is None
+    assert error.param is None
+    assert error.error_type is None
+
+
+def test_convert_exception_carries_status_code_from_attribute() -> None:
+    result = convert_exception(_StatusError(400, "Invalid request"), "openai")
+    assert isinstance(result, InvalidRequestError)
+    assert result.status_code == 400
+
+
+def test_convert_exception_carries_status_code_from_response() -> None:
+    """A status carried only on the attached response is still recovered."""
+    result = convert_exception(_ResponseStatusError(400, "Invalid request"), "openai")
+    assert result.status_code == 400
+
+
+def test_convert_exception_prefers_status_code_attribute_over_response() -> None:
+    error = _ResponseStatusError(500, "Invalid request")
+    error.status_code = 400  # type: ignore[attr-defined]
+    assert convert_exception(error, "openai").status_code == 400
+
+
+def test_convert_exception_ignores_non_integer_status_code() -> None:
+    """A provider that stores something other than an int is treated as absent."""
+    result = convert_exception(_StatusError("400", "Invalid request"), "openai")  # type: ignore[arg-type]
+    assert result.status_code is None
+
+
+def test_convert_exception_ignores_response_without_usable_status() -> None:
+    """An attached response that reports no integer status yields no status_code."""
+    error = _ResponseStatusError(400, "Invalid request")
+    error.response.status_code = None  # type: ignore[attr-defined]
+    assert convert_exception(error, "openai").status_code is None
+
+
+def test_convert_exception_carries_param_code_and_type_from_attributes() -> None:
+    """The OpenAI SDK populates these directly, so they are read off the exception."""
+    error = _StatusError(
+        400,
+        "Invalid request",
+        param="reasoning_effort",
+        code="unsupported_parameter",
+        type="invalid_request_error",
+    )
+    result = convert_exception(error, "openai")
+    assert result.param == "reasoning_effort"
+    assert result.code == "unsupported_parameter"
+    assert result.error_type == "invalid_request_error"
+
+
+def test_convert_exception_reads_metadata_from_flat_body() -> None:
+    error = _BodyError(
+        {"param": "reasoning_effort", "code": "unsupported_parameter", "type": "invalid_request_error"},
+        "Invalid request",
+    )
+    result = convert_exception(error, "openai")
+    assert result.param == "reasoning_effort"
+    assert result.code == "unsupported_parameter"
+    assert result.error_type == "invalid_request_error"
+
+
+def test_convert_exception_reads_metadata_from_nested_error_body() -> None:
+    """Bodies that keep the ``{"error": {...}}`` nesting are unwrapped."""
+    error = _BodyError(
+        {"error": {"param": "reasoning_effort", "code": "unsupported_parameter", "type": "invalid_request_error"}},
+        "Invalid request",
+    )
+    result = convert_exception(error, "openai")
+    assert result.param == "reasoning_effort"
+    assert result.code == "unsupported_parameter"
+    assert result.error_type == "invalid_request_error"
+
+
+def test_convert_exception_prefers_attribute_over_body() -> None:
+    error = _BodyError({"param": "from_body"}, "Invalid request")
+    error.param = "from_attribute"  # type: ignore[attr-defined]
+    assert convert_exception(error, "openai").param == "from_attribute"
+
+
+def test_convert_exception_prefers_nested_error_detail_over_envelope() -> None:
+    """When a body nests an ``error`` dict, that detail wins over the envelope."""
+    error = _BodyError({"param": "envelope", "error": {"param": "detail"}}, "Invalid request")
+    assert convert_exception(error, "openai").param == "detail"
+
+
+def test_convert_exception_ignores_anthropic_envelope_type() -> None:
+    """Anthropic's envelope carries a literal ``"type": "error"`` alongside the
+    real category in the nested dict; the nested value must win."""
+    error = _BodyError(
+        {"type": "error", "error": {"type": "invalid_request_error", "message": "Invalid request"}},
+        "Invalid request",
+    )
+    assert convert_exception(error, "openai").error_type == "invalid_request_error"
+
+
+@pytest.mark.parametrize("body", [None, "not a dict", 42, ["param"], {"error": "not a dict"}])
+def test_convert_exception_tolerates_unusable_body(body: Any) -> None:
+    """A body that is not a dict (or whose ``error`` is not a dict) yields no metadata."""
+    result = convert_exception(_BodyError(body, "Invalid request"), "openai")
+    assert result.param is None
+    assert result.code is None
+    assert result.error_type is None
+
+
+def test_convert_exception_ignores_non_string_body_values() -> None:
+    """OpenAI sends ``'code': None`` on some errors; non-strings are treated as absent."""
+    error = _BodyError({"param": None, "code": 500, "type": ["invalid"]}, "Invalid request")
+    result = convert_exception(error, "openai")
+    assert result.param is None
+    assert result.code is None
+    assert result.error_type is None
+
+
+def test_convert_exception_leaves_metadata_none_for_non_http_failure() -> None:
+    """A timeout carries no HTTP status, so every structured field stays None."""
+    result = convert_exception(TimeoutError("request timed out"), "openai")
+    assert isinstance(result, ProviderError)
+    assert result.status_code is None
+    assert result.code is None
+    assert result.param is None
+    assert result.error_type is None
+
+
+def test_convert_exception_carries_metadata_onto_rate_limit_error() -> None:
+    """RateLimitError overrides ``__init__``, so it must forward the new fields."""
+    error = _StatusError(429, "Rate limit exceeded", code="rate_limit_exceeded", type="rate_limit_error")
+    result = convert_exception(error, "openai")
+    assert isinstance(result, RateLimitError)
+    assert result.status_code == 429
+    assert result.code == "rate_limit_exceeded"
+    assert result.error_type == "rate_limit_error"
+    assert result.retry_after is None
+
+
+def test_convert_exception_preserves_already_unified_error_untouched() -> None:
+    """An AnyLLMError passes through with the metadata it was built with."""
+    original = InvalidRequestError("Invalid request", status_code=400, param="reasoning_effort")
+    result = convert_exception(original, "openai")
+    assert result is original
+    assert result.status_code == 400
+    assert result.param == "reasoning_effort"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`AnyLLMError` and its subclasses preserved only `message`, `original_exception`, and `provider_name`. The structured fields the provider SDKs already populate (`status_code`, `param`, `code`, `type`) were dropped from the unified exception and survived only on `original_exception`, so a consumer had to unwrap it and couple to each raw SDK's attribute layout. That defeats the purpose of the unified layer, and it gets worse once unified exceptions become the default.

This implements **all three** items of the proposal in #1190, and fills in `RateLimitError.retry_after`, which turned out to be dead in the same way.

> [!IMPORTANT]
> Item 3 changes classification behavior, so this PR is **not** behavior-preserving. See "Item 3" below for exactly what changes and why it is not implemented the way the issue words it.

**`src/any_llm/exceptions.py`**

Four optional, keyword-only fields on `AnyLLMError.__init__`: `status_code`, `code`, `param`, `error_type`. Keyword-only so they can't collide positionally with `RateLimitError`'s existing `retry_after`. Named `error_type` rather than `type` to avoid shadowing the builtin on the instance. `RateLimitError` overrides `__init__`, so it forwards them explicitly.

Additive and backward compatible: every field defaults to `None`, and no existing construction site had to change.

**`RateLimitError.retry_after`**

Also populated, from the `Retry-After` header on the attached response. The field has documented itself as "Value of the `Retry-After` header, when the server provides one" since it was added, but nothing in any-llm ever set it, so it was dead and the docstring promised something no code delivered. Returned verbatim, because the header is either a number of seconds or an HTTP-date and normalizing would throw away the caller's ability to tell them apart. Assigned after construction under an `isinstance` narrowing, since `retry_after` exists only on `RateLimitError` while the shared construction site is typed against the base.

**`src/any_llm/utils/exception_handler.py`**

`convert_exception` now extracts the metadata once, best-effort and provider-agnostic:

- `status_code` from `exc.status_code`, falling back to `exc.response.status_code`. Non-int values (a `MagicMock`, a stringified status) are treated as absent.
- `code` / `param` / `type` from the exception's own attributes, falling back to the parsed `body` dict.
- Non-HTTP failures (timeout, connection error) simply yield `status_code=None`. Nothing raises on providers that expose less.

One judgment call worth reviewing: when `body` nests an `error` dict, **the nested detail wins over the envelope**. The OpenAI client unwraps `body["error"]` before constructing the exception, so its fields sit at the top level and ordering is moot there. Where the nesting survives, the outer dict is only an envelope: Anthropic sends a literal `{"type": "error", "error": {"type": "invalid_request_error"}}`, and reading the outer value would report `error_type="error"` instead of the real category.

The regex chain became an ordered `(pattern, error_class)` table so the metadata is attached at a single construction site, instead of threading four keyword arguments through eleven duplicated constructor calls (which a future branch would forget). The patterns and their order are unchanged; what changes is when the table is consulted at all, which is item 3 below.

## Item 3: classify by HTTP status first

Message-string matching misclassifies whenever the body disagrees with the status. A 500 whose body mentions "policy" landed in the content-filter branch, and any status paired with an unhelpful body (`"Something went wrong"`) fell through to `ProviderError`, so a 429 was indistinguishable from an outage.

**This is not implemented the way the issue words it.** Keying 400/422 straight to `InvalidRequestError` would make `ContextLengthExceededError` and `ContentFilterError` unreachable for every provider that reports a status, because OpenAI returns 400 for both. It would also downgrade the providers that report a bad API key as a 400 (Gemini returns 400 `INVALID_ARGUMENT` for `"API key not valid"`). I reproduced that before writing the code:

```
status  today (regex)                item 3 as worded         change?
   400  ContextLengthExceededError   InvalidRequestError      ** REGRESSION
   400  ContentFilterError           InvalidRequestError      ** REGRESSION
```

So the status **narrows** and the message **disambiguates within it**:

- 401/403, 402, 404, 429, 502, 504 key directly. The 402/502/504 entries also align the code with what those exception docstrings have always claimed.
- Other 5xx are `ProviderError`, whatever the body says.
- 400/422 run the pattern table, because only the message says *why* the request was rejected, with `InvalidRequestError` as the floor rather than falling through to `ProviderError`.
- No status, or a status with no agreed meaning here (409, 413, 3xx), leaves the patterns fully in charge, unchanged.

### What actually changes

A differential harness loads `main`'s `convert_exception` alongside the new one and crosses 15 statuses with 26 realistic provider messages: **237 of 390 cases change class, and 0 status-free inputs change.** Every transition is in the intended direction:

| Transition | Statuses | Why |
| --- | --- | --- |
| `ProviderError` → `InvalidRequestError` | 400, 422 | rejected request with an unhelpful body |
| `ProviderError` → `AuthenticationError` | 401, 403 | ditto, status is authoritative |
| `ProviderError` → `RateLimitError` / `ModelNotFoundError` / `InsufficientFundsError` / `UpstreamProviderError` / `GatewayTimeoutError` | 429 / 404 / 402 / 502 / 504 | ditto |
| `ContentFilterError` → `ProviderError` | 500, 503, 529 | **the misclassification #1190 calls out** |
| `AuthenticationError` / `RateLimitError` / `ContextLengthExceededError` → `ProviderError` | 500, 503, 529 | a 5xx is a provider fault regardless of body |

The existing suite passes untouched, because its fixtures pair statuses with agreeing messages. Note the 237 figure comes from crossing every status with every message, so it includes combinations that do not occur in practice (a 504 whose body talks about rate limits); it is an upper bound on the blast radius, not a count of real-world cases.

### Deliberately out of scope

- **Carrying `body`**. The issue's summary mentions it, but item 1 lists only the four named fields, and `body` is the raw untyped provider payload rather than structured metadata: exposing it would re-introduce the coupling the unified layer exists to hide. Consumers who need it still have `original_exception`.

### Verified downstream shape

The motivating case from mozilla-ai/otari#331, driven through the real OpenAI client so the body unwrapping is not simulated:

```python
exc = client._make_status_error("Error code: 400", body=raw, response=resp)
u = convert_exception(exc, "openai")
# InvalidRequestError | status_code=400 | param='reasoning_effort' | error_type='invalid_request_error'
```

A consumer can now write `exc.status_code in (400, 422) and exc.param == "reasoning_effort"` without touching `original_exception`.

## PR Type

- 🆕 New Feature
- 💅 Refactor

Note: item 3 is a behavior change to exception classification. Worth a minor-version note if that matters for the release.

## Relevant issues

Fixes #1190
Unblocks mozilla-ai/otari#331

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

Test detail: 70 new unit tests. Provider-agnostic ones in `tests/unit/test_exception_handler.py` cover every extraction branch (attribute vs body vs nested body, precedence, non-int status, non-string body values, unusable bodies, non-HTTP failures, and `RateLimitError`'s forwarding). Real-SDK ones in `tests/unit/providers/test_openai_exceptions.py` and `test_anthropic_exceptions.py` pin both shapes, including Anthropic reporting `error_type` with no `param`/`code` equivalent.

Definition of done, run locally:

1. `uv run pre-commit run --all-files` clean, including `mypy` strict on 276 source files.
2. `uv run pytest tests/unit` green on Python 3.11 and 3.13: 1710 passed, 67 skipped. `tests/docs` green too. `exceptions.py` at 100% coverage, `exception_handler.py` at 92% with every new line covered (the remaining misses are pre-existing lines in `_handle_exception` and the streaming decorator, untouched here).
3. No provider integration behavior changed, so no integration run: this only reads attributes off exceptions the providers already raise, and the SDK shapes are pinned by the unit tests above. Happy to have `run-integration-tests` applied if you'd prefer the confirmation.

Docs: added "Structured Error Metadata" and "How the Exception Type Is Chosen" sections to `docs/quickstart.md`, next to the existing "Accessing Original Exceptions" section. The second documents the status table, since classification is now part of the observable contract.


## Guard tests for the pattern table

Two tests specifically cover the risk the single construction site introduces:

- `test_every_pattern_class_accepts_the_metadata_keywords` iterates `_ERROR_PATTERNS` and constructs each class with the full keyword set. `convert_exception` builds through an `error_class: type[AnyLLMError]` variable, so mypy validates the call against the **base** signature only; four subclasses in `exceptions.py` (`MissingApiKeyError`, `UnsupportedProviderError`, `BatchNotCompleteError`, `_FinishReasonError`) have incompatible `__init__`s and would pass the type check, then raise `TypeError` inside the exception handler and mask the provider's original error.
- `test_convert_exception_classification_order_is_pinned` pins one representative message per table entry plus the unmatched fallback, so a reorder or a broadened pattern fails loudly. This also closes a pre-existing gap: `ContentFilterError` and `ContextLengthExceededError` had no classification assertion anywhere in the suite.

## Known coverage limits

Not a regression, but worth stating since the docs now promise these fields. `google.genai.errors.APIError` keeps the HTTP status in `.code` as an `int` and the category in `.status` (`"INVALID_ARGUMENT"`), and exposes no `.body`, so Gemini yields only `status_code` and only when `.response` is set. I deliberately did **not** broaden `_extract_status_code` to accept an integer `.code`: some OpenAI-compatible gateways return a numeric error code there, which would surface as a bogus `status_code`, and a wrong status is worse than `None`. An integer `code` in a body is dropped for the same reason (the field is typed `str | None`).

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Filed as the upstream half of mozilla-ai/otari#331, where the generic 400 flattening was first noticed. The otari-side fix already landed against raw SDK exceptions; this is what lets it drop the `original_exception` unwrap once unified exceptions are the default.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified exceptions now expose structured provider error details, including HTTP status, error code, parameter and error type.
  * Rate-limit errors retain retry information alongside available structured metadata.
  * Error details are extracted from provider responses where available, with graceful handling when fields are unavailable.
  * Exceptions are classified more consistently using recognised status codes and error messages.

* **Documentation**
  * Added Quickstart guidance and examples for handling structured error metadata.

* **Tests**
  * Expanded coverage across providers, including nested responses, invalid fields, rate limits and status-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->