### PR TITLE
ci: run local-provider integration tests in two sequential groups

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -234,22 +234,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lmstudio-models-
 
-      - name: Setup Ollama
-        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
-        uses: ai-action/setup-ollama@v2
-
-      - name: Run ollama
-        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
-        run: |
-          ollama serve &
-          ollama pull llama3.2:1b
-          ollama pull qwen3:0.6b
-          ollama pull llava-phi3
-
-      - name: Wait for Ollama to be ready
-        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
-        run: |
-          timeout 60 bash -c 'until curl -s http://localhost:11434/api/tags >/dev/null; do sleep 1; done'
+      # llamafile/llamacpp and lmstudio/ollama run as two sequential groups, not all four at
+      # once, so their model servers never compete for RAM at the same time (see #1236: running
+      # all four together was OOM-killing the runner mid-suite, every run, at the same test).
 
       - name: Download and Run LlamaFile
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamafile')
@@ -275,12 +262,55 @@ jobs:
 
       - name : Download and Run LlamaCpp
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
-        run: docker run -d -p 8090:8090 ghcr.io/ggml-org/llama.cpp:server -hf ggml-org/Qwen3-1.7B-GGUF --jinja --port 8090
+        run: |
+          cid=$(docker run -d -p 8090:8090 ghcr.io/ggml-org/llama.cpp:server -hf ggml-org/Qwen3-1.7B-GGUF --jinja --port 8090)
+          echo "$cid" > llamacpp.cid
 
       - name: Wait for LlamaCpp to be ready
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
         run: |
           timeout 60 bash -c 'until curl -s http://localhost:8090/health >/dev/null; do sleep 1; done'
+
+      - name: Run LlamaFile and LlamaCpp integration tests
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamafile') || contains(github.event.inputs.filter, 'llamacpp')
+        env:
+          INCLUDE_LOCAL_PROVIDERS: "true"
+          INCLUDE_NON_LOCAL_PROVIDERS: "false"
+        run: |
+          if [ -n "${{ inputs.filter }}" ]; then
+            pytest tests/integration -v --cov --cov-report=xml -k "(llamafile or llamacpp) and (${{ inputs.filter }})" || [ $? -eq 5 ]
+          else
+            pytest tests/integration -v --cov --cov-report=xml -k "llamafile or llamacpp" || [ $? -eq 5 ]
+          fi
+
+      - name: Shut down LlamaFile and LlamaCpp
+        if: always()
+        run: |
+          if [ -f llamafile.pid ]; then
+            kill $(cat llamafile.pid) || true
+            rm llamafile.pid
+          fi
+          if [ -f llamacpp.cid ]; then
+            docker stop "$(cat llamacpp.cid)" || true
+            rm llamacpp.cid
+          fi
+
+      - name: Setup Ollama
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
+        uses: ai-action/setup-ollama@v2
+
+      - name: Run ollama
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
+        run: |
+          ollama serve &
+          ollama pull llama3.2:1b
+          ollama pull qwen3:0.6b
+          ollama pull llava-phi3
+
+      - name: Wait for Ollama to be ready
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
+        run: |
+          timeout 60 bash -c 'until curl -s http://localhost:11434/api/tags >/dev/null; do sleep 1; done'
 
       - name: Install LM Studio CLI
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
@@ -301,23 +331,16 @@ jobs:
         run: |
           timeout 120 bash -c 'until curl -s http://localhost:1234/v1/models >/dev/null; do sleep 1; done'
 
-      - name: Run Local Provider Integration tests
+      - name: Run LMStudio and Ollama integration tests
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio') || contains(github.event.inputs.filter, 'ollama')
         env:
           INCLUDE_LOCAL_PROVIDERS: "true"
           INCLUDE_NON_LOCAL_PROVIDERS: "false"
         run: |
           if [ -n "${{ inputs.filter }}" ]; then
-            pytest tests/integration -v --cov --cov-report=xml -k "${{ inputs.filter }}" || [ $? -eq 5 ]
+            pytest tests/integration -v --cov --cov-append --cov-report=xml -k "(lmstudio or ollama) and (${{ inputs.filter }})" || [ $? -eq 5 ]
           else
-            pytest tests/integration -v --cov --cov-report=xml || [ $? -eq 5 ]
-          fi
-
-      - name: Cleanup LlamaFile process
-        if: always()
-        run: |
-          if [ -f llamafile.pid ]; then
-            kill $(cat llamafile.pid) || true
-            rm llamafile.pid
+            pytest tests/integration -v --cov --cov-append --cov-report=xml -k "lmstudio or ollama" || [ $? -eq 5 ]
           fi
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Summary

`run-local-integration-tests` has been dying with exit 143 (runner shutdown/SIGTERM) at `test_completion_reasoning[ollama]` across dozens of unrelated commits (last known-green run: 2026-07-14). All four local model servers (ollama, llamafile, dockerized llama.cpp, LM Studio) stayed resident for the entire job, competing for the runner's RAM until the ollama reasoning test tipped it over.

- Split the job into two groups that never run concurrently: llamafile + llamacpp start, run their tests, then get torn down; only then do ollama and LM Studio start and run theirs.
- The llama.cpp docker container is now actually stopped after its group (previously it was never stopped at all).
- Manual `workflow_dispatch` filters still work: each group's pytest `-k` ANDs the group filter with the user-supplied filter, and each setup step keeps its original conditional gate.
- Coverage is combined across both groups via `--cov-append`; the first group also writes `--cov-report=xml` as a fallback in case a filtered manual run only touches one group.

## Test plan

- [ ] `uv run pre-commit run --all-files`
- [ ] Confirm `run-local-integration-tests` passes on this PR (push triggers it) without hitting the previous OOM/shutdown failure
- [ ] Spot-check that llamafile/llamacpp tests and lmstudio/ollama tests both still run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)