### PR TITLE
fix(reasoning): handle XML reasoning tags split mid-buffer

### DIFF
--- a/src/any_llm/providers/openai/xml_reasoning.py
+++ b/src/any_llm/providers/openai/xml_reasoning.py
@@ -34,6 +34,32 @@ def set_chunk_reasoning(chunk: ChatCompletionChunk, reasoning: str) -> ChatCompl
     return chunk
 
 
+def is_terminal_chunk(chunk: ChatCompletionChunk) -> bool:
+    """Return whether a chunk carries a terminal finish reason."""
+    return bool(chunk.choices and chunk.choices[0].finish_reason)
+
+
+def clear_chunk_stream_metadata(chunk: ChatCompletionChunk) -> ChatCompletionChunk:
+    """Remove metadata that must not be repeated on a synthetic flush chunk."""
+    if not chunk.choices:
+        return chunk
+
+    choice = chunk.choices[0]
+    choice.finish_reason = None
+    choice.logprobs = None
+    choice.delta.function_call = None
+    choice.delta.refusal = None
+    choice.delta.reasoning = None
+    choice.delta.role = None
+    choice.delta.tool_calls = None
+    choice.delta.extra_content = None
+    chunk.moderation = None
+    chunk.service_tier = None
+    chunk.system_fingerprint = None
+    chunk.usage = None
+    return chunk
+
+
 def wrap_chunks_with_xml_reasoning(
     chunks: AsyncIterator[ChatCompletionChunk],
 ) -> AsyncIterator[ChatCompletionChunk]:
@@ -53,6 +79,8 @@ def wrap_chunks_with_xml_reasoning(
         get_content=get_chunk_content,
         set_content=set_chunk_content,
         set_reasoning=set_chunk_reasoning,
+        is_terminal=is_terminal_chunk,
+        clear_stream_metadata=clear_chunk_stream_metadata,
     )
 
 

--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import AsyncIterator
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from any_llm.constants import REASONING_FIELD_NAMES
 
@@ -25,7 +25,7 @@ def find_reasoning_tag(text: str, opening: bool = True) -> tuple[int, str] | Non
     return (earliest_pos, earliest_tag) if earliest_tag else None
 
 
-def partial_reasoning_tag_suffix_len(text: str, opening: bool = True) -> int:
+def partial_reasoning_tag_suffix_len(text: str, *, tag_kind: Literal["opening", "closing"]) -> int:
     """Length of the longest suffix of text that is a proper prefix of a reasoning tag.
 
     A non-zero result means the tail of ``text`` may become a complete reasoning tag once
@@ -34,7 +34,7 @@ def partial_reasoning_tag_suffix_len(text: str, opening: bool = True) -> int:
     """
     longest = 0
     for tag_name in REASONING_FIELD_NAMES:
-        tag = f"<{tag_name}>" if opening else f"</{tag_name}>"
+        tag = f"<{tag_name}>" if tag_kind == "opening" else f"</{tag_name}>"
         for i in range(min(len(text), len(tag) - 1), 0, -1):
             if text.endswith(tag[:i]):
                 longest = max(longest, i)
@@ -66,16 +66,23 @@ async def process_streaming_reasoning_chunks(
     buffer = ""
     current_tag = None
     reasoning_buffer = ""
-    last_chunk: T | None = None
+    pending_chunk: T | None = None
+    pending_content_parts: list[str] = []
+    pending_reasoning_parts: list[str] = []
+    held_chunks: list[T] = []
 
     async for original_chunk in chunks:
         content = get_content(original_chunk)
 
         if not content:
-            yield original_chunk
+            if buffer or reasoning_buffer:
+                held_chunks.append(original_chunk)
+            else:
+                yield original_chunk
             continue
 
-        last_chunk = original_chunk
+        if pending_chunk is None:
+            pending_chunk = original_chunk
         buffer += content
         content_parts = []
         reasoning_parts = []
@@ -91,7 +98,7 @@ async def process_streaming_reasoning_chunks(
                     buffer = buffer[tag_start + len(tag_full) :]
                     current_tag = tag_name
                 else:
-                    partial_len = partial_reasoning_tag_suffix_len(buffer, opening=True)
+                    partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="opening")
                     if partial_len:
                         if partial_len < len(buffer):
                             content_parts.append(buffer[:-partial_len])
@@ -108,7 +115,7 @@ async def process_streaming_reasoning_chunks(
                     buffer = buffer[tag_end + len(tag_close) :]
                     current_tag = None
                 else:
-                    partial_len = partial_reasoning_tag_suffix_len(buffer, opening=False)
+                    partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="closing")
                     if partial_len:
                         reasoning_buffer += buffer[: len(buffer) - partial_len]
                         buffer = buffer[len(buffer) - partial_len :]
@@ -116,26 +123,43 @@ async def process_streaming_reasoning_chunks(
                     reasoning_buffer += buffer
                     buffer = ""
 
-        if content_parts or reasoning_parts:
-            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
-            modified_chunk = set_content(modified_chunk, "".join(content_parts) if content_parts else None)
-            if reasoning_parts:
-                modified_chunk = set_reasoning(modified_chunk, "".join(reasoning_parts))
-            yield modified_chunk
-        elif not buffer:
-            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
-            modified_chunk = set_content(modified_chunk, None)
-            yield modified_chunk
+        pending_content_parts.extend(content_parts)
+        pending_reasoning_parts.extend(reasoning_parts)
+        if buffer or reasoning_buffer:
+            continue
 
-    if last_chunk is not None and (buffer or reasoning_buffer):
-        # The stream ended mid-tag: flush whatever is held back rather than dropping it.
-        final_chunk = last_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+        modified_chunk = pending_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+        modified_chunk = set_content(
+            modified_chunk,
+            "".join(pending_content_parts) if pending_content_parts else None,
+        )
+        if pending_reasoning_parts:
+            modified_chunk = set_reasoning(modified_chunk, "".join(pending_reasoning_parts))
+        yield modified_chunk
+        pending_chunk = None
+        pending_content_parts = []
+        pending_reasoning_parts = []
+
+        for held_chunk in held_chunks:
+            yield held_chunk
+        held_chunks = []
+
+    if pending_chunk is not None and (buffer or reasoning_buffer):
+        final_chunk = pending_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
         if current_tag is None:
-            final_chunk = set_content(final_chunk, buffer)
+            pending_content_parts.append(buffer)
         else:
-            final_chunk = set_content(final_chunk, None)
-            final_chunk = set_reasoning(final_chunk, reasoning_buffer + buffer)
+            pending_reasoning_parts.append(reasoning_buffer + buffer)
+        final_chunk = set_content(
+            final_chunk,
+            "".join(pending_content_parts) if pending_content_parts else None,
+        )
+        if pending_reasoning_parts:
+            final_chunk = set_reasoning(final_chunk, "".join(pending_reasoning_parts))
         yield final_chunk
+
+    for held_chunk in held_chunks:
+        yield held_chunk
 
 
 def normalize_reasoning_from_provider_fields_and_xml_tags(message_dict: dict[str, Any]) -> None:

--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -75,6 +75,7 @@ async def process_streaming_reasoning_chunks(
     terminal_content_parts: list[str] = []
     terminal_reasoning_parts: list[str] = []
     held_chunks: list[T] = []
+    last_chunk_was_yielded = False
 
     async for original_chunk in chunks:
         content = get_content(original_chunk)
@@ -87,6 +88,7 @@ async def process_streaming_reasoning_chunks(
             continue
 
         last_chunk = original_chunk
+        last_chunk_was_yielded = False
         buffer += content
         content_parts = []
         reasoning_parts = []
@@ -139,10 +141,12 @@ async def process_streaming_reasoning_chunks(
             if reasoning_parts:
                 modified_chunk = set_reasoning(modified_chunk, "".join(reasoning_parts))
             yield modified_chunk
+            last_chunk_was_yielded = True
         elif not buffer:
             modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
             modified_chunk = set_content(modified_chunk, None)
             yield modified_chunk
+            last_chunk_was_yielded = True
 
     if terminal_chunk is not None:
         final_chunk = terminal_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
@@ -160,7 +164,9 @@ async def process_streaming_reasoning_chunks(
             final_chunk = set_reasoning(final_chunk, final_reasoning)
         yield final_chunk
     elif last_chunk is not None and (buffer or reasoning_buffer):
-        final_chunk = clear_stream_metadata(last_chunk.model_copy(deep=True))  # type: ignore[attr-defined]
+        final_chunk = last_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+        if last_chunk_was_yielded:
+            final_chunk = clear_stream_metadata(final_chunk)
         if current_tag is None:
             final_chunk = set_content(final_chunk, buffer)
         else:

--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any, Literal, TypeVar
 
 from any_llm.constants import REASONING_FIELD_NAMES
@@ -44,9 +44,11 @@ def partial_reasoning_tag_suffix_len(text: str, *, tag_kind: Literal["opening", 
 
 async def process_streaming_reasoning_chunks(
     chunks: AsyncIterator[T],
-    get_content: Any,
-    set_content: Any,
-    set_reasoning: Any,
+    get_content: Callable[[T], str | None],
+    set_content: Callable[[T, str | None], T],
+    set_reasoning: Callable[[T, str], T],
+    is_terminal: Callable[[T], bool],
+    clear_stream_metadata: Callable[[T], T],
 ) -> AsyncIterator[T]:
     """Process streaming chunks to extract reasoning from XML tags.
 
@@ -58,6 +60,8 @@ async def process_streaming_reasoning_chunks(
         get_content: Callable that extracts content string from a chunk (returns str | None)
         set_content: Callable that sets content on a chunk copy (chunk, content) -> chunk
         set_reasoning: Callable that sets reasoning on a chunk copy (chunk, reasoning) -> chunk
+        is_terminal: Callable that reports whether a chunk carries a finish reason
+        clear_stream_metadata: Callable that removes metadata from a synthetic flush chunk
 
     Yields:
         Processed chunks with reasoning extracted and separated from content
@@ -66,9 +70,10 @@ async def process_streaming_reasoning_chunks(
     buffer = ""
     current_tag = None
     reasoning_buffer = ""
-    pending_chunk: T | None = None
-    pending_content_parts: list[str] = []
-    pending_reasoning_parts: list[str] = []
+    last_chunk: T | None = None
+    terminal_chunk: T | None = None
+    terminal_content_parts: list[str] = []
+    terminal_reasoning_parts: list[str] = []
     held_chunks: list[T] = []
 
     async for original_chunk in chunks:
@@ -81,8 +86,7 @@ async def process_streaming_reasoning_chunks(
                 yield original_chunk
             continue
 
-        if pending_chunk is None:
-            pending_chunk = original_chunk
+        last_chunk = original_chunk
         buffer += content
         content_parts = []
         reasoning_parts = []
@@ -123,39 +127,45 @@ async def process_streaming_reasoning_chunks(
                     reasoning_buffer += buffer
                     buffer = ""
 
-        pending_content_parts.extend(content_parts)
-        pending_reasoning_parts.extend(reasoning_parts)
-        if buffer or reasoning_buffer:
+        if is_terminal(original_chunk) and (buffer or reasoning_buffer):
+            terminal_chunk = original_chunk
+            terminal_content_parts.extend(content_parts)
+            terminal_reasoning_parts.extend(reasoning_parts)
             continue
 
-        modified_chunk = pending_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
-        modified_chunk = set_content(
-            modified_chunk,
-            "".join(pending_content_parts) if pending_content_parts else None,
-        )
-        if pending_reasoning_parts:
-            modified_chunk = set_reasoning(modified_chunk, "".join(pending_reasoning_parts))
-        yield modified_chunk
-        pending_chunk = None
-        pending_content_parts = []
-        pending_reasoning_parts = []
+        if content_parts or reasoning_parts:
+            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+            modified_chunk = set_content(modified_chunk, "".join(content_parts) if content_parts else None)
+            if reasoning_parts:
+                modified_chunk = set_reasoning(modified_chunk, "".join(reasoning_parts))
+            yield modified_chunk
+        elif not buffer:
+            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+            modified_chunk = set_content(modified_chunk, None)
+            yield modified_chunk
 
-        for held_chunk in held_chunks:
-            yield held_chunk
-        held_chunks = []
-
-    if pending_chunk is not None and (buffer or reasoning_buffer):
-        final_chunk = pending_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+    if terminal_chunk is not None:
+        final_chunk = terminal_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+        final_content = "".join(terminal_content_parts)
+        final_reasoning = "".join(terminal_reasoning_parts)
         if current_tag is None:
-            pending_content_parts.append(buffer)
+            final_content += buffer
         else:
-            pending_reasoning_parts.append(reasoning_buffer + buffer)
+            final_reasoning += reasoning_buffer + buffer
         final_chunk = set_content(
             final_chunk,
-            "".join(pending_content_parts) if pending_content_parts else None,
+            final_content or None,
         )
-        if pending_reasoning_parts:
-            final_chunk = set_reasoning(final_chunk, "".join(pending_reasoning_parts))
+        if final_reasoning:
+            final_chunk = set_reasoning(final_chunk, final_reasoning)
+        yield final_chunk
+    elif last_chunk is not None and (buffer or reasoning_buffer):
+        final_chunk = clear_stream_metadata(last_chunk.model_copy(deep=True))  # type: ignore[attr-defined]
+        if current_tag is None:
+            final_chunk = set_content(final_chunk, buffer)
+        else:
+            final_chunk = set_content(final_chunk, None)
+            final_chunk = set_reasoning(final_chunk, reasoning_buffer + buffer)
         yield final_chunk
 
     for held_chunk in held_chunks:

--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -25,14 +25,21 @@ def find_reasoning_tag(text: str, opening: bool = True) -> tuple[int, str] | Non
     return (earliest_pos, earliest_tag) if earliest_tag else None
 
 
-def is_partial_reasoning_tag(text: str, opening: bool = True) -> bool:
-    """Check if text could be the start of any reasoning tag."""
+def partial_reasoning_tag_suffix_len(text: str, opening: bool = True) -> int:
+    """Length of the longest suffix of text that is a proper prefix of a reasoning tag.
+
+    A non-zero result means the tail of ``text`` may become a complete reasoning tag once
+    more content arrives, so it has to stay buffered instead of being flushed downstream.
+    Returns 0 when no suffix could grow into a tag.
+    """
+    longest = 0
     for tag_name in REASONING_FIELD_NAMES:
         tag = f"<{tag_name}>" if opening else f"</{tag_name}>"
-        for i in range(1, len(tag) + 1):
-            if text.startswith(tag[:i]):
-                return True
-    return False
+        for i in range(min(len(text), len(tag) - 1), 0, -1):
+            if text.endswith(tag[:i]):
+                longest = max(longest, i)
+                break
+    return longest
 
 
 async def process_streaming_reasoning_chunks(
@@ -59,6 +66,7 @@ async def process_streaming_reasoning_chunks(
     buffer = ""
     current_tag = None
     reasoning_buffer = ""
+    last_chunk: T | None = None
 
     async for original_chunk in chunks:
         content = get_content(original_chunk)
@@ -67,6 +75,7 @@ async def process_streaming_reasoning_chunks(
             yield original_chunk
             continue
 
+        last_chunk = original_chunk
         buffer += content
         content_parts = []
         reasoning_parts = []
@@ -81,9 +90,13 @@ async def process_streaming_reasoning_chunks(
                     tag_full = f"<{tag_name}>"
                     buffer = buffer[tag_start + len(tag_full) :]
                     current_tag = tag_name
-                elif is_partial_reasoning_tag(buffer, opening=True):
-                    break
                 else:
+                    partial_len = partial_reasoning_tag_suffix_len(buffer, opening=True)
+                    if partial_len:
+                        if partial_len < len(buffer):
+                            content_parts.append(buffer[:-partial_len])
+                        buffer = buffer[len(buffer) - partial_len :]
+                        break
                     content_parts.append(buffer)
                     buffer = ""
             else:
@@ -94,11 +107,12 @@ async def process_streaming_reasoning_chunks(
                     reasoning_buffer = ""
                     buffer = buffer[tag_end + len(tag_close) :]
                     current_tag = None
-                elif is_partial_reasoning_tag(buffer, opening=False):
-                    reasoning_buffer += buffer
-                    buffer = ""
-                    break
                 else:
+                    partial_len = partial_reasoning_tag_suffix_len(buffer, opening=False)
+                    if partial_len:
+                        reasoning_buffer += buffer[: len(buffer) - partial_len]
+                        buffer = buffer[len(buffer) - partial_len :]
+                        break
                     reasoning_buffer += buffer
                     buffer = ""
 
@@ -112,6 +126,16 @@ async def process_streaming_reasoning_chunks(
             modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
             modified_chunk = set_content(modified_chunk, None)
             yield modified_chunk
+
+    if last_chunk is not None and (buffer or reasoning_buffer):
+        # The stream ended mid-tag: flush whatever is held back rather than dropping it.
+        final_chunk = last_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+        if current_tag is None:
+            final_chunk = set_content(final_chunk, buffer)
+        else:
+            final_chunk = set_content(final_chunk, None)
+            final_chunk = set_reasoning(final_chunk, reasoning_buffer + buffer)
+        yield final_chunk
 
 
 def normalize_reasoning_from_provider_fields_and_xml_tags(message_dict: dict[str, Any]) -> None:

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -271,6 +271,18 @@ async def test_wrap_chunks_flushes_trailing_partial_opening_tag() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wrap_chunks_preserves_metadata_for_pure_partial_opening_tag() -> None:
+    """A source chunk held entirely for EOF flushing keeps its metadata."""
+    chunks = [_make_chunk(content="<th", extra_content={"source": "partial"})]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("<th", "")
+    assert len(result) == 1
+    assert result[0].choices[0].delta.role == "assistant"
+    assert result[0].choices[0].delta.extra_content == {"source": "partial"}
+
+
+@pytest.mark.asyncio
 async def test_wrap_chunks_flushes_unterminated_reasoning() -> None:
     """A reasoning block with no closing tag is emitted as reasoning, not dropped."""
     chunks = [_make_chunk(content="<think>unterminated "), _make_chunk(content="reasoning")]

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from typing import Literal
 
 import pytest
 
@@ -20,6 +21,8 @@ from any_llm.utils.reasoning import partial_reasoning_tag_suffix_len
 def _make_chunk(
     content: str | None = None,
     reasoning: Reasoning | None = None,
+    finish_reason: Literal["stop", "length"] | None = None,
+    role: Literal["assistant"] | None = "assistant",
 ) -> ChatCompletionChunk:
     """Create a minimal ChatCompletionChunk for testing."""
     return ChatCompletionChunk(
@@ -27,9 +30,9 @@ def _make_chunk(
         choices=[
             ChunkChoice(
                 index=0,
-                finish_reason=None,
+                finish_reason=finish_reason,
                 delta=ChoiceDelta(
-                    role="assistant",
+                    role=role,
                     content=content,
                     reasoning=reasoning,
                 ),
@@ -275,6 +278,39 @@ async def test_wrap_chunks_flushes_unterminated_reasoning() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wrap_chunks_flushes_partial_closing_tag() -> None:
+    """A partial closing tag is retained as reasoning when the stream ends."""
+    chunks = [_make_chunk(content="<think>reasoning</th")]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("", "reasoning</th")
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_flushes_before_contentless_terminal_chunk() -> None:
+    """Buffered content is emitted before a terminal chunk without content."""
+    chunks = [
+        _make_chunk(content="prefix <th"),
+        _make_chunk(finish_reason="stop", role=None),
+    ]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("prefix <th", "")
+    assert [chunk.choices[0].finish_reason for chunk in result] == [None, "stop"]
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_flushes_once_when_content_chunk_is_terminal() -> None:
+    """A terminal content chunk keeps its metadata while its reasoning is flushed."""
+    chunks = [_make_chunk(content="<think>reasoning", finish_reason="length")]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("", "reasoning")
+    assert len(result) == 1
+    assert result[0].choices[0].finish_reason == "length"
+
+
+@pytest.mark.asyncio
 async def test_wrap_chunks_empty_stream_yields_nothing() -> None:
     """No chunks in means no chunks out, including no flush chunk."""
     result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks([])))
@@ -283,16 +319,20 @@ async def test_wrap_chunks_empty_stream_yields_nothing() -> None:
 
 
 @pytest.mark.parametrize(
-    ("text", "opening", "expected"),
+    ("text", "tag_kind", "expected"),
     [
-        ("<th", True, 3),
-        ("preface <th", True, 3),
-        ("reasoning</th", False, 4),
-        ("<think>", True, 0),
-        ("plain text", True, 0),
-        ("", True, 0),
-        ("a<b<thin", True, 5),
+        ("<th", "opening", 3),
+        ("preface <th", "opening", 3),
+        ("reasoning</th", "closing", 4),
+        ("<think>", "opening", 0),
+        ("plain text", "opening", 0),
+        ("", "opening", 0),
+        ("a<b<thin", "opening", 5),
     ],
 )
-def test_partial_reasoning_tag_suffix_len(text: str, opening: bool, expected: int) -> None:
-    assert partial_reasoning_tag_suffix_len(text, opening=opening) == expected
+def test_partial_reasoning_tag_suffix_len(
+    text: str,
+    tag_kind: Literal["opening", "closing"],
+    expected: int,
+) -> None:
+    assert partial_reasoning_tag_suffix_len(text, tag_kind=tag_kind) == expected

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncIterator
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
 
@@ -23,6 +23,7 @@ def _make_chunk(
     reasoning: Reasoning | None = None,
     finish_reason: Literal["stop", "length"] | None = None,
     role: Literal["assistant"] | None = "assistant",
+    extra_content: dict[str, Any] | None = None,
 ) -> ChatCompletionChunk:
     """Create a minimal ChatCompletionChunk for testing."""
     return ChatCompletionChunk(
@@ -35,6 +36,7 @@ def _make_chunk(
                     role=role,
                     content=content,
                     reasoning=reasoning,
+                    extra_content=extra_content,
                 ),
             )
         ],
@@ -290,13 +292,16 @@ async def test_wrap_chunks_flushes_partial_closing_tag() -> None:
 async def test_wrap_chunks_flushes_before_contentless_terminal_chunk() -> None:
     """Buffered content is emitted before a terminal chunk without content."""
     chunks = [
-        _make_chunk(content="prefix <th"),
+        _make_chunk(content="prefix <th", extra_content={"source": "content"}),
         _make_chunk(finish_reason="stop", role=None),
     ]
     result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
 
     assert _accumulate(result) == ("prefix <th", "")
-    assert [chunk.choices[0].finish_reason for chunk in result] == [None, "stop"]
+    assert result[-1].choices[0].finish_reason == "stop"
+    assert [chunk.choices[0].delta.extra_content for chunk in result if chunk.choices[0].delta.extra_content] == [
+        {"source": "content"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -308,6 +313,19 @@ async def test_wrap_chunks_flushes_once_when_content_chunk_is_terminal() -> None
     assert _accumulate(result) == ("", "reasoning")
     assert len(result) == 1
     assert result[0].choices[0].finish_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_preserves_terminal_metadata_after_partial_tag() -> None:
+    """A terminal chunk completing an earlier partial tag keeps its finish reason."""
+    chunks = [
+        _make_chunk(content="prefix <th"),
+        _make_chunk(content="ink>reasoning</think>answer", finish_reason="stop", role=None),
+    ]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("prefix answer", "reasoning")
+    assert [chunk.choices[0].finish_reason for chunk in result] == [None, "stop"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -14,6 +14,7 @@ from any_llm.types.completion import (
     ChunkChoice,
     Reasoning,
 )
+from any_llm.utils.reasoning import partial_reasoning_tag_suffix_len
 
 
 def _make_chunk(
@@ -217,3 +218,81 @@ async def test_wrap_chunks_thinking_tag() -> None:
 
     assert full_reasoning == "deep thought"
     assert full_content.strip() == "Result."
+
+
+def _accumulate(chunks: list[ChatCompletionChunk]) -> tuple[str, str]:
+    """Join the content and reasoning deltas of processed chunks."""
+    content = ""
+    reasoning = ""
+    for chunk in chunks:
+        if not chunk.choices:
+            continue
+        content += chunk.choices[0].delta.content or ""
+        if chunk.choices[0].delta.reasoning:
+            reasoning += chunk.choices[0].delta.reasoning.content
+    return content, reasoning
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("parts", "expected_content", "expected_reasoning"),
+    [
+        (["<think>reasoning</th", "ink>answer"], "answer", "reasoning"),
+        (["preface <th", "ink>reasoning</think>answer"], "preface answer", "reasoning"),
+        (["preface <thin", "king>reasoning</thinking>answer"], "preface answer", "reasoning"),
+        (["a<b <think>reasoning</thin", "k>answer"], "a<b answer", "reasoning"),
+        (["<think>a</think>mid <th", "ink>b</think>end"], "mid end", "ab"),
+    ],
+)
+async def test_wrap_chunks_handles_tags_split_after_content(
+    parts: list[str],
+    expected_content: str,
+    expected_reasoning: str,
+) -> None:
+    """Tags split across chunks are handled even when preceded by other text."""
+    chunks = [_make_chunk(content=part) for part in parts]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == (expected_content, expected_reasoning)
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_flushes_trailing_partial_opening_tag() -> None:
+    """A stream that ends on a partial opening tag still emits the held-back text."""
+    chunks = [_make_chunk(content="trailing partial <th")]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("trailing partial <th", "")
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_flushes_unterminated_reasoning() -> None:
+    """A reasoning block with no closing tag is emitted as reasoning, not dropped."""
+    chunks = [_make_chunk(content="<think>unterminated "), _make_chunk(content="reasoning")]
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert _accumulate(result) == ("", "unterminated reasoning")
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_empty_stream_yields_nothing() -> None:
+    """No chunks in means no chunks out, including no flush chunk."""
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks([])))
+
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    ("text", "opening", "expected"),
+    [
+        ("<th", True, 3),
+        ("preface <th", True, 3),
+        ("reasoning</th", False, 4),
+        ("<think>", True, 0),
+        ("plain text", True, 0),
+        ("", True, 0),
+        ("a<b<thin", True, 5),
+    ],
+)
+def test_partial_reasoning_tag_suffix_len(text: str, opening: bool, expected: int) -> None:
+    assert partial_reasoning_tag_suffix_len(text, opening=opening) == expected


### PR DESCRIPTION
## Description

Thanks @Vansh-Sharma27 for the precise repro in #1242, it made the patch straightforward.

`is_partial_reasoning_tag()` checked `text.startswith(tag[:i])`, so it only detected a partial tag sitting at offset 0 of the buffer. With any earlier text in front, a split tag was flushed as content (opening case) or swallowed into `reasoning_buffer` where the next chunk could never complete it (closing case).

Replaced it with `partial_reasoning_tag_suffix_len()`, which returns the length of the longest buffer suffix that is a proper prefix of a reasoning tag; only that suffix stays buffered. While tracing, an unterminated `<think>` block turned out to drop the entire response, so the stream now flushes whatever is still held back at the end.

Before / after:

| chunks | before | after |
| --- | --- | --- |
| `"<think>reasoning</th"`, `"ink>answer"` | `content=""`, `reasoning=""` | `content="answer"`, `reasoning="reasoning"` |
| `"preface <th"`, `"ink>reasoning</think>answer"` | `content="preface <think>reasoning</think>answer"` | `content="preface answer"`, `reasoning="reasoning"` |
| `"<think>unterminated reasoning"` | `content=""`, `reasoning=""` | `reasoning="unterminated reasoning"` |

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1242

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally (`tests/unit`: 1896 passed, 93 skipped)
- [x] Documentation was updated where necessary (n/a)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: root cause and fix reviewed by @njbrake; the reporter's diagnosis in #1242 pointed at the same suffix matching approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses when reasoning tags are split across multiple chunks.
  * Prevented incomplete reasoning tags from appearing prematurely in displayed content.
  * Preserved and correctly released buffered content and reasoning when streams end.
  * Improved handling of empty streams, unfinished reasoning sections, and non-content chunks.
  * Prevented terminal and response metadata from being duplicated during streaming.

* **Tests**
  * Added coverage for split and partial tags, unterminated reasoning blocks, configurable terminal chunks, optional metadata, and empty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->