### PR TITLE
fix(messages): map cached-token usage through the completion bridge

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -836,6 +836,7 @@ class AnyLLM(ABC):
             chat_completion_chunk_to_message_stream_events,
             chat_completion_to_message_response,
             messages_params_to_completion_params,
+            split_cached_input_tokens,
         )
 
         completion_kwargs = messages_params_to_completion_params(params)
@@ -849,13 +850,14 @@ class AnyLLM(ABC):
             state = StreamingState()
 
             def usage_delta(stop_reason: StopReason | None) -> MessageDeltaEvent:
+                input_tokens, cache_read = split_cached_input_tokens(state.input_tokens, state.cache_read_input_tokens)
                 return MessageDeltaEvent(
                     type="message_delta",
                     delta=MessageDelta(stop_reason=stop_reason),
                     usage=MessageDeltaUsage(
                         output_tokens=state.output_tokens,
-                        input_tokens=state.input_tokens,
-                        cache_read_input_tokens=state.cache_read_input_tokens or None,
+                        input_tokens=input_tokens,
+                        cache_read_input_tokens=cache_read,
                     ),
                 )
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -256,11 +256,12 @@ def split_cached_input_tokens(prompt_tokens: int, cached_tokens: int) -> tuple[i
     in this repo populates ``prompt_tokens_details.cache_write_tokens``, which is the field a cache
     write would arrive on.
 
-    The cached count is capped at ``prompt_tokens`` so a provider that reports the two inconsistently
-    cannot produce a negative ``input_tokens``. Capping the subtrahend rather than flooring the result
-    keeps the sum invariant intact: the two returned values still add up to ``prompt_tokens``.
+    The cached count is clamped into ``[0, prompt_tokens]`` so a provider that reports the two
+    inconsistently cannot push ``input_tokens`` negative (cached above the total) or above the prompt
+    total (cached below zero). Clamping the subtrahend rather than flooring the result keeps the sum
+    invariant intact: the two returned values still add up to ``prompt_tokens``.
     """
-    cached = min(cached_tokens, prompt_tokens)
+    cached = min(max(cached_tokens, 0), prompt_tokens)
     return prompt_tokens - cached, cached or None
 
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -252,10 +252,16 @@ def split_cached_input_tokens(prompt_tokens: int, cached_tokens: int) -> tuple[i
 
     The cached count comes back as ``None`` rather than 0 when there was no cache hit, so a response
     from a provider that reports no cache accounting looks exactly as it did before this mapping
-    existed. ``cache_creation_input_tokens`` has no OpenAI counterpart, since automatic prefix caching
-    has no write step to report, so it is left unset rather than synthesized.
+    existed. ``cache_creation_input_tokens`` is left unset rather than synthesized because no provider
+    in this repo populates ``prompt_tokens_details.cache_write_tokens``, which is the field a cache
+    write would arrive on.
+
+    The cached count is capped at ``prompt_tokens`` so a provider that reports the two inconsistently
+    cannot produce a negative ``input_tokens``. Capping the subtrahend rather than flooring the result
+    keeps the sum invariant intact: the two returned values still add up to ``prompt_tokens``.
     """
-    return prompt_tokens - cached_tokens, cached_tokens or None
+    cached = min(cached_tokens, prompt_tokens)
+    return prompt_tokens - cached, cached or None
 
 
 def _cached_tokens_from_usage(usage: CompletionUsage) -> int:

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -25,7 +25,7 @@ from any_llm.utils.structured_output import is_structured_output_type
 if TYPE_CHECKING:
     from anthropic.types import ContentBlock as SDKContentBlock
 
-    from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
+    from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionUsage
     from any_llm.types.messages import MessagesParams
 
 
@@ -241,6 +241,30 @@ def _budget_to_reasoning_effort(budget: int) -> str:
     return "xhigh"
 
 
+def split_cached_input_tokens(prompt_tokens: int, cached_tokens: int) -> tuple[int, int | None]:
+    """Split an OpenAI prompt-token total into disjoint Anthropic input/cache-read counts.
+
+    OpenAI reports ``prompt_tokens`` as the whole prompt with ``prompt_tokens_details.cached_tokens``
+    as a subset of it, while Anthropic's ``input_tokens`` and ``cache_read_input_tokens`` are disjoint
+    and sum to the prompt. Copying the cached count across without subtracting would make any consumer
+    that sums the fields over-count, and would bill cached tokens twice in a cost model that prices
+    the two at different rates.
+
+    The cached count comes back as ``None`` rather than 0 when there was no cache hit, so a response
+    from a provider that reports no cache accounting looks exactly as it did before this mapping
+    existed. ``cache_creation_input_tokens`` has no OpenAI counterpart, since automatic prefix caching
+    has no write step to report, so it is left unset rather than synthesized.
+    """
+    return prompt_tokens - cached_tokens, cached_tokens or None
+
+
+def _cached_tokens_from_usage(usage: CompletionUsage) -> int:
+    """Read ``prompt_tokens_details.cached_tokens`` off a usage object, defaulting to 0."""
+    if usage.prompt_tokens_details is None:
+        return 0
+    return usage.prompt_tokens_details.cached_tokens or 0
+
+
 def chat_completion_to_message_response(completion: ChatCompletion) -> MessageResponse:
     """Convert an OpenAI ChatCompletion to an Anthropic MessageResponse."""
     content_blocks: list[SDKContentBlock] = []
@@ -282,8 +306,13 @@ def chat_completion_to_message_response(completion: ChatCompletion) -> MessageRe
 
     usage = MessageUsage(input_tokens=0, output_tokens=0)
     if completion.usage:
+        input_tokens, cache_read = split_cached_input_tokens(
+            completion.usage.prompt_tokens,
+            _cached_tokens_from_usage(completion.usage),
+        )
         usage = MessageUsage(
-            input_tokens=completion.usage.prompt_tokens,
+            input_tokens=input_tokens,
+            cache_read_input_tokens=cache_read,
             output_tokens=completion.usage.completion_tokens,
         )
 
@@ -344,13 +373,18 @@ def chat_completion_chunk_to_message_stream_events(
             state.input_tokens = chunk.usage.prompt_tokens
         if chunk.usage.completion_tokens:
             state.output_tokens = chunk.usage.completion_tokens
-        prompt_details = chunk.usage.prompt_tokens_details
-        if prompt_details and prompt_details.cached_tokens:
-            state.cache_read_input_tokens = prompt_details.cached_tokens
+        cached = _cached_tokens_from_usage(chunk.usage)
+        if cached:
+            state.cache_read_input_tokens = cached
 
     if not state.started:
         state.started = True
-        usage = MessageUsage(input_tokens=state.input_tokens, output_tokens=0)
+        input_tokens, cache_read = split_cached_input_tokens(state.input_tokens, state.cache_read_input_tokens)
+        usage = MessageUsage(
+            input_tokens=input_tokens,
+            cache_read_input_tokens=cache_read,
+            output_tokens=0,
+        )
         msg = MessageResponse(
             id=chunk.id,
             type="message",

--- a/tests/integration/test_messages_cached_tokens.py
+++ b/tests/integration/test_messages_cached_tokens.py
@@ -53,8 +53,8 @@ async def test_messages_bridge_cached_tokens_non_streaming(openai_model: str) ->
     if not result.usage.cache_read_input_tokens:
         pytest.skip("provider served no cached tokens: automatic prefix caching did not engage for this prompt")
 
-    # Disjointness: the two fields must still sum to the same prompt total the uncached call
-    # reported. Copying cached_tokens across without subtracting would inflate this sum.
+    # The two fields are disjoint, so they must still sum to the same prompt total the
+    # uncached call reported. Copying cached_tokens across without subtracting inflates this sum.
     assert result.usage.input_tokens + result.usage.cache_read_input_tokens == prompt_total
     # Most of this prompt is the cached prefix, so the fresh remainder must be the smaller of
     # the two. Reporting the whole prompt as input_tokens alongside the cache count fails here.

--- a/tests/integration/test_messages_cached_tokens.py
+++ b/tests/integration/test_messages_cached_tokens.py
@@ -1,0 +1,93 @@
+"""Integration test for cached-token reporting through the Messages-to-Completions bridge.
+
+Providers reached via the bridge report caching the OpenAI way: ``prompt_tokens`` is the
+whole prompt and ``prompt_tokens_details.cached_tokens`` is a subset of it. Anthropic's
+Messages usage instead keeps ``input_tokens`` and ``cache_read_input_tokens`` disjoint, so
+the bridge has to subtract. These tests exercise that against real automatic prefix caching.
+
+Requires OPENAI_API_KEY to be set.
+"""
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+
+from any_llm import AnyLLM, LLMProvider
+from any_llm.types.messages import MessageDeltaEvent, MessageResponse
+
+# OpenAI only caches prompt prefixes above 1,024 tokens, so pad well past that.
+_LONG_PREFIX = (
+    "You are a helpful assistant that answers questions concisely. "
+    "The following is reference material that you should use to answer questions.\n\n"
+) + (
+    "Automatic prefix caching lets a provider reuse an already-processed prompt prefix "
+    "across requests, so the cached portion is billed at a reduced rate rather than being "
+    "re-processed from scratch. It engages without any explicit cache-control marking.\n"
+) * 200
+
+_PROMPT = _LONG_PREFIX + "\n\nReply with the single word OK."
+
+
+@pytest.fixture
+def openai_model(provider_model_map: dict[LLMProvider, str]) -> str:
+    if not os.environ.get("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set")
+    return provider_model_map[LLMProvider.OPENAI]
+
+
+@pytest.mark.asyncio
+async def test_messages_bridge_cached_tokens_non_streaming(openai_model: str) -> None:
+    """A cache hit is reported as cache_read_input_tokens, subtracted out of input_tokens."""
+    llm = AnyLLM.create(LLMProvider.OPENAI)
+    messages = [{"role": "user", "content": _PROMPT}]
+
+    # The first call populates the cache; the prefix is only eligible for a hit afterwards.
+    first = await llm.amessages(model=openai_model, messages=messages, max_tokens=2000)
+    assert isinstance(first, MessageResponse)
+    prompt_total = first.usage.input_tokens + (first.usage.cache_read_input_tokens or 0)
+
+    result = await llm.amessages(model=openai_model, messages=messages, max_tokens=2000)
+    assert isinstance(result, MessageResponse)
+
+    if not result.usage.cache_read_input_tokens:
+        pytest.skip("provider served no cached tokens: automatic prefix caching did not engage for this prompt")
+
+    # Disjointness: the two fields must still sum to the same prompt total the uncached call
+    # reported. Copying cached_tokens across without subtracting would inflate this sum.
+    assert result.usage.input_tokens + result.usage.cache_read_input_tokens == prompt_total
+    # Most of this prompt is the cached prefix, so the fresh remainder must be the smaller of
+    # the two. Reporting the whole prompt as input_tokens alongside the cache count fails here.
+    assert result.usage.input_tokens < result.usage.cache_read_input_tokens
+    # Automatic caching has no write step to report, so this stays unset.
+    assert result.usage.cache_creation_input_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_messages_bridge_cached_tokens_streaming(openai_model: str) -> None:
+    """A streamed call reports the same disjoint totals as a non-streamed one."""
+    llm = AnyLLM.create(LLMProvider.OPENAI)
+    messages = [{"role": "user", "content": _PROMPT}]
+
+    non_streamed = await llm.amessages(model=openai_model, messages=messages, max_tokens=2000)
+    assert isinstance(non_streamed, MessageResponse)
+    prompt_total = non_streamed.usage.input_tokens + (non_streamed.usage.cache_read_input_tokens or 0)
+
+    stream = await llm.amessages(model=openai_model, messages=messages, max_tokens=2000, stream=True)
+    assert isinstance(stream, AsyncIterator)
+
+    delta: MessageDeltaEvent | None = None
+    async for event in stream:
+        if isinstance(event, MessageDeltaEvent):
+            delta = event
+
+    assert delta is not None, "stream should end with a message_delta carrying usage"
+    if not delta.usage.cache_read_input_tokens:
+        pytest.skip("provider served no cached tokens: automatic prefix caching did not engage for this prompt")
+
+    assert delta.usage.input_tokens is not None
+    assert delta.usage.input_tokens + delta.usage.cache_read_input_tokens == prompt_total
+    # Most of this prompt is the cached prefix, so the fresh remainder must be the smaller of
+    # the two. Reporting the whole prompt as input_tokens alongside the cache count fails here.
+    assert delta.usage.input_tokens < delta.usage.cache_read_input_tokens
+    assert delta.usage.cache_creation_input_tokens is None

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -520,9 +520,13 @@ async def test_default_amessages_streaming_usage_from_trailing_chunk() -> None:
 
     events = [event async for event in result]
     delta = next(e for e in events if isinstance(e, MessageDeltaEvent))
-    assert delta.usage.input_tokens == 100
+    # Anthropic's input_tokens and cache_read_input_tokens are disjoint, so the cached
+    # count is subtracted out of the 100-token OpenAI prompt total rather than copied
+    # alongside it.
+    assert delta.usage.input_tokens == 20
     assert delta.usage.output_tokens == 50
     assert delta.usage.cache_read_input_tokens == 80
+    assert delta.usage.input_tokens + delta.usage.cache_read_input_tokens == 100
     assert delta.delta.stop_reason == "end_turn"
     assert events[-1].type == "message_stop"
 

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -16,12 +16,14 @@ from any_llm.types.completion import (
     PromptTokensDetails,
     Reasoning,
 )
-from any_llm.types.messages import MessagesParams
+from any_llm.types.messages import MessagesParams, MessageStartEvent
 from any_llm.utils.messages_compat import (
     StreamingState,
+    _cached_tokens_from_usage,
     chat_completion_chunk_to_message_stream_events,
     chat_completion_to_message_response,
     messages_params_to_completion_params,
+    split_cached_input_tokens,
 )
 
 
@@ -381,16 +383,12 @@ def test_chat_completion_zero_cached_tokens_reports_full_input_tokens() -> None:
 
 def test_split_cached_input_tokens_returns_none_for_zero_cache() -> None:
     """The helper reports no-cache as None so the field is omitted rather than reported as 0."""
-    from any_llm.utils.messages_compat import split_cached_input_tokens
-
     assert split_cached_input_tokens(100, 0) == (100, None)
     assert split_cached_input_tokens(100, 80) == (20, 80)
 
 
 def test_cached_tokens_from_usage_defaults_to_zero() -> None:
     """cached_tokens reads as 0 when details are absent or the field itself is None."""
-    from any_llm.utils.messages_compat import _cached_tokens_from_usage
-
     assert _cached_tokens_from_usage(CompletionUsage(prompt_tokens=10, completion_tokens=1, total_tokens=11)) == 0
     assert (
         _cached_tokens_from_usage(
@@ -1104,8 +1102,6 @@ def test_streaming_usage_cache_read_from_prompt_tokens_details() -> None:
 
 def test_streaming_message_start_reports_cache_read_disjointly() -> None:
     """When usage rides the first chunk, message_start splits it the same way the non-streamed path does."""
-    from any_llm.types.messages import MessageStartEvent
-
     state = StreamingState()
     chunk = ChatCompletionChunk(
         id="chunk-1",
@@ -1129,8 +1125,6 @@ def test_streaming_message_start_reports_cache_read_disjointly() -> None:
 
 def test_streaming_message_start_without_cache_reports_full_input_tokens() -> None:
     """No cache accounting on the first chunk leaves message_start's input_tokens whole."""
-    from any_llm.types.messages import MessageStartEvent
-
     state = StreamingState()
     chunk = ChatCompletionChunk(
         id="chunk-1",

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -299,6 +299,112 @@ def test_chat_completion_text_response_to_message() -> None:
     assert result.usage.output_tokens == 5
 
 
+def test_chat_completion_cached_tokens_mapped_disjointly() -> None:
+    """cached_tokens is reported as cache_read_input_tokens and subtracted out of input_tokens.
+
+    OpenAI's prompt_tokens is the whole prompt with cached_tokens a subset of it; Anthropic's
+    two fields are disjoint. Summing them must recover the original prompt total.
+    """
+    completion = ChatCompletion(
+        id="cmpl-1",
+        model="some-model",
+        created=0,
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="stop", message=ChatCompletionMessage(role="assistant", content="hi"))],
+        usage=CompletionUsage(
+            prompt_tokens=10_000,
+            completion_tokens=50,
+            total_tokens=10_050,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=9_600),
+        ),
+    )
+    usage = chat_completion_to_message_response(completion).usage
+    assert usage.input_tokens == 400
+    assert usage.cache_read_input_tokens == 9_600
+    assert usage.input_tokens + usage.cache_read_input_tokens == 10_000
+    assert usage.output_tokens == 50
+
+
+def test_chat_completion_cache_creation_tokens_never_synthesized() -> None:
+    """Automatic prefix caching has no write step, so cache_creation_input_tokens stays unset."""
+    completion = ChatCompletion(
+        id="cmpl-1",
+        model="some-model",
+        created=0,
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="stop", message=ChatCompletionMessage(role="assistant", content="hi"))],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=5,
+            total_tokens=105,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=60),
+        ),
+    )
+    usage = chat_completion_to_message_response(completion).usage
+    assert usage.cache_creation_input_tokens is None
+
+
+def test_chat_completion_without_prompt_tokens_details_reports_full_input_tokens() -> None:
+    """A provider that reports no cache accounting is unchanged: input_tokens is the full prompt."""
+    completion = ChatCompletion(
+        id="cmpl-1",
+        model="some-model",
+        created=0,
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="stop", message=ChatCompletionMessage(role="assistant", content="hi"))],
+        usage=CompletionUsage(prompt_tokens=10_000, completion_tokens=50, total_tokens=10_050),
+    )
+    usage = chat_completion_to_message_response(completion).usage
+    assert usage.input_tokens == 10_000
+    assert usage.cache_read_input_tokens is None
+
+
+def test_chat_completion_zero_cached_tokens_reports_full_input_tokens() -> None:
+    """A cache miss (cached_tokens=0) leaves input_tokens whole and cache_read unset."""
+    completion = ChatCompletion(
+        id="cmpl-1",
+        model="some-model",
+        created=0,
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="stop", message=ChatCompletionMessage(role="assistant", content="hi"))],
+        usage=CompletionUsage(
+            prompt_tokens=10_000,
+            completion_tokens=50,
+            total_tokens=10_050,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=0),
+        ),
+    )
+    usage = chat_completion_to_message_response(completion).usage
+    assert usage.input_tokens == 10_000
+    assert usage.cache_read_input_tokens is None
+
+
+def test_split_cached_input_tokens_returns_none_for_zero_cache() -> None:
+    """The helper reports no-cache as None so the field is omitted rather than reported as 0."""
+    from any_llm.utils.messages_compat import split_cached_input_tokens
+
+    assert split_cached_input_tokens(100, 0) == (100, None)
+    assert split_cached_input_tokens(100, 80) == (20, 80)
+
+
+def test_cached_tokens_from_usage_defaults_to_zero() -> None:
+    """cached_tokens reads as 0 when details are absent or the field itself is None."""
+    from any_llm.utils.messages_compat import _cached_tokens_from_usage
+
+    assert _cached_tokens_from_usage(CompletionUsage(prompt_tokens=10, completion_tokens=1, total_tokens=11)) == 0
+    assert (
+        _cached_tokens_from_usage(
+            CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=1,
+                total_tokens=11,
+                prompt_tokens_details=PromptTokensDetails(),
+            )
+        )
+        == 0
+    )
+
+
 def test_chat_completion_tool_calls_response_to_message() -> None:
     """Test converting a tool_calls ChatCompletion to MessageResponse with tool_use blocks."""
     completion = ChatCompletion(
@@ -994,6 +1100,50 @@ def test_streaming_usage_cache_read_from_prompt_tokens_details() -> None:
     )
     chat_completion_chunk_to_message_stream_events(chunk, state)
     assert state.cache_read_input_tokens == 80
+
+
+def test_streaming_message_start_reports_cache_read_disjointly() -> None:
+    """When usage rides the first chunk, message_start splits it the same way the non-streamed path does."""
+    from any_llm.types.messages import MessageStartEvent
+
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=80),
+        ),
+    )
+    events = chat_completion_chunk_to_message_stream_events(chunk, state)
+    start = next(e for e in events if isinstance(e, MessageStartEvent))
+    assert start.message.usage.input_tokens == 20
+    assert start.message.usage.cache_read_input_tokens == 80
+    assert start.message.usage.input_tokens + start.message.usage.cache_read_input_tokens == 100
+
+
+def test_streaming_message_start_without_cache_reports_full_input_tokens() -> None:
+    """No cache accounting on the first chunk leaves message_start's input_tokens whole."""
+    from any_llm.types.messages import MessageStartEvent
+
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+        usage=CompletionUsage(prompt_tokens=100, completion_tokens=20, total_tokens=120),
+    )
+    events = chat_completion_chunk_to_message_stream_events(chunk, state)
+    start = next(e for e in events if isinstance(e, MessageStartEvent))
+    assert start.message.usage.input_tokens == 100
+    assert start.message.usage.cache_read_input_tokens is None
 
 
 def test_streaming_usage_zero_cached_tokens_leaves_cache_read_unset() -> None:

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -387,6 +387,44 @@ def test_split_cached_input_tokens_returns_none_for_zero_cache() -> None:
     assert split_cached_input_tokens(100, 80) == (20, 80)
 
 
+def test_split_cached_input_tokens_caps_cached_at_prompt_total() -> None:
+    """A cached count exceeding the prompt total is capped so input_tokens cannot go negative.
+
+    Capping the subtrahend keeps the sum invariant: the two values still add up to prompt_tokens.
+    """
+    input_tokens, cache_read = split_cached_input_tokens(100, 120)
+    assert input_tokens == 0
+    assert cache_read == 100
+    assert input_tokens + (cache_read or 0) == 100
+
+
+def test_streaming_message_start_cached_without_prompt_total_is_not_negative() -> None:
+    """A usage chunk carrying cached tokens but no prompt total must not yield negative input_tokens.
+
+    ``prompt_tokens`` is only recorded when truthy while the cached count is recorded independently,
+    so the two can go out of sync; Gemini's chunk converter defaults a missing prompt count to 0
+    while still reporting a cached count.
+    """
+    state = StreamingState()
+    chunk = ChatCompletionChunk(
+        id="chunk-1",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hi"), finish_reason=None)],
+        usage=CompletionUsage(
+            prompt_tokens=0,
+            completion_tokens=5,
+            total_tokens=5,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=800),
+        ),
+    )
+    events = chat_completion_chunk_to_message_stream_events(chunk, state)
+    start = next(e for e in events if isinstance(e, MessageStartEvent))
+    assert start.message.usage.input_tokens == 0
+    assert start.message.usage.cache_read_input_tokens is None
+
+
 def test_cached_tokens_from_usage_defaults_to_zero() -> None:
     """cached_tokens reads as 0 when details are absent or the field itself is None."""
     assert _cached_tokens_from_usage(CompletionUsage(prompt_tokens=10, completion_tokens=1, total_tokens=11)) == 0

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -398,6 +398,17 @@ def test_split_cached_input_tokens_caps_cached_at_prompt_total() -> None:
     assert input_tokens + (cache_read or 0) == 100
 
 
+def test_split_cached_input_tokens_floors_negative_cached_at_zero() -> None:
+    """A negative cached count is floored, so input_tokens never exceeds the prompt total.
+
+    Left unclamped, subtracting a negative would report more fresh input than the whole prompt
+    and hand back a negative cache count.
+    """
+    input_tokens, cache_read = split_cached_input_tokens(100, -1)
+    assert input_tokens == 100
+    assert cache_read is None
+
+
 def test_streaming_message_start_cached_without_prompt_total_is_not_negative() -> None:
     """A usage chunk carrying cached tokens but no prompt total must not yield negative input_tokens.
 


### PR DESCRIPTION
## Description

`chat_completion_to_message_response` built `MessageUsage` from `prompt_tokens` and `completion_tokens` only, so `prompt_tokens_details.cached_tokens` was discarded. A caller using `amessages` against any provider reached through the Messages-to-Completions bridge saw no cache accounting at all, even when the provider served and discounted a cache hit.

The two APIs use opposite conventions, so this is not a straight copy:

- **OpenAI:** `prompt_tokens` is the whole prompt, and `prompt_tokens_details.cached_tokens` is a subset of it.
- **Anthropic:** `input_tokens` and `cache_read_input_tokens` are disjoint and sum to the prompt.

The cached count is therefore subtracted out of `input_tokens`. Assigning it alongside the untouched total would make any consumer that sums the fields over-count, and would bill cached tokens twice in a cost model that prices the two at different rates.

### What changed

- `src/any_llm/utils/messages_compat.py`
  - New `split_cached_input_tokens(prompt_tokens, cached_tokens)` holds the disjointness invariant in one documented place, returning `(prompt - cached, cached or None)`.
  - New `_cached_tokens_from_usage(usage)` reads `prompt_tokens_details.cached_tokens`, defaulting to 0.
  - `chat_completion_to_message_response` now maps the cached count and subtracts it from `input_tokens`.
  - The streamed `message_start` applies the same split.
- `src/any_llm/any_llm.py`
  - The closing `message_delta` already had the exact double count the issue warns about: it set `input_tokens` to the full prompt total *and* populated `cache_read_input_tokens`. It now uses the shared helper, so a streamed call reports the same totals as a non-streamed one.

`cache_creation_input_tokens` stays unset rather than synthesized, since automatic prefix caching has no write step to report. The cached count is reported as `None` rather than 0 on a miss, so a provider without cache accounting looks exactly as it did before.

This is symmetric with the existing inverse mapping in `providers/anthropic/utils.py`, which sums `input_tokens + cache_read + cache_creation` into `prompt_tokens` and sets `cached_tokens=cache_read`. The two round-trip exactly when `cache_creation_input_tokens` is 0. When it is non-zero the creation tokens fold into `input_tokens` on the way back, since the inverse mapping sums all three into `prompt_tokens` but exposes only the cache-read count. That is lossy in principle and unreachable in practice here, because the native Anthropic provider overrides `_amessages` and never crosses this bridge.

### One behavior change to flag for review

`tests/unit/test_messages.py::test_default_amessages_streaming_usage_from_trailing_chunk` asserted `input_tokens == 100` **and** `cache_read_input_tokens == 80` for a 100-token prompt, summing to 180. That test encoded the double count, so its expectation is corrected to `input_tokens == 20`. This is an intentional behavior change, not a test bent to fit the implementation.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1229

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## Test plan

**Tests fail without the fix.** The new tests were run against `origin/main` source in a throwaway worktree; 5 failed, including the streaming double count. The no-cache tests pass on baseline too, which is what is wanted from regression guards.

- 6 new unit tests in `tests/unit/test_messages_compat.py`: disjointness invariant (`input + cache_read == prompt_tokens`), unchanged behavior when `prompt_tokens_details` is absent or `cached_tokens` is 0, `cache_creation_input_tokens` never synthesized, streamed `message_start` split, and the two helpers.
- 2 new integration tests in `tests/integration/test_messages_cached_tokens.py` exercising real automatic prefix caching through the bridge, non-streaming and streaming.

Results:

- `uv run pytest tests/unit`: 1712 passed, 92 skipped.
- `uv run pre-commit run --all-files`: ruff lint, ruff format, and codespell pass. mypy reports 5 pre-existing `import-not-found` errors in `voyage`/`watsonx`, whose SDKs are not in the local extras set; none are in the files this PR touches.
- Integration, with a real key: both new tests pass. Live OpenAI automatic prefix caching over a ~9.6k-token prefix reported `input=9620, cache_read=None` on a miss and `input=148, cache_read=9472` on a hit, both summing to the same 9620 prompt total. The streamed `message_delta` matched the non-streamed totals exactly.

A follow-up this change deliberately does not take on: `prompt_tokens_details.cache_write_tokens` exists on the pinned openai SDK but no provider in this repo populates it, and `providers/bedrock/utils.py` folds its computed cache-write count into `prompt_tokens` without exposing it. So a Bedrock cache-write call through `amessages` reports premium-billed write tokens as ordinary `input_tokens`. That is pre-existing and out of scope here.

Two caveats for the reviewer:

1. `tests/integration/test_cached_tokens.py` could not be run locally (no `GEMINI_API_KEY`), so it is left untouched rather than extended with Gemini tests that were never executed.
2. The new integration tests `pytest.skip` with a concrete reason if the provider serves no cached tokens, since automatic caching engagement is not guaranteed for a given prompt. The `input_tokens < cache_read_input_tokens` assertion is the one that actually discriminates this bug; the sum-equality assertion alone would pass pre-fix if both calls inflate identically.

## AI Usage Information

- AI Model used: Claude Opus 5 and Haiku 4.5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Issue triage, implementation, and verification were driven by @njbrake via Claude Code. The live-provider verification above was run against a real OpenAI key.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token usage reporting by separating regular input tokens from cached input tokens.
  * Cached token counts are now reported consistently for streaming and non-streaming responses.
  * Usage totals now distinguish newly processed input from reused cached content.

* **Bug Fixes**
  * Prevented cached tokens from being counted twice in input totals.
  * Preserved accurate reporting when cache details are unavailable.
  * Cache-creation tokens are no longer incorrectly reported as cached input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
