### PR TITLE
fix(anthropic): guard created_at before calling .timestamp()

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from anthropic import transform_schema
@@ -372,7 +373,15 @@ def _convert_response(response: Message) -> ChatCompletion:
         message=message,
     )
 
-    created_ts = int(response.created_at.timestamp()) if hasattr(response, "created_at") else 0
+    # The Anthropic Messages API carries no timestamp, so ``created_at`` is absent on a
+    # spec-compliant response. ``Message`` does not declare the field either, so an
+    # Anthropic-compatible endpoint that sends it anyway has it kept as an unvalidated extra
+    # attribute holding the raw JSON value: None for an explicit null, but also int or str.
+    # A ``hasattr`` guard passes for all of those and ``.timestamp()`` then raises
+    # ``AttributeError: 'NoneType' object has no attribute 'timestamp'``, failing the whole
+    # completion, so only fall back to the timestamp when it really is a datetime.
+    created_at = getattr(response, "created_at", None)
+    created_ts = int(created_at.timestamp()) if isinstance(created_at, datetime) else 0
 
     return ChatCompletion(
         id=response.id,
@@ -519,8 +528,8 @@ def _convert_models_list(models_list: list[AnthropicModelInfo]) -> list[Model]:
     without validation, so the field is present but ``None``, and calling
     ``.timestamp()`` on it raises ``AttributeError: 'NoneType' object has no
     attribute 'timestamp'`` for the whole listing. Fall back to ``0`` for that
-    entry instead, matching what ``_create_openai_completion_from_anthropic``
-    already does for a response missing the same field.
+    entry instead, matching what ``_convert_response`` already does for a
+    response missing the same field.
     """
     return [
         Model(

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from anthropic import transform_schema
+from anthropic.types import Message
 from anthropic.types.model_info import ModelInfo
 from pydantic import BaseModel
 
@@ -1328,10 +1329,8 @@ def test_convert_models_list_mixed_created_at() -> None:
     assert [m.created for m in result] == [int(created_at.timestamp()), 0]
 
 
-def _anthropic_message(**extra: Any) -> Any:
+def _anthropic_message(**extra: Any) -> Message:
     """Build a spec-shaped Messages response, plus any extra fields an endpoint might send."""
-    from anthropic.types import Message
-
     return Message.model_validate(
         {
             "id": "msg_123",

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1326,3 +1326,62 @@ def test_convert_models_list_mixed_created_at() -> None:
 
     assert [m.id for m in result] == ["with", "without"]
     assert [m.created for m in result] == [int(created_at.timestamp()), 0]
+
+
+def _anthropic_message(**extra: Any) -> Any:
+    """Build a spec-shaped Messages response, plus any extra fields an endpoint might send."""
+    from anthropic.types import Message
+
+    return Message.model_validate(
+        {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-haiku",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            **extra,
+        }
+    )
+
+
+def test_convert_response_without_created_at() -> None:
+    """The Anthropic Messages API carries no timestamp, so created falls back to 0."""
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    result = _convert_response(_anthropic_message())
+
+    assert result.created == 0
+    assert result.choices[0].message.content == "hello"
+
+
+def test_convert_response_with_created_at() -> None:
+    """When an endpoint does supply a datetime, it is used."""
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    created_at = datetime(2026, 2, 19, tzinfo=UTC)
+
+    result = _convert_response(_anthropic_message(created_at=created_at))
+
+    assert result.created == int(created_at.timestamp())
+
+
+@pytest.mark.parametrize("created_at", [None, 1750000000, "2026-01-01T00:00:00Z"])
+def test_convert_response_non_datetime_created_at(created_at: Any) -> None:
+    """Regression: a non-datetime created_at must not raise "'NoneType' object has no attribute 'timestamp'".
+
+    Message does not declare created_at, so an Anthropic-compatible endpoint that sends the
+    field anyway has it kept as an unvalidated extra attribute holding the raw JSON value.
+    A bare hasattr guard passed for these and crashed the whole completion on .timestamp().
+    """
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = _anthropic_message(created_at=created_at)
+    assert hasattr(response, "created_at")
+
+    result = _convert_response(response)
+
+    assert result.created == 0
+    assert result.choices[0].message.content == "hello"


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`_convert_response` guarded the `created` conversion with `hasattr(response, "created_at")`, then called `.timestamp()`. That crashes the whole completion for any Anthropic-compatible endpoint that sends the field.

One correction to the issue's analysis, which changed the fix: the pinned SDK's `Message` does **not** declare `created_at` (it isn't in `model_fields`). The field arrives via `extra="allow"`, so it is stored **unvalidated**, holding whatever JSON came in. All three of these crash on the old line:

```
None                    -> 'NoneType' object has no attribute 'timestamp'
1750000000              -> 'int' object has no attribute 'timestamp'
'2026-01-01T00:00:00Z'  -> 'str' object has no attribute 'timestamp'
```

The `is not None` guard the issue suggests would still crash on the int and the string. This guards on `isinstance(..., datetime)` and falls back to `0`.

That is stricter than the sibling `_convert_models_list`, which uses `is not None`. To correct something I initially got wrong: that is not because `ModelInfo.created_at` is validated. It is declared, but the SDK's `construct_type` bypasses validation, so an unparseable value survives raw there too, and `_convert_models_list` (and `base.py:84`) still raise on `created_at="not-a-date"`. Those are pre-existing and on different code paths than this issue, so I left them alone rather than widen the PR. They are a one-word change each if you'd rather have consistency now.

Also fixes that function's docstring, which cited `_create_openai_completion_from_anthropic` as the reference implementation. No such name exists in the repo; it is `_convert_response`.

**One gap:** the Anthropic integration suite was not run, as no API key was available. Worth applying the `run-integration-tests` label.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1231

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The `isinstance` guard and the docstring fix came from checking the issue's stated root cause against the pinned SDK rather than taking it at face value.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of response timestamps when metadata is missing or has an unexpected format.
  * Preserved valid response timestamps and message content during conversion.
* **Tests**
  * Added coverage for missing, valid, and invalid timestamp values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->