### PR TITLE
fix(openai): suppress parsed response serializer warnings

### DIFF
--- a/src/any_llm/providers/openai/utils.py
+++ b/src/any_llm/providers/openai/utils.py
@@ -79,7 +79,7 @@ def _convert_chat_completion(response: OpenAIChatCompletion) -> ChatCompletion:
             type(response.created),
         )
         response.created = int(response.created)
-    normalized = _normalize_openai_dict_response(response.model_dump())
+    normalized = _normalize_openai_dict_response(response.model_dump(warnings=False))
     return ChatCompletion.model_validate(normalized)
 
 

--- a/tests/unit/providers/test_openai_utils.py
+++ b/tests/unit/providers/test_openai_utils.py
@@ -1,11 +1,46 @@
+import warnings
+
 import pytest
+from openai.lib._parsing._completions import parse_chat_completion
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
+from pydantic import BaseModel
 
 from any_llm.exceptions import ProviderError
 from any_llm.providers.openai.base import BaseOpenAIProvider
-from any_llm.providers.openai.utils import _convert_chat_completion
+from any_llm.providers.openai.utils import _convert_chat_completion, _convert_parsed_chat_completion
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
+
+
+class Answer(BaseModel):
+    answer: str
+
+
+def test_convert_parsed_chat_completion_does_not_emit_serializer_warning() -> None:
+    """The SDK's parsed response path must not warn while preserving parsed data."""
+    raw = OpenAIChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-offline",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "gpt-4o-mini",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": '{"answer":"Earth"}'},
+                }
+            ],
+        }
+    )
+    parsed = parse_chat_completion(response_format=Answer, input_tools=[], chat_completion=raw)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        converted = _convert_parsed_chat_completion(parsed)
+
+    assert not any("Pydantic serializer warnings" in str(item.message) for item in caught)
+    assert converted.choices[0].message.parsed == Answer(answer="Earth")
 
 
 def test_convert_chat_completion_with_empty_response() -> None:


### PR DESCRIPTION
## Description

Suppress the Pydantic serializer warning emitted when converting parsed OpenAI Chat Completions. The OpenAI SDK can construct a parsed response with an unbound TypeVar schema even though the parsed value is valid; passing `warnings=False` to `model_dump` avoids a warning for this discarded serialization while preserving the parsed value. Adds an offline regression test using the SDK's real `parse_chat_completion` path.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #1203

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally (focused tests pass; full unit suite timed out locally)
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: The change and regression test were reviewed against the issue's offline reproduction.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of parsed OpenAI chat-completion responses.
  * Prevented unnecessary serialisation warnings during response processing.
  * Ensured parsed answers remain intact when converted.

* **Tests**
  * Added coverage for parsed responses and warning-free conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->