### PR TITLE
feat(openai): support Responses API context compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,35 @@ compaction items are preserved in `result.output` and can be replayed with the
 rest of the response output on the next stateless request.
 
 ```python
+conversation = [
+    {"role": "user", "content": "Let's begin a long coding task."}
+]
+context_management = [
+    {"type": "compaction", "compact_threshold": 200_000}
+]
+
 result = responses(
     model="gpt-5.3-codex",
     provider="openai",
     input_data=conversation,
     store=False,
-    context_management=[
-        {"type": "compaction", "compact_threshold": 200_000}
-    ],
+    include=["reasoning.encrypted_content"],
+    context_management=context_management,
+)
+
+conversation.extend(
+    item.model_dump(exclude_none=True) for item in result.output
+)
+conversation.append(
+    {"role": "user", "content": "Continue with the next step."}
+)
+follow_up = responses(
+    model="gpt-5.3-codex",
+    provider="openai",
+    input_data=conversation,
+    store=False,
+    include=["reasoning.encrypted_content"],
+    context_management=context_management,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -194,46 +194,6 @@ result = responses(
 print(result.output_text)
 ```
 
-OpenAI Responses can compact long-running conversations on the server. Returned
-compaction items are preserved in `result.output` and can be replayed with the
-rest of the response output on the next stateless request.
-
-```python
-conversation = [
-    {"role": "user", "content": "Let's begin a long coding task."}
-]
-context_management = [
-    {"type": "compaction", "compact_threshold": 200_000}
-]
-
-result = responses(
-    model="gpt-5.3-codex",
-    provider="openai",
-    input_data=conversation,
-    store=False,
-    include=["reasoning.encrypted_content"],
-    context_management=context_management,
-)
-
-conversation.extend(
-    item.model_dump(exclude_none=True) for item in result.output
-)
-conversation.append(
-    {"role": "user", "content": "Continue with the next step."}
-)
-follow_up = responses(
-    model="gpt-5.3-codex",
-    provider="openai",
-    input_data=conversation,
-    store=False,
-    include=["reasoning.encrypted_content"],
-    context_management=context_management,
-)
-```
-
-See [OpenAI's compaction guide](https://platform.openai.com/docs/guides/compaction)
-for conversation pruning and `previous_response_id` guidance.
-
 ### Finding the Right Model
 
 The `provider_id` should match our [supported provider names](https://docs.mozilla.ai/any-llm/providers/).

--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ result = responses(
 print(result.output_text)
 ```
 
+OpenAI Responses can compact long-running conversations on the server. Returned
+compaction items are preserved in `result.output` and can be replayed with the
+rest of the response output on the next stateless request.
+
+```python
+result = responses(
+    model="gpt-5.3-codex",
+    provider="openai",
+    input_data=conversation,
+    store=False,
+    context_management=[
+        {"type": "compaction", "compact_threshold": 200_000}
+    ],
+)
+```
+
+See [OpenAI's compaction guide](https://platform.openai.com/docs/guides/compaction)
+for conversation pruning and `previous_response_id` guidance.
+
 ### Finding the Right Model
 
 The `provider_id` should match our [supported provider names](https://docs.mozilla.ai/any-llm/providers/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 version = "0.0.0-dev" # There is a regex in the release.yaml file that looks for this version string to set the version in the pyproject.toml file. Do not change this version string without updating the regex.
 dependencies = [
   "pydantic>2,<3",
-  "openai>=1.99.3",
+  "openai>=2.18.0",
   "openresponses-types>=2.3.0.post1",
   "anthropic>=0.83.0",
   "rich",

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1016,6 +1016,7 @@ class AnyLLM(ABC):
         presence_penalty: float | None = None,
         frequency_penalty: float | None = None,
         truncation: str | None = None,
+        context_management: list[dict[str, Any]] | None = None,
         store: bool | None = None,
         service_tier: str | None = None,
         user: str | None = None,
@@ -1060,6 +1061,9 @@ class AnyLLM(ABC):
             presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
             frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
             truncation: Controls how the service truncates input when it exceeds the model context window.
+            context_management: OpenAI Responses context management configuration. Use a
+                `compaction` entry with `compact_threshold` to enable server-side compaction;
+                see [OpenAI's compaction documentation](https://platform.openai.com/docs/guides/compaction).
             store: Whether to store the response so it can be retrieved later.
             service_tier: The service tier to use for this request.
             user: A unique identifier representing your end user.
@@ -1111,6 +1115,7 @@ class AnyLLM(ABC):
             presence_penalty=presence_penalty,
             frequency_penalty=frequency_penalty,
             truncation=truncation,
+            context_management=context_management,
             store=store,
             service_tier=service_tier,
             user=user,

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -262,6 +262,7 @@ def responses(
     presence_penalty: float | None = None,
     frequency_penalty: float | None = None,
     truncation: str | None = None,
+    context_management: list[dict[str, Any]] | None = None,
     store: bool | None = None,
     service_tier: str | None = None,
     user: str | None = None,
@@ -313,6 +314,9 @@ def responses(
         presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
         frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
         truncation: Controls how the service truncates input when it exceeds the model context window.
+        context_management: OpenAI Responses context management configuration. Use a
+            `compaction` entry with `compact_threshold` to enable server-side compaction;
+            see [OpenAI's compaction documentation](https://platform.openai.com/docs/guides/compaction).
         store: Whether to store the response so it can be retrieved later.
         service_tier: The service tier to use for this request.
         user: A unique identifier representing your end user.
@@ -368,6 +372,7 @@ def responses(
         presence_penalty=presence_penalty,
         frequency_penalty=frequency_penalty,
         truncation=truncation,
+        context_management=context_management,
         store=store,
         service_tier=service_tier,
         user=user,
@@ -406,6 +411,7 @@ async def aresponses(
     presence_penalty: float | None = None,
     frequency_penalty: float | None = None,
     truncation: str | None = None,
+    context_management: list[dict[str, Any]] | None = None,
     store: bool | None = None,
     service_tier: str | None = None,
     user: str | None = None,
@@ -457,6 +463,9 @@ async def aresponses(
         presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
         frequency_penalty: Penalizes new tokens based on their frequency in the text so far.
         truncation: Controls how the service truncates input when it exceeds the model context window.
+        context_management: OpenAI Responses context management configuration. Use a
+            `compaction` entry with `compact_threshold` to enable server-side compaction;
+            see [OpenAI's compaction documentation](https://platform.openai.com/docs/guides/compaction).
         store: Whether to store the response so it can be retrieved later.
         service_tier: The service tier to use for this request.
         user: A unique identifier representing your end user.
@@ -512,6 +521,7 @@ async def aresponses(
         presence_penalty=presence_penalty,
         frequency_penalty=frequency_penalty,
         truncation=truncation,
+        context_management=context_management,
         store=store,
         service_tier=service_tier,
         user=user,

--- a/src/any_llm/types/responses.py
+++ b/src/any_llm/types/responses.py
@@ -94,6 +94,9 @@ class ResponsesParams(BaseModel):
     truncation: str | None = None
     """Controls how the service truncates the input when it exceeds the model context window."""
 
+    context_management: list[dict[str, Any]] | None = None
+    """OpenAI Responses context management configuration."""
+
     store: bool | None = None
     """Whether to store the response so it can be retrieved later."""
 

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -3,7 +3,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses import ResponseCompactionItem, ResponseOutputMessage, ResponseOutputText
 from pydantic import BaseModel
 
 from any_llm.providers.openai.base import BaseOpenAIProvider
@@ -44,6 +44,24 @@ def _make_openai_response(text: str) -> Response:
         model="test-model",
         object="response",
         output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+def _make_openai_compaction_response() -> Response:
+    compaction = ResponseCompactionItem(
+        id="cmp-1",
+        type="compaction",
+        encrypted_content="opaque-compacted-context",
+    )
+    return Response(
+        id="resp-compaction",
+        created_at=0,
+        model="gpt-5.3-codex",
+        object="response",
+        output=[compaction],
         parallel_tool_calls=False,
         tool_choice="auto",
         tools=[],
@@ -136,6 +154,42 @@ async def test_aresponses_without_response_format_returns_response(mock_openai_c
     assert "text" not in mock_client.responses.create.call_args.kwargs
     assert isinstance(result, Response)
     assert not isinstance(result, ParsedResponse)
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_context_management_preserves_compaction_item(mock_openai_class: MagicMock) -> None:
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_openai_compaction_response())
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+    result = await provider.aresponses(
+        model="gpt-5.3-codex",
+        input_data="Continue the coding task.",
+        context_management=context_management,
+    )
+
+    assert mock_client.responses.create.call_args.kwargs["context_management"] == context_management
+    assert isinstance(result, Response)
+    assert isinstance(result.output[0], ResponseCompactionItem)
+    assert result.output[0].encrypted_content == "opaque-compacted-context"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_replays_compaction_item_unchanged(mock_openai_class: MagicMock) -> None:
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_openai_response("Done"))
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    compaction_input = _make_openai_compaction_response().output[0].model_dump(exclude_none=True)
+    input_data = [compaction_input, {"role": "user", "content": "Continue."}]
+    await provider.aresponses(model="gpt-5.3-codex", input_data=input_data)
+
+    assert mock_client.responses.create.call_args.kwargs["input"] == input_data
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -152,6 +152,7 @@ async def test_aresponses_without_response_format_returns_response(mock_openai_c
 
     mock_client.responses.parse.assert_not_called()
     assert "text" not in mock_client.responses.create.call_args.kwargs
+    assert "context_management" not in mock_client.responses.create.call_args.kwargs
     assert isinstance(result, Response)
     assert not isinstance(result, ParsedResponse)
 

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from any_llm import AnyLLM
-from any_llm.api import acompletion, aresponses
+from any_llm.api import acompletion, aresponses, responses
 from any_llm.constants import LLMProvider
 
 _PYTHON_314_INCOMPATIBLE_PROVIDERS = {"voyage", "watsonx"}
@@ -113,6 +113,29 @@ async def test_aresponses_context_management_parameter_capture() -> None:
             api_base=None,
         )
         assert mock_provider.aresponses.call_args.kwargs["context_management"] == context_management
+
+
+def test_responses_context_management_parameter_capture() -> None:
+    mock_provider = Mock()
+    mock_provider.responses = Mock(return_value=Mock())
+
+    with patch("any_llm.any_llm.AnyLLM.create") as mock_create:
+        mock_create.return_value = mock_provider
+        context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+
+        responses(
+            model="openai:gpt-5.3-codex",
+            input_data="Continue the coding task.",
+            context_management=context_management,
+            api_key="openai-key",
+        )
+
+        mock_create.assert_called_once_with(
+            LLMProvider.OPENAI,
+            api_key="openai-key",
+            api_base=None,
+        )
+        assert mock_provider.responses.call_args.kwargs["context_management"] == context_management
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -68,6 +68,7 @@ async def test_aresponses_parameter_capture() -> None:
             stream=True,
             instructions="Be helpful",
             parallel_tool_calls=True,
+            context_management=[{"type": "compaction", "compact_threshold": 200_000}],
             api_key="mistral-key-456",
             api_base="https://custom-mistral.example.com/v1",
             another_custom_param="another_value",
@@ -88,34 +89,12 @@ async def test_aresponses_parameter_capture() -> None:
         assert call_args.kwargs["stream"] is True
         assert call_args.kwargs["instructions"] == "Be helpful"
         assert call_args.kwargs["parallel_tool_calls"] is True
+        assert call_args.kwargs["context_management"] == [{"type": "compaction", "compact_threshold": 200_000}]
         assert call_args.kwargs["another_custom_param"] == "another_value"
 
 
-@pytest.mark.asyncio
-async def test_aresponses_context_management_parameter_capture() -> None:
-    mock_provider = Mock()
-    mock_provider.aresponses = AsyncMock(return_value=Mock())
-
-    with patch("any_llm.any_llm.AnyLLM.create") as mock_create:
-        mock_create.return_value = mock_provider
-        context_management = [{"type": "compaction", "compact_threshold": 200_000}]
-
-        await aresponses(
-            model="openai:gpt-5.3-codex",
-            input_data="Continue the coding task.",
-            context_management=context_management,
-            api_key="openai-key",
-        )
-
-        mock_create.assert_called_once_with(
-            LLMProvider.OPENAI,
-            api_key="openai-key",
-            api_base=None,
-        )
-        assert mock_provider.aresponses.call_args.kwargs["context_management"] == context_management
-
-
 def test_responses_context_management_parameter_capture() -> None:
+    """Test that the synchronous responses wrapper forwards context_management."""
     mock_provider = Mock()
     mock_provider.responses = Mock(return_value=Mock())
 

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -92,6 +92,30 @@ async def test_aresponses_parameter_capture() -> None:
 
 
 @pytest.mark.asyncio
+async def test_aresponses_context_management_parameter_capture() -> None:
+    mock_provider = Mock()
+    mock_provider.aresponses = AsyncMock(return_value=Mock())
+
+    with patch("any_llm.any_llm.AnyLLM.create") as mock_create:
+        mock_create.return_value = mock_provider
+        context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+
+        await aresponses(
+            model="openai:gpt-5.3-codex",
+            input_data="Continue the coding task.",
+            context_management=context_management,
+            api_key="openai-key",
+        )
+
+        mock_create.assert_called_once_with(
+            LLMProvider.OPENAI,
+            api_key="openai-key",
+            api_base=None,
+        )
+        assert mock_provider.aresponses.call_args.kwargs["context_management"] == context_management
+
+
+@pytest.mark.asyncio
 async def test_completion_invalid_model_format_no_slash() -> None:
     """Test completion raises ValueError for model without separator."""
     with pytest.raises(

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -37,6 +37,13 @@ def test_omitted_parallel_tool_calls_stays_none() -> None:
     assert "parallel_tool_calls" not in params.model_dump(exclude_none=True)
 
 
+def test_omitted_context_management_stays_none() -> None:
+    params = ResponsesParams(model="test", input="hello")
+
+    assert params.context_management is None
+    assert "context_management" not in params.model_dump(exclude_none=True)
+
+
 @pytest.mark.parametrize("value", [True, False])
 def test_explicit_parallel_tool_calls_preserved(value: bool) -> None:
     """Explicit True/False should be kept as-is."""

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -44,6 +44,14 @@ def test_explicit_parallel_tool_calls_preserved(value: bool) -> None:
     assert params.parallel_tool_calls is value
 
 
+def test_context_management_preserved() -> None:
+    context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+    params = ResponsesParams(model="test", input="hello", context_management=context_management)
+
+    assert params.context_management == context_management
+    assert params.model_dump(exclude_none=True)["context_management"] == context_management
+
+
 def test_responses_params_preserves_codex_continuation_items() -> None:
     """Responses input accepts Codex items not yet represented by the SDK union."""
     input_data: list[dict[str, Any]] = [

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -38,6 +38,7 @@ def test_omitted_parallel_tool_calls_stays_none() -> None:
 
 
 def test_omitted_context_management_stays_none() -> None:
+    """Omitted context_management should not appear in provider request."""
     params = ResponsesParams(model="test", input="hello")
 
     assert params.context_management is None
@@ -52,6 +53,7 @@ def test_explicit_parallel_tool_calls_preserved(value: bool) -> None:
 
 
 def test_context_management_preserved() -> None:
+    """An explicit context_management value is kept as-is for the provider request."""
     context_management = [{"type": "compaction", "compact_threshold": 200_000}]
     params = ResponsesParams(model="test", input="hello", context_management=context_management)
 


### PR DESCRIPTION
## Description

Adds first-class support for OpenAI Responses server-side context compaction.

- Exposes `context_management` through the synchronous and asynchronous Responses APIs.
- Preserves typed `ResponseCompactionItem` output and supports replaying it in stateless input history.
- Raises the minimum OpenAI SDK version to 2.18.0, the first release exposing `context_management` on Responses requests.
- Documents the parameter through its docstring, which links to OpenAI's compaction guidance and feeds the generated API reference.

> _Maintainer edit: the documentation bullet originally read "Documents the compaction request flow and links to OpenAI guidance." Commit 047aa93 removed the README section, so the parameter docstring is now the only documentation. Corrected for accuracy; nothing else in this description was changed. Wording drafted by Claude via back-and-forth with @njbrake._

## PR Type

- 🆕 New Feature
- 📚 Documentation

## Relevant issues

None.

## Testing

- Full pre-commit suite: passed
- `uv run pytest tests/unit`: 1735 passed, 67 skipped
- Minimum supported SDK check with `openai==2.18.0`: 133 targeted tests passed, 2 skipped
- Live baseline request without `context_management`: returned `BASELINE-OK`
- Live compaction request using `gpt-5.3-codex`:
  - Sent 213 conversation items with 212,446 API-counted input tokens
  - Used a 200,000 token compaction threshold
  - Received typed output items `compaction` and `message`
  - Received a non-empty encrypted compaction payload
  - Preserved the early conversation marker and returned `ORANGE-742`

The live test uses many historical conversation items because compaction needs earlier history to reduce. OpenAI returned a server error when the threshold was crossed by one oversized current input item with no prior turns available to compact.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol
- AI Developer Tool used: Pi
- Any other info you'd like to share: The agent researched the current OpenAI compaction API and SDK support, implemented the change, and ran the repository verification commands.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional context-management settings to synchronous and asynchronous Responses API calls.
  - Added support for server-side response compaction using configurable thresholds.
  - Compaction information is preserved and can be replayed consistently across requests.

- **Bug Fixes**
  - Ensured context-management settings are forwarded unchanged and omitted cleanly when not provided.

- **Tests**
  - Added coverage for synchronous and asynchronous requests, serialisation, compaction responses, and input preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
