### PR TITLE
fix(messages): flatten Anthropic system content blocks for OpenAI backends

### DIFF
--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -42,6 +42,19 @@ def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str
     return {"type": "json_schema", "json_schema": {"name": name, "schema": schema}}
 
 
+def _convert_system_to_openai(system: str | list[dict[str, Any]]) -> str:
+    """Flatten an Anthropic system value to a plain string.
+
+    Anthropic accepts a list of text blocks so callers can attach cache_control
+    breakpoints. OpenAI-compatible backends validate the system message as
+    str | list[content_part] and reject the extra cache_control key, so send
+    the concatenated text instead.
+    """
+    if isinstance(system, str):
+        return system
+    return "".join(b.get("text", "") for b in system if b.get("type") == "text")
+
+
 def messages_params_to_completion_params(params: MessagesParams) -> dict[str, Any]:
     """Convert MessagesParams (Anthropic format) to kwargs suitable for CompletionParams.
 
@@ -50,7 +63,7 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
     messages: list[dict[str, Any]] = []
 
     if params.system:
-        messages.append({"role": "system", "content": params.system})
+        messages.append({"role": "system", "content": _convert_system_to_openai(params.system)})
 
     for msg in params.messages:
         converted = _convert_message_to_openai(msg)

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -19,6 +19,7 @@ from any_llm.types.completion import (
 from any_llm.types.messages import MessagesParams
 from any_llm.utils.messages_compat import (
     StreamingState,
+    _convert_system_to_openai,
     chat_completion_chunk_to_message_stream_events,
     chat_completion_to_message_response,
     messages_params_to_completion_params,
@@ -100,6 +101,109 @@ def test_system_message_prepended() -> None:
     result = messages_params_to_completion_params(params)
     assert result["messages"][0] == {"role": "system", "content": "You are helpful."}
     assert result["messages"][1]["role"] == "user"
+
+
+def test_system_string_unchanged() -> None:
+    """Test that a plain string system value is passed through unchanged."""
+    result = _convert_system_to_openai("You are helpful.")
+    assert result == "You are helpful."
+
+
+def test_system_block_list_flattened() -> None:
+    """Test that a list of system content blocks is flattened to a string."""
+    system = [{"type": "text", "text": "You are a helpful assistant."}]
+    result = _convert_system_to_openai(system)
+    assert result == "You are a helpful assistant."
+
+
+def test_system_block_list_with_cache_control_stripped() -> None:
+    """Test that cache_control markers are removed when flattening system blocks."""
+    system = [
+        {
+            "type": "text",
+            "text": "You are a helpful assistant.",
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+        }
+    ]
+    result = _convert_system_to_openai(system)
+    assert result == "You are a helpful assistant."
+    assert "cache_control" not in str(result)
+
+
+def test_system_multiple_blocks_concatenated() -> None:
+    """Test that multiple text blocks in system are concatenated."""
+    system = [
+        {"type": "text", "text": "You are helpful. "},
+        {"type": "text", "text": "Be concise."},
+    ]
+    result = _convert_system_to_openai(system)
+    assert result == "You are helpful. Be concise."
+
+
+def test_system_mixed_block_types_text_extracted() -> None:
+    """Test that only text blocks are extracted, non-text blocks are ignored."""
+    system = [
+        {"type": "text", "text": "Be helpful. "},
+        {"type": "image", "source": "ignored"},
+        {"type": "text", "text": "Be concise."},
+    ]
+    result = _convert_system_to_openai(system)
+    assert result == "Be helpful. Be concise."
+
+
+def test_system_empty_block_list() -> None:
+    """Test that an empty system block list returns an empty string."""
+    system: list[dict[str, Any]] = []
+    result = _convert_system_to_openai(system)
+    assert result == ""
+
+
+def test_system_block_without_text_field() -> None:
+    """Test that blocks without a 'text' field contribute empty strings."""
+    system = [
+        {"type": "text", "text": "Hello"},
+        {"type": "text"},  # Missing 'text' field
+        {"type": "text", "text": " world"},
+    ]
+    result = _convert_system_to_openai(system)
+    assert result == "Hello world"
+
+
+def test_system_content_block_in_messages_params() -> None:
+    """Test converting MessagesParams with system content blocks."""
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        system=[
+            {
+                "type": "text",
+                "text": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["messages"][0] == {
+        "role": "system",
+        "content": "You are a helpful assistant.",
+    }
+
+
+def test_system_no_cache_control_in_output() -> None:
+    """Test that cache_control never appears in the completion params output."""
+    params = MessagesParams(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "test"}],
+        max_tokens=1024,
+        system=[
+            {"type": "text", "text": "System ", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "prompt", "cache_control": {"type": "ephemeral"}},
+        ],
+    )
+    result = messages_params_to_completion_params(params)
+    result_str = str(result)
+    assert "cache_control" not in result_str
 
 
 def test_tool_conversion_to_openai() -> None:


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`messages_params_to_completion_params` passed the Anthropic `system` value into the OpenAI message body without converting it. When `system` is a list of content blocks, which is the shape Anthropic requires in order to attach a `cache_control` breakpoint, that list landed verbatim in `messages[0].content` and strict OpenAI-compatible backends rejected the request with a 400.

The system field was the only one in this function that was not converted. Every sibling converter already normalizes and drops `cache_control` as a side effect of rebuilding its output:

- `_convert_user_blocks_to_openai` rebuilds text blocks as `{"type": "text", "text": ...}`
- `_convert_assistant_blocks_to_openai` joins text parts into a plain string
- `_convert_tools_to_openai` rebuilds tool defs from name, description and `input_schema`

So a caller that stamps the four breakpoints Anthropic allows had three of them silently normalized away and the fourth forwarded as an unconvertible payload.

This adds `_convert_system_to_openai`, which returns a plain string unchanged and otherwise joins the `text` of every `type: "text"` block, and routes `params.system` through it.

The flatten is unconditional rather than a per-provider capability flag or a registry row field. There is no provider for which forwarding the raw block list is correct, because every provider that understands Anthropic `cache_control` overrides `_amessages` and never reaches this function. On `main` those are `anthropic`, `azureanthropic`, `vertexaianthropic` and `otari`; the other 47 provider directories inherit `AnyLLM._amessages` and can hit this.

One behavior worth calling out: a `system` list containing only non-text blocks flattens to `""`, producing an empty system message rather than omitting it. Anthropic's `system` only accepts text blocks, so this is a degenerate case, and it matches the implementation proposed in the issue.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1228

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

### Verification

The reproduction from the issue now prints the expected `{'role': 'system', 'content': 'You are a helpful assistant.'}`. The new tests were confirmed to fail without the source change.

Nine unit tests were added in `tests/unit/test_messages_compat.py`: plain string unchanged, single block flattened, `cache_control` stripped, multiple blocks concatenated, non-text blocks skipped, empty list, a block missing its `text` key, plus two end-to-end through `messages_params_to_completion_params` asserting the exact expected message and that `cache_control` appears nowhere in the output.

`uv run pytest tests/unit` passes: 1713 passed, 92 skipped.

`uv run pre-commit run --all-files` passes except for 5 pre-existing mypy `import-not-found` errors in `providers/voyage/` and `providers/watsonx/`, whose SDKs do not install on Python 3.14 in the sandbox used here. Neither file is touched by this PR, and `uv run mypy src/any_llm/utils/messages_compat.py` is clean.

Integration tests were not run locally. The defect is in a pure conversion function with no network path, and reproducing the original 400 needs Fireworks credentials. Happy to have the `run-integration-tests` label applied.

## AI Usage Information

- AI Model used: Claude Opus 5 and Claude Haiku 4.5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The issue itself was also drafted by Claude via discussion with @njbrake. The fix follows the implementation proposed there.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
