### PR TITLE
chore(deps): require openresponses-types>=2.4.0 for compaction normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.0.0-dev" # There is a regex in the release.yaml file that looks for
 dependencies = [
   "pydantic>2,<3",
   "openai>=2.18.0",
-  "openresponses-types>=2.3.0.post1",
+  "openresponses-types>=2.4.0",
   "anthropic>=0.83.0",
   "rich",
   "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.0.0-dev" # There is a regex in the release.yaml file that looks for
 dependencies = [
   "pydantic>2,<3",
   "openai>=2.18.0",
-  "openresponses-types>=2.4.0",
+  "openresponses-types>=2.4.0,<3",
   "anthropic>=0.83.0",
   "rich",
   "httpx",
@@ -157,6 +157,9 @@ exclude-newer = "7 days"
 # Trade-off: uv.lock is gitignored and CI re-resolves on every run, so a broken release
 # reaches CI immediately with no pinned fallback. We accept that for these deps because
 # we control their publishing; the soak still applies to every other dependency.
+# Note that openresponses-types is a core dependency rather than an optional extra like
+# otari, so a bad release there breaks every install and every CI job, not just the
+# otari extra. The `<3` cap on it is what bounds that blast radius.
 exclude-newer-package = { otari = "2100-01-01", openresponses-types = "2100-01-01" }
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,13 +150,14 @@ Source = "https://github.com/mozilla-ai/any-llm"
 
 [tool.uv]
 exclude-newer = "7 days"
-# otari is first-party (mozilla.ai owns it) and co-developed with any-llm, so we
-# intentionally exempt it from the global 7-day exclude-newer soak and always resolve the
-# latest published otari. The far-future date is a sentinel meaning "never soak otari".
-# Trade-off: uv.lock is gitignored and CI re-resolves on every run, so a broken otari
-# release reaches CI immediately with no pinned fallback. We accept that for this dep
-# because we control its publishing; the soak still applies to every other dependency.
-exclude-newer-package = { otari = "2100-01-01" }
+# otari and openresponses-types are first-party (mozilla.ai owns both) and co-developed
+# with any-llm, so we intentionally exempt them from the global 7-day exclude-newer soak
+# and always resolve the latest published version. The far-future date is a sentinel
+# meaning "never soak this package".
+# Trade-off: uv.lock is gitignored and CI re-resolves on every run, so a broken release
+# reaches CI immediately with no pinned fallback. We accept that for these deps because
+# we control their publishing; the soak still applies to every other dependency.
+exclude-newer-package = { otari = "2100-01-01", openresponses-types = "2100-01-01" }
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai.types.responses import ResponseCompactionItem, ResponseOutputMessage, ResponseOutputText
+from openresponses_types import CompactionBody, ResponseResource
 from pydantic import BaseModel
 
 from any_llm.providers.openai.base import BaseOpenAIProvider
@@ -65,6 +66,58 @@ def _make_openai_compaction_response() -> Response:
         parallel_tool_calls=False,
         tool_choice="auto",
         tools=[],
+    )
+
+
+def _make_populated_openai_compaction_response() -> Response:
+    """A compaction response carrying every field ResponseResource requires.
+
+    Built from a wire-shape payload rather than SDK kwargs: ResponseResource
+    requires `store`, `presence_penalty` and `frequency_penalty`, which openai's
+    Response does not declare as fields and only carries as extras.
+
+    The sparse fixtures above leave optional scalars unset, so they fail
+    ResponseResource validation on those fields regardless of compaction support
+    and exercise the fallback path rather than the normalization path.
+    """
+    return Response.model_validate(
+        {
+            "id": "resp-compaction",
+            "created_at": 0,
+            "model": "gpt-5.3-codex",
+            "object": "response",
+            "output": [
+                {
+                    "id": "cmp-1",
+                    "type": "compaction",
+                    "encrypted_content": "opaque-compacted-context",
+                },
+                {
+                    "id": "msg-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {"type": "output_text", "text": "Resumed.", "annotations": [], "logprobs": []},
+                    ],
+                },
+            ],
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+            "status": "completed",
+            "store": False,
+            "background": False,
+            "truncation": "disabled",
+            "metadata": {},
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "top_logprobs": 0,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "service_tier": "auto",
+            "text": {"format": {"type": "text"}},
+        }
     )
 
 
@@ -173,9 +226,35 @@ async def test_aresponses_context_management_preserves_compaction_item(mock_open
     )
 
     assert mock_client.responses.create.call_args.kwargs["context_management"] == context_management
+    # This fixture omits optional scalars (status, store, text, ...), so it fails
+    # ResponseResource validation on those and falls back to the raw Response.
+    # See test_aresponses_normalizes_compaction_item for the normalization path.
     assert isinstance(result, Response)
     assert isinstance(result.output[0], ResponseCompactionItem)
     assert result.output[0].encrypted_content == "opaque-compacted-context"
+
+
+@pytest.mark.asyncio
+@patch("any_llm.providers.openai.base.AsyncOpenAI")
+async def test_aresponses_normalizes_compaction_item(mock_openai_class: MagicMock) -> None:
+    """A fully populated compaction response normalizes to a ResponseResource.
+
+    Requires openresponses-types >= 2.4.0, where ResponseResource.output accepts
+    CompactionBody. Against earlier releases the compaction item failed validation
+    and aresponses fell back to returning the raw OpenAI Response.
+    """
+    mock_client = AsyncMock()
+    mock_client.responses.create = AsyncMock(return_value=_make_populated_openai_compaction_response())
+    mock_openai_class.return_value = mock_client
+
+    provider = _ResponsesProvider(api_key="key")
+    result = await provider.aresponses(model="gpt-5.3-codex", input_data="Continue the coding task.")
+
+    assert isinstance(result, ResponseResource)
+    assert [item.type for item in result.output] == ["compaction", "message"]
+    compaction = result.output[0]
+    assert isinstance(compaction, CompactionBody)
+    assert compaction.encrypted_content == "opaque-compacted-context"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Raises the `openresponses-types` floor from `>=2.3.0.post1` to `>=2.4.0` so that
Responses replies containing a `compaction` output item are actually normalized instead
of silently falling back to the raw OpenAI `Response`.

Compaction support landed in #1227, but only the request/passthrough half worked. The
`ResponseResource` models published in 2.3.0.post1 were generated from OpenResponses spec
`2.3.0`, which predates compaction entirely, so `ResponseResource.output` had no
`CompactionBody` member. Any reply containing a compaction item failed validation, hit
the `ValidationError` fallback in `src/any_llm/providers/openai/base.py:261`, and logged
the failure at info level.

`openresponses-types` 2.4.0 (mozilla-ai/openresponses-python#1) regenerates from spec
`2026-04-24`, which adds `CompactionBody` to the `ItemField` union. That release was
reviewed as additive only: no public type, field, or enum value removed, nothing
narrowed, and no new required field on an existing model.

### Changes

- `pyproject.toml`: `openresponses-types>=2.3.0.post1` -> `>=2.4.0` (the only reference
  in the repo).
- `pyproject.toml`: add `openresponses-types` to the existing `exclude-newer-package`
  exemption. Without this nothing resolves at all: the global
  `[tool.uv] exclude-newer = "7 days"` soak filtered out 2.4.0, which had been published
  minutes earlier, so every CI job failed at `uv sync` with
  "only openresponses-types<=2.3.0.post1 is available". `openresponses-types` is
  first-party (mozilla-ai/openresponses-python) and co-developed with any-llm, which is
  the same rationale already documented for `otari`, so the surrounding comment now
  covers both packages.
- `tests/unit/providers/test_openai_base_provider.py`: add
  `test_aresponses_normalizes_compaction_item` plus a populated fixture.

### About the pre-existing compaction test

`test_aresponses_context_management_preserves_compaction_item` asserts
`isinstance(result, Response)`, which reads as though it pins the fallback behaviour. It
does not, and it keeps passing on 2.4.0: its fixture leaves optional scalars unset
(`status`, `store`, `text`, `truncation`, `metadata`), so it fails `ResponseResource`
validation on *those* fields rather than on compaction, taking the fallback for an
unrelated reason.

That test is left as-is, with a comment recording why it returns a raw `Response` so the
next reader is not misled. The new test uses a fully populated payload and asserts the
compaction item now normalizes into `ResponseResource.output`.

The new fixture is built through `Response.model_validate` rather than SDK kwargs
because `ResponseResource` requires `store`, `presence_penalty` and `frequency_penalty`,
none of which openai's `Response` declares as fields (it accepts them as extras under
`extra="allow"`).

### One caveat worth recording

`ResponseResource` requires three non-nullable fields that openai's `Response` does not
declare: `store: bool`, `presence_penalty: float`, `frequency_penalty: float`. They
survive normalization only when the provider actually returns them on the wire, since
the SDK keeps unknown keys as extras.

So this bump removes compaction as a *cause* of normalization failure, but whether a
given real-world response normalizes still depends on the provider emitting those three
fields. That is pre-existing, unrelated to compaction, and is why the fallback in
`base.py` exists at all. Worth a separate look at whether that divergence should be
raised upstream against the spec.

## PR Type
<!-- Delete the types that don't apply -->

- 🐛 Bug Fix
- 🚦 Infrastructure

## Relevant issues

No existing issue. Follows up on #1227, which added compaction support, and consumes
mozilla-ai/openresponses-python#1, which fixed the missing type upstream.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

### How the above was verified

- `UV_SYSTEM_PYTHON=0 uv run pre-commit run --all-files`: clean, including mypy across
  277 source files.
- `uv run pytest tests/unit`: 1761 passed, 67 skipped.
- The new test genuinely discriminates on the floor rather than passing vacuously. Pinned
  back to 2.3.0.post1 the module cannot even import `CompactionBody`, so the file fails
  at collection, which is exactly what `>=2.4.0` encodes. Before the import was added it
  failed as a plain assertion failure while the other 21 tests in the file passed.
- The full unit suite was also run against 2.3.0.post1 and 2.4.0 in a minimal
  environment and produced identical results, confirming the bump introduces no
  regressions.
- No documentation changes were needed: the bump is internal and no documented behaviour
  or public signature changes. `tests/integration/test_responses.py:47` already accepts
  either return type, so it passes either way and needs no change.
- Integration tests were not run: this touches no provider behaviour and requires no
  credentials to validate. The change is covered by unit tests.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: the upstream release
  (mozilla-ai/openresponses-python#1) was produced in the same session. The drift from
  spec `2.3.0` to `2026-04-24` was inventoried structurally before release, since
  `datamodel-codegen` renumbers anonymous `TypeN`/`ItemN` schemas and a plain text diff
  of the generated module reports dozens of phantom changes.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the latest `openresponses-types` 2.x releases, improving compatibility with modern response formats.
  - Compaction responses are now correctly normalised while preserving compaction details and message output items.

- **Bug Fixes**
  - Improved handling of incomplete response data by retaining a raw-response fallback when required fields are missing.

- **Tests**
  - Added coverage for both fully populated and sparse compaction responses to help ensure reliable response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->