### PR TITLE
fix(mistral): clamp reasoning_effort, drop prompt_mode, replay thinking traces

### DIFF
--- a/src/any_llm/providers/mistral/mistral.py
+++ b/src/any_llm/providers/mistral/mistral.py
@@ -45,17 +45,13 @@ if TYPE_CHECKING:
     from any_llm.types.moderation import ModerationResponse
 
 
-# any_llm's ReasoningEffort vocabulary is a superset of Mistral's; "max" has no Mistral
-# equivalent, so it maps onto the strongest level Mistral accepts. "auto" and "none" are
-# handled separately because neither turns reasoning on.
-_REASONING_EFFORT_TO_MISTRAL: dict[str, str] = {
-    "minimal": "minimal",
-    "low": "low",
-    "medium": "medium",
-    "high": "high",
-    "xhigh": "xhigh",
-    "max": "xhigh",
-}
+# Mistral's API accepts a reasoning_effort of only "high" or "none", regardless of the wider
+# set its SDK types allow (https://docs.mistral.ai/studio-api/conversations/reasoning). Any
+# other value is rejected with "reasoning_effort <value> is not supported for this model,
+# supported values: [high, none]". any_llm's ReasoningEffort vocabulary is more granular, so
+# every explicit level other than "auto"/"none" collapses onto "high" rather than surfacing a
+# 400 for an effort any_llm advertises.
+_MISTRAL_REASONING_EFFORT = "high"
 
 
 class MistralProvider(AnyLLM):
@@ -108,15 +104,15 @@ class MistralProvider(AnyLLM):
             elif isinstance(params.response_format, dict):
                 converted_params["response_format"] = ResponseFormat.model_validate(params.response_format)
 
-        # Mistral gates the reasoning system prompt behind prompt_mode. Without it a magistral
-        # model answers directly and never emits a `thinking` block, so an explicit reasoning
-        # effort has to set both. "auto" leaves the choice to Mistral (its current default is
-        # no reasoning prompt) and "none" asks for no reasoning, so neither sets prompt_mode.
+        # An explicit reasoning_effort is all Mistral needs to emit a `thinking` block; every
+        # model defaults to not reasoning, so "auto" (leave the choice to Mistral) and "none"
+        # both mean send nothing. Note that prompt_mode="reasoning" must not be sent alongside
+        # it: Mistral documents that param only for the deprecated native-reasoning magistral
+        # models and now rejects it on every model, magistral included, with "Reasoning prompt
+        # mode is not enabled for this model".
         reasoning_effort = converted_params.pop("reasoning_effort", None)
-        mistral_effort = _REASONING_EFFORT_TO_MISTRAL.get(reasoning_effort) if reasoning_effort else None
-        if mistral_effort is not None:
-            converted_params["reasoning_effort"] = mistral_effort
-            converted_params["prompt_mode"] = "reasoning"
+        if reasoning_effort is not None and reasoning_effort not in ("auto", "none"):
+            converted_params["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
 
         converted_params.update(kwargs)
         return converted_params

--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -127,21 +127,25 @@ def _convert_mistral_streaming_tool_calls_to_any_llm(
 
 def _extract_mistral_content_and_reasoning(
     content_data: MistralAssistantMessageContent,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, str | None]:
     """
-    Extract text content and reasoning from Mistral's content structure.
+    Extract text content, reasoning, and the thinking signature from Mistral's content structure.
 
     Mistral returns content as an array of objects, where reasoning is in a 'thinking' object.
+    The signature, when present, has to be replayed with the thinking block on later turns.
     """
 
     text_parts = []
     reasoning_content = None
+    thinking_signature = None
 
     for item in content_data:
         if isinstance(item, str):
             text_parts.append(item)
         else:
             if isinstance(item, MistralThinkChunk):
+                if isinstance(item.signature, str):
+                    thinking_signature = item.signature
                 thinking_data = item.thinking
                 if isinstance(thinking_data, list):
                     thinking_texts = []
@@ -161,7 +165,7 @@ def _extract_mistral_content_and_reasoning(
                 text_parts.append(item.text)
 
     content = "".join(text_parts) if text_parts else None
-    return content, reasoning_content
+    return content, reasoning_content, thinking_signature
 
 
 def _create_mistral_completion_from_response(
@@ -180,10 +184,13 @@ def _create_mistral_completion_from_response(
             raise ValueError(msg)
 
         if message_data.content:
-            content, reasoning_content = _extract_mistral_content_and_reasoning(message_data.content)
+            content, reasoning_content, thinking_signature = _extract_mistral_content_and_reasoning(
+                message_data.content
+            )
         else:
             content = None
             reasoning_content = None
+            thinking_signature = None
 
         tool_calls_list: list[dict[str, Any]] | None = None
         if message_data.tool_calls is not None and not isinstance(message_data.tool_calls, Unset):
@@ -225,6 +232,7 @@ def _create_mistral_completion_from_response(
             content=content,
             tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls_final),
             reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
+            extra_content={"mistral": {"signature": thinking_signature}} if thinking_signature else None,
         )
 
         choice = Choice(
@@ -263,6 +271,7 @@ def _create_openai_chunk_from_mistral_chunk(event: CompletionEvent) -> ChatCompl
     for choice in chunk.choices:
         content = None
         reasoning_content = None
+        thinking_signature = None
 
         if choice.delta.content:
             if isinstance(choice.delta.content, str):
@@ -271,6 +280,8 @@ def _create_openai_chunk_from_mistral_chunk(event: CompletionEvent) -> ChatCompl
                 text_parts = []
                 for part in choice.delta.content:
                     if isinstance(part, MistralThinkChunk):
+                        if isinstance(part.signature, str):
+                            thinking_signature = part.signature
                         thinking_data = part.thinking
                         thinking_texts = []
                         for thinking_item in thinking_data:
@@ -297,7 +308,12 @@ def _create_openai_chunk_from_mistral_chunk(event: CompletionEvent) -> ChatCompl
         if reasoning_content:
             reasoning = Reasoning(content=reasoning_content)
 
-        delta = ChoiceDelta(content=content, role=role, reasoning=reasoning)
+        delta = ChoiceDelta(
+            content=content,
+            role=role,
+            reasoning=reasoning,
+            extra_content={"mistral": {"signature": thinking_signature}} if thinking_signature else None,
+        )
 
         delta.tool_calls = None
         if choice.delta.tool_calls is not None and not isinstance(choice.delta.tool_calls, Unset):
@@ -417,15 +433,76 @@ def _create_openai_moderation_response_from_mistral(
     )
 
 
+def _extract_reasoning_text(message: dict[str, Any]) -> str:
+    """Extract the plain-text reasoning content from a message, regardless of its shape.
+
+    ``reasoning`` may be a plain string (the OpenAI-wire-compatible serialized form) or a
+    ``{"content": str}`` dict, depending on how the caller constructed the message.
+    """
+    reasoning = message.get("reasoning")
+    if isinstance(reasoning, str):
+        return reasoning
+    if isinstance(reasoning, dict) and isinstance(content := reasoning.get("content"), str):
+        return content
+    return ""
+
+
+def _extract_mistral_thinking_signature(message: dict[str, Any]) -> str | None:
+    """Extract the thinking signature stored on a message's extra_content, if any."""
+    extra_content = message.get("extra_content")
+    if isinstance(extra_content, dict) and isinstance(mistral_extra := extra_content.get("mistral"), dict):
+        signature = mistral_extra.get("signature")
+        if isinstance(signature, str):
+            return signature
+    return None
+
+
+def _build_mistral_assistant_content(message: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Rebuild an assistant message's content with a ThinkChunk for replay across turns.
+
+    Mistral requires the full assistant message, thinking trace included, to be replayed on
+    subsequent turns; dropping the trace measurably degrades output quality. Since any-llm
+    normalizes the trace onto ``message.reasoning``, it has to be folded back into Mistral's
+    chunked content shape on the way out. See
+    https://docs.mistral.ai/studio-api/conversations/reasoning#multi-turn-conversations
+
+    Returns None when there is nothing to rebuild, leaving the message untouched.
+    """
+    reasoning_text = _extract_reasoning_text(message)
+    if not reasoning_text:
+        return None
+
+    content = message.get("content")
+    if content is not None and not isinstance(content, str):
+        # The caller already supplied provider-native content chunks; trust them as-is rather
+        # than guessing how to merge a thinking block into them.
+        return None
+
+    think_chunk: dict[str, Any] = {"type": "thinking", "thinking": [{"type": "text", "text": reasoning_text}]}
+    signature = _extract_mistral_thinking_signature(message)
+    if signature is not None:
+        think_chunk["signature"] = signature
+
+    chunks: list[dict[str, Any]] = [think_chunk]
+    if content:
+        chunks.append({"type": "text", "text": content})
+    return chunks
+
+
 def _patch_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Patches messages for Mistral API compatibility.
 
+    - Rebuilds assistant thinking blocks so reasoning traces survive multi-turn replay.
     - Inserts an assistant message with "OK" content between a tool message and a user message.
     - Validates the message sequence to ensure correctness.
     """
     processed_msg: list[dict[str, Any]] = []
     for i, msg in enumerate(messages):
+        if msg.get("role") == "assistant":
+            rebuilt_content = _build_mistral_assistant_content(msg)
+            if rebuilt_content is not None:
+                msg = {**msg, "content": rebuilt_content}
         processed_msg.append(msg)
         if msg.get("role") == "tool":
             if i + 1 < len(messages) and messages[i + 1].get("role") == "user":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,10 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.GROQ: "openai/gpt-oss-20b",
         LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-20b",
         LLMProvider.OPENAI: "gpt-5-nano",
-        LLMProvider.MISTRAL: "magistral-medium-latest",
+        # magistral-medium-latest / magistral-small-latest (native reasoning models) are
+        # deprecated; mistral-medium-3-5 supports adjustable reasoning via reasoning_effort
+        # (high/none only, see MistralProvider._convert_completion_params).
+        LLMProvider.MISTRAL: "mistral-medium-3-5",
         LLMProvider.GMI: "zai-org/GLM-5-FP8",
         LLMProvider.XAI: "grok-3-mini-latest",
         LLMProvider.OLLAMA: "qwen3:0.6b",

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -101,6 +101,97 @@ def test_patch_messages_with_multiple_valid_tool_calls() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "reasoning",
+    ["thought hard", {"content": "thought hard"}],
+    ids=["serialized-string", "object-form"],
+)
+def test_patch_messages_rebuilds_thinking_chunk_for_replay(reasoning: Any) -> None:
+    """Reasoning normalized onto `reasoning` must be folded back into a Mistral ThinkChunk."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "the answer", "reasoning": reasoning},
+        {"role": "user", "content": "u2"},
+    ]
+    out = _patch_messages(messages)
+    assert out[1]["content"] == [
+        {"type": "thinking", "thinking": [{"type": "text", "text": "thought hard"}]},
+        {"type": "text", "text": "the answer"},
+    ]
+
+
+def test_patch_messages_replays_thinking_signature_from_extra_content() -> None:
+    """A signature captured off the response has to be replayed with the thinking block."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": "the answer",
+            "reasoning": "thought hard",
+            "extra_content": {"mistral": {"signature": "sig-abc"}},
+        },
+    ]
+    out = _patch_messages(messages)
+    assert out[0]["content"][0] == {
+        "type": "thinking",
+        "thinking": [{"type": "text", "text": "thought hard"}],
+        "signature": "sig-abc",
+    }
+
+
+def test_patch_messages_rebuilds_thinking_chunk_without_text_when_content_empty() -> None:
+    """A reasoning-only assistant turn yields a thinking chunk and no empty text chunk."""
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": None, "reasoning": "thought hard"}]
+    out = _patch_messages(messages)
+    assert out[0]["content"] == [{"type": "thinking", "thinking": [{"type": "text", "text": "thought hard"}]}]
+
+
+def test_patch_messages_leaves_prechunked_content_untouched() -> None:
+    """Caller-supplied provider-native chunks are trusted rather than merged into."""
+    prechunked = [{"type": "text", "text": "already chunked"}]
+    messages: list[dict[str, Any]] = [
+        {"role": "assistant", "content": prechunked, "reasoning": "thought hard"},
+    ]
+    out = _patch_messages(messages)
+    assert out[0]["content"] == prechunked
+
+
+def test_patch_messages_ignores_unusable_reasoning_shapes() -> None:
+    """An absent or malformed `reasoning` value leaves the message alone."""
+    messages: list[dict[str, Any]] = [
+        {"role": "assistant", "content": "a1"},
+        {"role": "assistant", "content": "a2", "reasoning": None},
+        {"role": "assistant", "content": "a3", "reasoning": {"nope": "wrong-key"}},
+        {"role": "assistant", "content": "a4", "reasoning": ""},
+    ]
+    out = _patch_messages(messages)
+    assert out == messages
+
+
+def test_patch_messages_does_not_mutate_input_messages() -> None:
+    """Rebuilding content must not write back into the caller's message dicts."""
+    messages: list[dict[str, Any]] = [
+        {"role": "assistant", "content": "the answer", "reasoning": "thought hard"},
+    ]
+    _patch_messages(messages)
+    assert messages == [{"role": "assistant", "content": "the answer", "reasoning": "thought hard"}]
+
+
+def test_patch_messages_rebuilds_thinking_and_still_inserts_assistant_ok() -> None:
+    """The thinking rebuild composes with the tool-message "OK" insertion."""
+    messages: list[dict[str, Any]] = [
+        {"role": "assistant", "content": "a1", "reasoning": "thought hard", "tool_calls": [{}]},
+        {"role": "tool", "content": "t1"},
+        {"role": "user", "content": "u1"},
+    ]
+    out = _patch_messages(messages)
+    assert out[0]["content"] == [
+        {"type": "thinking", "thinking": [{"type": "text", "text": "thought hard"}]},
+        {"type": "text", "text": "a1"},
+    ]
+    assert out[0]["tool_calls"] == [{}]
+    assert out[2] == {"role": "assistant", "content": "OK"}
+
+
 class StructuredOutput(BaseModel):
     foo: str
     bar: int
@@ -292,18 +383,16 @@ async def test_reasoning_effort_filtered_out(reasoning_effort: str) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("reasoning_effort", "expected_effort"),
-    [
-        ("minimal", "minimal"),
-        ("low", "low"),
-        ("medium", "medium"),
-        ("high", "high"),
-        ("xhigh", "xhigh"),
-        ("max", "xhigh"),
-    ],
+    "reasoning_effort",
+    ["minimal", "low", "medium", "high", "xhigh", "max"],
 )
-async def test_explicit_reasoning_effort_enables_prompt_mode(reasoning_effort: str, expected_effort: str) -> None:
-    """An explicit reasoning effort must also send prompt_mode so Mistral emits a thinking block."""
+@pytest.mark.parametrize("model_id", ["mistral-medium-3-5", "magistral-medium-latest"])
+async def test_explicit_reasoning_effort_collapses_to_high(model_id: str, reasoning_effort: str) -> None:
+    """Mistral accepts only "high" or "none", so every explicit any_llm effort sends "high".
+
+    prompt_mode must never accompany it: Mistral rejects that param on every model, including
+    the magistral ones it was originally documented for.
+    """
     pytest.importorskip("mistralai")
     from any_llm.providers.mistral.mistral import MistralProvider
 
@@ -318,20 +407,20 @@ async def test_explicit_reasoning_effort_enables_prompt_mode(reasoning_effort: s
 
         await provider._acompletion(
             CompletionParams(
-                model_id="magistral-medium-latest",
+                model_id=model_id,
                 messages=[{"role": "user", "content": "Hello"}],
                 reasoning_effort=reasoning_effort,  # type: ignore[arg-type]
             ),
         )
 
         completion_call_kwargs = mocked_mistral.return_value.chat.complete_async.call_args[1]
-        assert completion_call_kwargs["reasoning_effort"] == expected_effort
-        assert completion_call_kwargs["prompt_mode"] == "reasoning"
+        assert completion_call_kwargs["reasoning_effort"] == "high"
+        assert "prompt_mode" not in completion_call_kwargs
 
 
 @pytest.mark.asyncio
-async def test_explicit_prompt_mode_kwarg_wins() -> None:
-    """A caller-supplied prompt_mode overrides the one derived from reasoning_effort."""
+async def test_explicit_prompt_mode_kwarg_passes_through() -> None:
+    """A caller-supplied prompt_mode still reaches the SDK, for callers on a model that takes it."""
     pytest.importorskip("mistralai")
     from any_llm.providers.mistral.mistral import MistralProvider
 
@@ -350,11 +439,11 @@ async def test_explicit_prompt_mode_kwarg_wins() -> None:
                 messages=[{"role": "user", "content": "Hello"}],
                 reasoning_effort="low",
             ),
-            prompt_mode=None,
+            prompt_mode="reasoning",
         )
 
         completion_call_kwargs = mocked_mistral.return_value.chat.complete_async.call_args[1]
-        assert completion_call_kwargs["prompt_mode"] is None
+        assert completion_call_kwargs["prompt_mode"] == "reasoning"
 
 
 @pytest.mark.asyncio
@@ -1110,3 +1199,90 @@ def test_create_mistral_completion_builds_chatcompletion_from_well_formed_respon
     assert completion.usage.prompt_tokens == 12
     assert completion.usage.completion_tokens == 7
     assert completion.usage.total_tokens == 19
+
+
+def test_create_mistral_completion_extracts_reasoning_and_signature() -> None:
+    """A ThinkChunk's text lands on `reasoning` and its signature on `extra_content`."""
+    pytest.importorskip("mistralai")
+    from mistralai.client.models import TextChunk, ThinkChunk
+
+    from any_llm.providers.mistral.utils import _create_mistral_completion_from_response
+
+    message = Mock()
+    message.content = [
+        ThinkChunk(thinking=[TextChunk(text="step one"), TextChunk(text="step two")], signature="sig-abc"),
+        TextChunk(text="the answer"),
+    ]
+    message.tool_calls = None
+
+    choice = Mock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    response = Mock()
+    response.id = "chatcmpl-abc"
+    response.created = 1_700_000_000
+    response.choices = [choice]
+    response.usage = None
+
+    completion = _create_mistral_completion_from_response(response, model="mistral-medium-3-5")
+
+    assert completion.choices[0].message.content == "the answer"
+    assert completion.choices[0].message.reasoning is not None
+    assert completion.choices[0].message.reasoning.content == "step one\nstep two"
+    assert completion.choices[0].message.extra_content == {"mistral": {"signature": "sig-abc"}}
+
+
+def test_create_mistral_completion_omits_extra_content_without_signature() -> None:
+    """Mistral leaves the signature unset today, so extra_content stays absent."""
+    pytest.importorskip("mistralai")
+    from mistralai.client.models import TextChunk, ThinkChunk
+
+    from any_llm.providers.mistral.utils import _create_mistral_completion_from_response
+
+    message = Mock()
+    message.content = [ThinkChunk(thinking=[TextChunk(text="step one")]), TextChunk(text="the answer")]
+    message.tool_calls = None
+
+    choice = Mock()
+    choice.message = message
+    choice.finish_reason = "stop"
+
+    response = Mock()
+    response.id = "chatcmpl-abc"
+    response.created = 1_700_000_000
+    response.choices = [choice]
+    response.usage = None
+
+    completion = _create_mistral_completion_from_response(response, model="mistral-medium-3-5")
+
+    assert completion.choices[0].message.reasoning is not None
+    assert completion.choices[0].message.extra_content is None
+
+
+def test_create_openai_chunk_captures_thinking_signature() -> None:
+    """Streaming deltas surface the thinking signature the same way as non-streaming."""
+    pytest.importorskip("mistralai")
+    from mistralai.client.models import TextChunk, ThinkChunk
+
+    from any_llm.providers.mistral.utils import _create_openai_chunk_from_mistral_chunk
+
+    choice = Mock()
+    choice.index = 0
+    choice.delta.content = [ThinkChunk(thinking=[TextChunk(text="step one")], signature="sig-abc")]
+    choice.delta.role = "assistant"
+    choice.delta.tool_calls = None
+    choice.finish_reason = None
+
+    event = Mock()
+    event.data.id = "chatcmpl-abc"
+    event.data.created = 1_700_000_000
+    event.data.model = "mistral-medium-3-5"
+    event.data.choices = [choice]
+    event.data.usage = None
+
+    chunk = _create_openai_chunk_from_mistral_chunk(event)
+
+    assert chunk.choices[0].delta.reasoning is not None
+    assert chunk.choices[0].delta.reasoning.content == "step one"
+    assert chunk.choices[0].delta.extra_content == {"mistral": {"signature": "sig-abc"}}


### PR DESCRIPTION
## Description

Fixes the two `test_reasoning.py::*[mistral]` failures on `main` ([run 31011944484](https://github.com/mozilla-ai/any-llm/actions/runs/31011944484/job/92326164331)), and one related bug found while verifying.

**`reasoning_effort` clamping.** Mistral accepts only `"high"` or `"none"`, so passing any_llm's finer-grained levels through returned `400 reasoning_effort low is not supported for this model`. Every explicit level now collapses onto `"high"`. Bifrost does the same thing for Mistral, and both bifrost and litellm clamp rather than propagate a predictable 400 on other restricted providers (Gemini Pro, Bedrock Nova).

**`prompt_mode` removed.** #1236 added `prompt_mode="reasoning"`, which Mistral documents only for the deprecated magistral models. It now returns `400 Reasoning prompt mode is not enabled for this model` on *every* model, magistral included. An explicit `reasoning_effort` is sufficient to get a thinking block; I verified that against `mistral-medium-3-5`, `mistral-small-latest`, `magistral-medium-latest` and `magistral-small-latest`. The reasoning test model moves to `mistral-medium-3-5` since magistral is deprecated.

**Thinking replay.** Mistral [requires the full assistant message, thinking trace included, on later turns](https://docs.mistral.ai/studio-api/conversations/reasoning) and warns that dropping it degrades quality. We parsed traces out but never folded them back in, so multi-turn reasoning silently lost them. `_patch_messages` now rebuilds the `ThinkChunk`, carrying the replay `signature` through `extra_content` as the Anthropic provider already does.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None filed; caught by the post-merge integration run above.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

Verified locally with a real `MISTRAL_API_KEY`: both previously failing tests pass, the full Mistral integration selection is green (21 passed, 6 skipped), `tests/unit` is green (1881 passed), and multi-turn replay was confirmed end to end to carry the trace into turn 2.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Behavior was established by probing the live Mistral API rather than from docs alone, which is what showed `prompt_mode` now failing on magistral too. Cross-checked the clamping approach against litellm and bifrost before landing it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Mistral reasoning support by preserving thinking signatures in standard and streaming responses.
  * Enabled reliable replay of reasoning across multi-turn conversations and tool interactions.

* **Bug Fixes**
  * Normalised explicit reasoning requests to Mistral’s supported high-effort setting.
  * Prevented unsupported reasoning values and unwanted prompt-mode changes from being sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->