### PR TITLE
refactor(kenari): migrate to a config registry row

### DIFF
--- a/src/any_llm/providers/kenari/kenari.py
+++ b/src/any_llm/providers/kenari/kenari.py
@@ -1,32 +1,11 @@
-from any_llm.providers.openai.base import BaseOpenAIProvider
+"""Import shim: Kenari migrated to the config registry.
 
+The provider is now a row in ``any_llm.providers.registry``; this module keeps
+the historical deep-import path working.
+"""
 
-class KenariProvider(BaseOpenAIProvider):
-    """Provider for Kenari (https://kenari.id).
+from any_llm.providers.registry import get_registry_provider_class
 
-    Kenari is an OpenAI-compatible LLM gateway focused on the Indonesian market,
-    serving Claude, GPT, Gemini, DeepSeek, Kimi, GLM, Qwen and other models behind
-    one API with local-currency billing. It exposes the standard chat completions
-    and model listing endpoints under https://kenari.id/v1, so this provider only
-    needs to set configuration defaults and capability flags on top of
-    BaseOpenAIProvider.
-    """
+KenariProvider = get_registry_provider_class("kenari")
 
-    API_BASE = "https://kenari.id/v1"
-    ENV_API_KEY_NAME = "KENARI_API_KEY"
-    ENV_API_BASE_NAME = "KENARI_API_BASE"
-    PROVIDER_NAME = "kenari"
-    PROVIDER_DOCUMENTATION_URL = "https://kenari.id/docs"
-
-    SUPPORTS_COMPLETION = True
-    SUPPORTS_COMPLETION_STREAMING = True
-    SUPPORTS_COMPLETION_REASONING = True
-    SUPPORTS_COMPLETION_IMAGE = False
-    SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_EMBEDDING = False
-    SUPPORTS_MODERATION = False
-    SUPPORTS_LIST_MODELS = True
-    SUPPORTS_BATCH = False
-    SUPPORTS_IMAGE_GENERATION = False
-    SUPPORTS_RERANK = False
-    SUPPORTS_RESPONSES = False
+__all__ = ["KenariProvider"]

--- a/src/any_llm/providers/registry.py
+++ b/src/any_llm/providers/registry.py
@@ -95,6 +95,14 @@ PROVIDER_REGISTRY: dict[str, OpenAICompatibleProviderConfig] = {
         supports_embedding=True,
         supports_moderation=True,
     ),
+    "kenari": OpenAICompatibleProviderConfig(
+        name="kenari",
+        api_base="https://kenari.id/v1",
+        env_api_key_name="KENARI_API_KEY",
+        env_api_base_name="KENARI_API_BASE",
+        provider_documentation_url="https://kenari.id/docs",
+        supports_completion_reasoning=True,
+    ),
     "moonshot": OpenAICompatibleProviderConfig(
         name="moonshot",
         api_base="https://api.moonshot.ai/v1",

--- a/tests/unit/providers/test_kenari_provider.py
+++ b/tests/unit/providers/test_kenari_provider.py
@@ -3,7 +3,9 @@ import pytest
 from any_llm.any_llm import AnyLLM
 from any_llm.constants import LLMProvider
 from any_llm.exceptions import MissingApiKeyError
+from any_llm.providers.kenari import KenariProvider as PackageKenariProvider
 from any_llm.providers.kenari.kenari import KenariProvider
+from any_llm.providers.registry import get_registry_config, get_registry_provider_class
 
 
 def test_provider_metadata() -> None:
@@ -73,3 +75,9 @@ def test_registered_in_enum_and_loader() -> None:
     assert LLMProvider.from_string("kenari") is LLMProvider.KENARI
     assert AnyLLM.get_provider_class("kenari") is KenariProvider
     assert "kenari" in AnyLLM.get_supported_providers()
+
+
+def test_backed_by_a_registry_row_through_both_import_paths() -> None:
+    assert get_registry_config("kenari") is not None
+    assert KenariProvider is get_registry_provider_class("kenari")
+    assert PackageKenariProvider is KenariProvider


### PR DESCRIPTION
## Description

`kenari` was the last config-only OpenAI-compatible gateway still carrying a code folder. It landed (#1194) just before the registry existed (#1201), so it was never migrated and now contradicts the acceptance rule it was meant to precede: a gateway gets a code folder only when the protocol requires behavior.

The class had zero method overrides, so the row reproduces its flags exactly. Only `supports_completion_reasoning` departs from the conservative row default; every other flag it set already matched the baseline, making the row behavior-neutral.

```python
"kenari": OpenAICompatibleProviderConfig(
    name="kenari",
    api_base="https://kenari.id/v1",
    env_api_key_name="KENARI_API_KEY",
    env_api_base_name="KENARI_API_BASE",
    provider_documentation_url="https://kenari.id/docs",
    supports_completion_reasoning=True,
),
```

The folder shrinks to the same import shim the other migrated gateways use. `LLMProvider.KENARI`, the `kenari = []` extra, and `providers/kenari/__init__.py` are untouched, so the deep-import path, enum member, and class identity through `get_provider_class` all behave as before. The eight existing unit tests pass unmodified, which is the compatibility evidence; one test was added asserting the class now resolves from a registry row through both import paths.

Out of scope, worth a follow-up: nothing enforces that a future config-only gateway lands as a row rather than a folder, which is how this one drifted. A guard test over the provider folders would close that, but it is a separate concern.

Verification:

- `uv run pytest tests/unit`: 1856 passed, 93 skipped
- `uv run pytest tests/docs`: 5 passed; `scripts/generate_provider_table.py` runs clean (`docs/providers.md` is generated and untracked) and emits an unchanged kenari row
- `uv run pre-commit run --all-files`: clean apart from 5 pre-existing missing-SDK mypy errors in `providers/voyage/` and `providers/watsonx/`, files this diff does not touch; they reproduce identically with all extras installed
- No integration run: kenari has no CI key, so its `tests/conftest.py` parametrizations skip in CI. It does carry entries in the model and reasoning maps, so a maintainer holding a `KENARI_API_KEY` can run `pytest tests/integration -k kenari` locally. Not verified live here.

## PR Type

- 💅 Refactor

## Relevant issues

Fixes #1237

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Follow-up filed during the #1197 rollout; the migration mirrors #1201 exactly.

- [x] I am an AI Agent filling out this form (check box if true)