### PR TITLE
fix(anthropic): tolerate a models listing without created_at

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -511,8 +511,23 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
 
 
 def _convert_models_list(models_list: list[AnthropicModelInfo]) -> list[Model]:
-    """Convert Anthropic models list to OpenAI format."""
+    """Convert Anthropic models list to OpenAI format.
+
+    ``created_at`` is required by ``ModelInfo``, but an Anthropic-compatible
+    proxy or gateway may serve ``/v1/models`` in the OpenAI shape, which carries
+    an integer ``created`` and no ``created_at``. The SDK constructs the model
+    without validation, so the field is present but ``None``, and calling
+    ``.timestamp()`` on it raises ``AttributeError: 'NoneType' object has no
+    attribute 'timestamp'`` for the whole listing. Fall back to ``0`` for that
+    entry instead, matching what ``_create_openai_completion_from_anthropic``
+    already does for a response missing the same field.
+    """
     return [
-        Model(id=model.id, object="model", created=int(model.created_at.timestamp()), owned_by="anthropic")
+        Model(
+            id=model.id,
+            object="model",
+            created=int(model.created_at.timestamp()) if model.created_at is not None else 0,
+            owned_by="anthropic",
+        )
         for model in models_list
     ]

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1,12 +1,13 @@
 import dataclasses
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, contextmanager
-from datetime import UTC
+from datetime import UTC, datetime
 from typing import Any, cast, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from anthropic import transform_schema
+from anthropic.types.model_info import ModelInfo
 from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
@@ -14,6 +15,7 @@ from any_llm.providers.anthropic.anthropic import AnthropicProvider
 from any_llm.providers.anthropic.utils import (
     DEFAULT_MAX_TOKENS,
     REASONING_EFFORT_TO_ANTHROPIC_EFFORT,
+    _convert_models_list,
     _convert_response_format,
     _convert_tool_spec,
 )
@@ -1279,3 +1281,48 @@ def test_convert_tool_spec_parameters_missing_properties() -> None:
     tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}])
     assert len(tools) == 1
     assert tools[0]["input_schema"]["properties"] == {}
+
+
+def test_convert_models_list_uses_created_at() -> None:
+    """The normal path: a real Anthropic listing carries created_at."""
+    created_at = datetime(2026, 2, 19, tzinfo=UTC)
+    model = ModelInfo.construct(id="claude-opus-4-5", type="model", display_name="Opus", created_at=created_at)
+
+    result = _convert_models_list([model])
+
+    assert len(result) == 1
+    assert result[0].id == "claude-opus-4-5"
+    assert result[0].created == int(created_at.timestamp())
+    assert result[0].owned_by == "anthropic"
+
+
+def test_convert_models_list_missing_created_at() -> None:
+    """Regression: created_at=None must not raise "'NoneType' object has no attribute 'timestamp'".
+
+    ModelInfo requires created_at, but an Anthropic-compatible gateway may serve
+    /v1/models in the OpenAI shape, which has an integer "created" and no
+    "created_at". The SDK constructs the model without validating, so the
+    attribute exists and is None, and the whole listing used to fail.
+    """
+    model = ModelInfo.construct(id="gateway-alias:some-model", type="model", display_name="Alias", created_at=None)
+
+    result = _convert_models_list([model])
+
+    assert len(result) == 1
+    assert result[0].id == "gateway-alias:some-model"
+    assert result[0].created == 0
+    assert result[0].owned_by == "anthropic"
+
+
+def test_convert_models_list_mixed_created_at() -> None:
+    """One entry missing created_at must not discard the entries that have it."""
+    created_at = datetime(2026, 2, 19, tzinfo=UTC)
+    models = [
+        ModelInfo.construct(id="with", type="model", display_name="With", created_at=created_at),
+        ModelInfo.construct(id="without", type="model", display_name="Without", created_at=None),
+    ]
+
+    result = _convert_models_list(models)
+
+    assert [m.id for m in result] == ["with", "without"]
+    assert [m.created for m in result] == [int(created_at.timestamp()), 0]


### PR DESCRIPTION
## Description

`alist_models` against an Anthropic-compatible gateway raises

```
AttributeError: 'NoneType' object has no attribute 'timestamp'
```

and the entire listing fails.

`ModelInfo` declares `created_at` as required, so `_convert_models_list` calls `.timestamp()` on it unconditionally. But a proxy or gateway that speaks the Anthropic **messages** API may serve `/v1/models` in the **OpenAI** shape, which carries an integer `created` and no `created_at`. The SDK constructs `ModelInfo` without validating, so the attribute is present and `None` rather than absent, which is why a `hasattr` guard would not have caught it either.

Fall back to `0` for that entry. This matches what `_create_openai_completion_from_anthropic` already does a few hundred lines up in the same module, where it guards the same field for a response that lacks it:

```python
created_ts = int(response.created_at.timestamp()) if hasattr(response, "created_at") else 0
```

So the two conversion paths now agree instead of one being strict and the other lenient.

Found against a self-hosted [mozilla-ai/otari](https://github.com/mozilla-ai/otari) gateway, whose `/v1/messages` is Anthropic-format while `/v1/models` is OpenAI-format. An Anthropic-native client could complete requests but could never enumerate models, which broke a downstream app's model picker.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None filed; found while debugging a downstream model-listing failure.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

Three tests in `tests/unit/providers/test_anthropic_provider.py`: the normal `created_at` path, the `None` path (which reproduces the exact `AttributeError` above when the fix is reverted, verified), and a mixed list confirming one bad entry no longer discards the good ones.

Verified locally: `mypy src` clean on 158 files, `pytest tests/unit` 1650 passed / 67 skipped, and `ruff check` + `ruff format --check` clean on the changed files at the version pinned in `.pre-commit-config.yaml` (v0.15.20).

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The failure was first observed in production as a downstream model-picker error, then reproduced here against the real `anthropic` SDK types rather than inferred from reading the code.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model list handling when creation dates are unavailable.
  * Models without a creation date are now retained and shown with a default creation timestamp instead of causing an error.

* **Tests**
  * Added coverage for valid, missing, and mixed creation-date values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->