### PR TITLE
feat(cache): type prompt cache keys across chat APIs

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -15,6 +15,7 @@ from any_llm.exceptions import (
     ContentFilterFinishReasonError,
     LengthFinishReasonError,
     MissingApiKeyError,
+    UnsupportedParameterError,
     UnsupportedProviderError,
 )
 from any_llm.tools import prepare_tools
@@ -131,6 +132,9 @@ class AnyLLM(ABC):
 
     SUPPORTS_MESSAGES: bool = True
     """Anthropic Messages API (all providers support it via conversion)"""
+
+    PROMPT_CACHE_KEY_SUPPORT: Literal["unsupported", "supported", "passthrough"] = "unsupported"
+    """Whether prompt_cache_key is supported, forwarded to a router, or rejected."""
 
     API_BASE: str | None = None
     """This is used to set the API base for the provider.
@@ -572,6 +576,7 @@ class AnyLLM(ABC):
         *,
         response_format: dict[str, Any] | type | None = None,
         stream: bool | None = None,
+        prompt_cache_key: str | None = None,
         allow_running_loop: bool | None = None,
         **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk] | ParsedChatCompletion[Any]:
@@ -588,13 +593,21 @@ class AnyLLM(ABC):
                     messages=messages,
                     response_format=response_format,
                     stream=stream,
+                    prompt_cache_key=prompt_cache_key,
                     **kwargs,
                 ),
                 allow_running_loop=allow_running_loop,
             )
 
         response = run_async_in_sync(
-            self.acompletion(model=model, messages=messages, response_format=response_format, stream=stream, **kwargs),
+            self.acompletion(
+                model=model,
+                messages=messages,
+                response_format=response_format,
+                stream=stream,
+                prompt_cache_key=prompt_cache_key,
+                **kwargs,
+            ),
             allow_running_loop=allow_running_loop,
         )
         if isinstance(response, ChatCompletion):
@@ -673,6 +686,7 @@ class AnyLLM(ABC):
         stream_options: dict[str, Any] | None = None,
         max_completion_tokens: int | None = None,
         reasoning_effort: ReasoningEffort | None = "auto",
+        prompt_cache_key: str | None = None,
         **kwargs: Any,
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk] | ParsedChatCompletion[Any]:
         """Create a chat completion asynchronously.
@@ -701,6 +715,7 @@ class AnyLLM(ABC):
             stream_options: Additional options controlling streaming behavior
             max_completion_tokens: Maximum number of tokens for the completion
             reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
+            prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
         Returns:
@@ -742,8 +757,10 @@ class AnyLLM(ABC):
             stream_options=stream_options,
             max_completion_tokens=max_completion_tokens,
             reasoning_effort=reasoning_effort,
+            prompt_cache_key=prompt_cache_key,
         )
 
+        self._validate_prompt_cache_key(prompt_cache_key)
         result = await self._acompletion(params, **kwargs)
 
         if is_structured_output_type(response_format):
@@ -767,6 +784,11 @@ class AnyLLM(ABC):
 
         return result
 
+    def _validate_prompt_cache_key(self, prompt_cache_key: str | None) -> None:
+        if prompt_cache_key is not None and self.PROMPT_CACHE_KEY_SUPPORT == "unsupported":
+            parameter_name = "prompt_cache_key"
+            raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
+
     async def _acompletion(
         self, params: CompletionParams, **kwargs: Any
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
@@ -780,6 +802,7 @@ class AnyLLM(ABC):
         self,
         *,
         allow_running_loop: bool | None = None,
+        prompt_cache_key: str | None = None,
         context_management: dict[str, Any] | None = None,
         betas: list[str] | None = None,
         **kwargs: Any,
@@ -791,7 +814,12 @@ class AnyLLM(ABC):
         if allow_running_loop is None:
             allow_running_loop = INSIDE_NOTEBOOK
         response = run_async_in_sync(
-            self.amessages(context_management=context_management, betas=betas, **kwargs),
+            self.amessages(
+                prompt_cache_key=prompt_cache_key,
+                context_management=context_management,
+                betas=betas,
+                **kwargs,
+            ),
             allow_running_loop=allow_running_loop,
         )
         if isinstance(response, (MessageResponse, ParsedMessage, ParsedBetaMessage)):
@@ -816,6 +844,7 @@ class AnyLLM(ABC):
         metadata: dict[str, Any] | None = None,
         thinking: dict[str, Any] | None = None,
         cache_control: dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
         context_management: dict[str, Any] | None = None,
         betas: list[str] | None = None,
         output_format: type | dict[str, Any] | None = None,
@@ -841,6 +870,7 @@ class AnyLLM(ABC):
             metadata: Request metadata.
             thinking: Thinking/reasoning configuration.
             cache_control: Cache control configuration for prompt caching.
+            prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
             context_management: Anthropic context management configuration. The
                 `compact_20260112` strategy requires a supported model. Its `input_tokens`
                 trigger value must be at least 50,000 when provided; see
@@ -882,10 +912,12 @@ class AnyLLM(ABC):
             metadata=metadata,
             thinking=thinking,
             cache_control=cache_control,
+            prompt_cache_key=prompt_cache_key,
             context_management=context_management,
             betas=betas,
             output_format=output_format,
         )
+        self._validate_prompt_cache_key(prompt_cache_key)
         result = await self._amessages(params, **kwargs)
 
         # The Anthropic provider already returns a ParsedMessage via native messages.parse (typed

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -50,6 +50,7 @@ def completion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
+    prompt_cache_key: str | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
@@ -85,6 +86,7 @@ def completion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
+        prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -127,6 +129,7 @@ def completion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        prompt_cache_key=prompt_cache_key,
         **kwargs,
     )
 
@@ -159,6 +162,7 @@ async def acompletion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
+    prompt_cache_key: str | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
@@ -194,6 +198,7 @@ async def acompletion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
+        prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -236,6 +241,7 @@ async def acompletion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        prompt_cache_key=prompt_cache_key,
         **kwargs,
     )
 
@@ -555,6 +561,7 @@ def messages(
     metadata: dict[str, Any] | None = None,
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
+    prompt_cache_key: str | None = None,
     context_management: dict[str, Any] | None = None,
     betas: list[str] | None = None,
     output_format: type | dict[str, Any] | None = None,
@@ -582,6 +589,7 @@ def messages(
         metadata: Request metadata.
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
+        prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         context_management: Anthropic context management configuration. The `compact_20260112`
             strategy requires a supported model. Its `input_tokens` trigger value must be at
             least 50,000 when provided; see [Anthropic's compaction documentation](https://platform.claude.com/docs/en/build-with-claude/compaction).
@@ -623,6 +631,7 @@ def messages(
         metadata=metadata,
         thinking=thinking,
         cache_control=cache_control,
+        prompt_cache_key=prompt_cache_key,
         context_management=context_management,
         betas=betas,
         output_format=output_format,
@@ -647,6 +656,7 @@ async def amessages(
     metadata: dict[str, Any] | None = None,
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
+    prompt_cache_key: str | None = None,
     context_management: dict[str, Any] | None = None,
     betas: list[str] | None = None,
     output_format: type | dict[str, Any] | None = None,
@@ -674,6 +684,7 @@ async def amessages(
         metadata: Request metadata.
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
+        prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         context_management: Anthropic context management configuration. The `compact_20260112`
             strategy requires a supported model. Its `input_tokens` trigger value must be at
             least 50,000 when provided; see [Anthropic's compaction documentation](https://platform.claude.com/docs/en/build-with-claude/compaction).
@@ -715,6 +726,7 @@ async def amessages(
         metadata=metadata,
         thinking=thinking,
         cache_control=cache_control,
+        prompt_cache_key=prompt_cache_key,
         context_management=context_management,
         betas=betas,
         output_format=output_format,

--- a/src/any_llm/providers/openai/custom.py
+++ b/src/any_llm/providers/openai/custom.py
@@ -36,6 +36,7 @@ class OpenAICompatibleProvider(BaseOpenAIProvider):
     PROVIDER_NAME = "openai_compatible"
     PROVIDER_DOCUMENTATION_URL = "https://platform.openai.com/docs/api-reference"
     ENV_API_KEY_NAME = "OPENAI_COMPATIBLE_API_KEY"
+    PROMPT_CACHE_KEY_SUPPORT = "passthrough"
 
     def __init__(self, api_base: str, api_key: str | None = None, **kwargs: Any) -> None:
         if not api_base:

--- a/src/any_llm/providers/openai/openai.py
+++ b/src/any_llm/providers/openai/openai.py
@@ -8,6 +8,7 @@ class OpenaiProvider(BaseOpenAIProvider):
     ENV_API_BASE_NAME = "OPENAI_BASE_URL"
     PROVIDER_NAME = "openai"
     PROVIDER_DOCUMENTATION_URL = "https://platform.openai.com/docs/api-reference"
+    PROMPT_CACHE_KEY_SUPPORT = "supported"
     SUPPORTS_RESPONSES = True
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = True

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -159,6 +159,7 @@ class OtariProvider(BaseOpenAIProvider):
     PROVIDER_NAME = "otari"
     PROVIDER_DOCUMENTATION_URL = "https://mozilla-ai.github.io/otari/"
     MISSING_PACKAGES_ERROR = _MISSING_PACKAGES_ERROR
+    PROMPT_CACHE_KEY_SUPPORT = "passthrough"
 
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -232,3 +232,6 @@ class CompletionParams(BaseModel):
 
     reasoning_effort: ReasoningEffort | None = "auto"
     """Reasoning effort level for models that support it. "auto" will map to each provider's default."""
+
+    prompt_cache_key: str | None = None
+    """A key to use when reading from or writing to a provider's prompt cache."""

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -212,6 +212,9 @@ class MessagesParams(BaseModel):
     cache_control: dict[str, Any] | None = None
     """Cache control configuration for prompt caching"""
 
+    prompt_cache_key: str | None = None
+    """A key to use when reading from or writing to a provider's prompt cache."""
+
     context_management: dict[str, Any] | None = None
     """Anthropic context management configuration"""
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -73,6 +73,8 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
         "max_tokens": params.max_tokens,
     }
 
+    if params.prompt_cache_key is not None:
+        result["prompt_cache_key"] = params.prompt_cache_key
     if params.temperature is not None:
         result["temperature"] = params.temperature
     if params.top_p is not None:

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -13,6 +13,7 @@ from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usa
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage
 from pydantic import BaseModel
 
+from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.anthropic.anthropic import AnthropicProvider
 from any_llm.providers.anthropic.base import BaseAnthropicProvider, _messages_betas, _pop_anthropic_beta_header
 from any_llm.types.messages import (
@@ -255,6 +256,53 @@ async def test_amessages_non_streaming() -> None:
     call_kwargs = mock_client.messages.create.call_args.kwargs
     assert call_kwargs["model"] == "claude-3-5-sonnet"
     assert call_kwargs["max_tokens"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_amessages_rejects_prompt_cache_key_before_client_call() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = AnthropicProvider(api_key="test-key", http_client=http_client)
+    try:
+        with pytest.raises(UnsupportedParameterError, match="prompt_cache_key"):
+            await provider.amessages(
+                model="claude-opus-5",
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=1024,
+                prompt_cache_key="tenant-1",
+            )
+    finally:
+        await http_client.aclose()
+
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_acompletion_rejects_prompt_cache_key_before_client_call() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = AnthropicProvider(api_key="test-key", http_client=http_client)
+    try:
+        with pytest.raises(UnsupportedParameterError, match="prompt_cache_key"):
+            await provider.acompletion(
+                model="claude-opus-5",
+                messages=[{"role": "user", "content": "Hello"}],
+                prompt_cache_key="tenant-1",
+            )
+    finally:
+        await http_client.aclose()
+
+    assert requests == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_openai_base_provider.py
+++ b/tests/unit/providers/test_openai_base_provider.py
@@ -1,17 +1,65 @@
 import dataclasses
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from openai.types.responses import ResponseCompactionItem, ResponseOutputMessage, ResponseOutputText
 from openresponses_types import CompactionBody, ResponseResource
 from pydantic import BaseModel
 
 from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.providers.openai.openai import OpenaiProvider
 from any_llm.types.completion import CompletionParams
 from any_llm.types.model import Model
 from any_llm.types.responses import ParsedResponse, Response
 from any_llm.utils.structured_output import parse_responses_output
+
+
+def test_prompt_cache_key_capability_is_opt_in() -> None:
+    assert BaseOpenAIProvider.PROMPT_CACHE_KEY_SUPPORT == "unsupported"
+    assert OpenaiProvider.PROMPT_CACHE_KEY_SUPPORT == "supported"
+
+
+@pytest.mark.asyncio
+async def test_openai_messages_bridge_sends_typed_prompt_cache_key() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-5.6",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "ok", "refusal": None},
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = OpenaiProvider(api_key="test-key", http_client=http_client)
+    try:
+        await provider.amessages(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            prompt_cache_key="tenant-1",
+        )
+    finally:
+        await http_client.aclose()
+
+    assert len(requests) == 1
+    assert json.loads(requests[0].content)["prompt_cache_key"] == "tenant-1"
 
 
 class _City(BaseModel):

--- a/tests/unit/providers/test_openai_compatible_provider.py
+++ b/tests/unit/providers/test_openai_compatible_provider.py
@@ -67,6 +67,7 @@ def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPa
 
 def test_capability_flags_follow_openai_compatible_defaults() -> None:
     provider = AnyLLM.create_openai_compatible(name="mygateway", api_base="https://mygateway.example/v1")
+    assert provider.PROMPT_CACHE_KEY_SUPPORT == "passthrough"
     assert provider.SUPPORTS_COMPLETION
     assert provider.SUPPORTS_COMPLETION_STREAMING
     assert provider.SUPPORTS_LIST_MODELS

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -42,6 +42,10 @@ def _build_provider(mocked_client: MagicMock) -> OtariProvider:
         return OtariProvider(api_base="https://otari.example.com")
 
 
+def test_otari_passes_prompt_cache_key_to_the_resolved_provider() -> None:
+    assert OtariProvider.PROMPT_CACHE_KEY_SUPPORT == "passthrough"
+
+
 def _mock_otari_client() -> MagicMock:
     client = MagicMock()
     client.platform_mode = False
@@ -603,12 +607,14 @@ async def test_otari_completion_sends_max_tokens_not_max_completion_tokens() -> 
         model_id="gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=42,
+        prompt_cache_key="tenant-1",
     )
 
     await provider._acompletion(params)
 
     call_kwargs = mocked_client.completion.call_args.kwargs
     assert call_kwargs["max_tokens"] == 42
+    assert call_kwargs["prompt_cache_key"] == "tenant-1"
     assert "max_completion_tokens" not in call_kwargs
 
 
@@ -781,6 +787,7 @@ async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic
         max_tokens=100,
         system=[{"type": "text", "text": "You are helpful.", "cache_control": {"type": "ephemeral"}}],
         thinking={"type": "enabled", "budget_tokens": 1024},
+        prompt_cache_key="tenant-1",
     )
 
     result = await provider._amessages(params, metadata={"user_id": "u1"})
@@ -797,6 +804,7 @@ async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic
     # cache_control on the system block and thinking config survive the pass-through.
     assert call_kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
     assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+    assert call_kwargs["prompt_cache_key"] == "tenant-1"
     # Extra kwargs are forwarded; stream is not set for non-streaming calls.
     assert call_kwargs["metadata"] == {"user_id": "u1"}
     assert "stream" not in call_kwargs

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -9,7 +9,6 @@ from any_llm import AnyLLM
 from any_llm.api import acompletion, aresponses, completion, responses
 from any_llm.constants import LLMProvider
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.providers.bedrock.bedrock import BedrockProvider
 from any_llm.types.completion import CompletionParams
 
 _PYTHON_314_INCOMPATIBLE_PROVIDERS = {"voyage", "watsonx"}
@@ -29,9 +28,22 @@ def test_completion_params_exposes_prompt_cache_key() -> None:
     assert "prompt_cache_key" in signature(AnyLLM.completion).parameters
     assert "prompt_cache_key" in signature(AnyLLM.acompletion).parameters
 
+    mock_provider = Mock()
+    with patch("any_llm.any_llm.AnyLLM.create", return_value=mock_provider):
+        completion(
+            model="openai:gpt-5.6",
+            messages=[{"role": "user", "content": "Hello"}],
+            prompt_cache_key="tenant-1",
+        )
+
+    assert mock_provider.completion.call_args.kwargs["prompt_cache_key"] == "tenant-1"
+
 
 @pytest.mark.asyncio
 async def test_acompletion_rejects_prompt_cache_key_for_unsupported_provider() -> None:
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
     client = Mock()
     provider = BedrockProvider(client=client)
 

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -1,14 +1,48 @@
 import sys
+from inspect import signature
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from any_llm import AnyLLM
-from any_llm.api import acompletion, aresponses, responses
+from any_llm.api import acompletion, aresponses, completion, responses
 from any_llm.constants import LLMProvider
+from any_llm.exceptions import UnsupportedParameterError
+from any_llm.providers.bedrock.bedrock import BedrockProvider
+from any_llm.types.completion import CompletionParams
 
 _PYTHON_314_INCOMPATIBLE_PROVIDERS = {"voyage", "watsonx"}
+
+
+def test_completion_params_exposes_prompt_cache_key() -> None:
+    params = CompletionParams(
+        model_id="gpt-5.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        prompt_cache_key="tenant-1",
+    )
+
+    assert params.prompt_cache_key == "tenant-1"
+    assert "prompt_cache_key" in CompletionParams.model_json_schema()["properties"]
+    assert "prompt_cache_key" in signature(completion).parameters
+    assert "prompt_cache_key" in signature(acompletion).parameters
+    assert "prompt_cache_key" in signature(AnyLLM.completion).parameters
+    assert "prompt_cache_key" in signature(AnyLLM.acompletion).parameters
+
+
+@pytest.mark.asyncio
+async def test_acompletion_rejects_prompt_cache_key_for_unsupported_provider() -> None:
+    client = Mock()
+    provider = BedrockProvider(client=client)
+
+    with pytest.raises(UnsupportedParameterError, match="prompt_cache_key"):
+        await provider.acompletion(
+            model="anthropic.claude-sonnet",
+            messages=[{"role": "user", "content": "Hello"}],
+            prompt_cache_key="tenant-1",
+        )
+
+    client.converse.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -28,6 +62,7 @@ async def test_acompletion_parameter_capture() -> None:
             max_tokens=100,
             stream=False,
             reasoning_effort="high",
+            prompt_cache_key="tenant-1",
             api_key="sk-test-key-123",
             api_base="https://custom-openai.example.com/v1",
             custom_param="custom_value",
@@ -48,6 +83,7 @@ async def test_acompletion_parameter_capture() -> None:
         assert call_args.kwargs["max_tokens"] == 100
         assert call_args.kwargs["stream"] is False
         assert call_args.kwargs["reasoning_effort"] == "high"
+        assert call_args.kwargs["prompt_cache_key"] == "tenant-1"
         assert call_args.kwargs["custom_param"] == "custom_value"
 
 

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -22,6 +22,8 @@ from pydantic import BaseModel
 
 from any_llm.any_llm import AnyLLM
 from any_llm.api import amessages, messages
+from any_llm.exceptions import UnsupportedParameterError
+from any_llm.providers.bedrock.bedrock import BedrockProvider
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -54,6 +56,34 @@ def test_stop_reason_aliases_anthropic_beta_type() -> None:
 
 def test_content_block_alias_matches_message_content_block() -> None:
     assert ContentBlock is MessageContentBlock
+
+
+def test_messages_params_exposes_prompt_cache_key_in_schema() -> None:
+    params = MessagesParams(
+        model="gpt-5.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        prompt_cache_key="tenant-1",
+    )
+
+    assert params.prompt_cache_key == "tenant-1"
+    assert "prompt_cache_key" in MessagesParams.model_json_schema()["properties"]
+
+
+@pytest.mark.asyncio
+async def test_amessages_rejects_prompt_cache_key_for_unsupported_provider() -> None:
+    client = Mock()
+    provider = BedrockProvider(client=client)
+
+    with pytest.raises(UnsupportedParameterError, match="prompt_cache_key"):
+        await provider.amessages(
+            model="anthropic.claude-sonnet",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            prompt_cache_key="tenant-1",
+        )
+
+    client.converse.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -467,6 +497,7 @@ async def test_amessages_parameter_capture() -> None:
             tool_choice={"type": "auto"},
             metadata={"user_id": "u1"},
             thinking={"type": "enabled", "budget_tokens": 4096},
+            prompt_cache_key="tenant-1",
             api_key="sk-test",
             api_base="https://custom.example.com",
         )
@@ -493,12 +524,15 @@ async def test_amessages_parameter_capture() -> None:
         assert call_args.kwargs["tool_choice"] == {"type": "auto"}
         assert call_args.kwargs["metadata"] == {"user_id": "u1"}
         assert call_args.kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+        assert call_args.kwargs["prompt_cache_key"] == "tenant-1"
 
 
 @pytest.mark.asyncio
-async def test_amessages_forwards_context_management_and_betas() -> None:
+async def test_amessages_forwards_typed_messages_params() -> None:
+    assert "prompt_cache_key" in signature(amessages).parameters
     assert "context_management" in signature(amessages).parameters
     assert "betas" in signature(amessages).parameters
+    assert "prompt_cache_key" in signature(AnyLLM.amessages).parameters
     assert "context_management" in signature(AnyLLM.amessages).parameters
     assert "betas" in signature(AnyLLM.amessages).parameters
 
@@ -513,11 +547,13 @@ async def test_amessages_forwards_context_management_and_betas() -> None:
             provider="anthropic",
             messages=[{"role": "user", "content": "Hello"}],
             max_tokens=1024,
+            prompt_cache_key="tenant-1",
             context_management=context_management,
             betas=betas,
         )
 
     call_kwargs = mock_provider.amessages.await_args.kwargs
+    assert call_kwargs["prompt_cache_key"] == "tenant-1"
     assert call_kwargs["context_management"] == context_management
     assert call_kwargs["betas"] == betas
 
@@ -557,9 +593,11 @@ def test_messages_returns_parsed_beta_message_without_treating_it_as_a_stream() 
     assert parsed_message.parsed_output == Answer(value="ok")
 
 
-def test_messages_forwards_context_management_and_betas() -> None:
+def test_messages_forwards_typed_messages_params() -> None:
+    assert "prompt_cache_key" in signature(messages).parameters
     assert "context_management" in signature(messages).parameters
     assert "betas" in signature(messages).parameters
+    assert "prompt_cache_key" in signature(AnyLLM.messages).parameters
     assert "context_management" in signature(AnyLLM.messages).parameters
     assert "betas" in signature(AnyLLM.messages).parameters
 
@@ -574,11 +612,13 @@ def test_messages_forwards_context_management_and_betas() -> None:
             provider="anthropic",
             messages=[{"role": "user", "content": "Hello"}],
             max_tokens=1024,
+            prompt_cache_key="tenant-1",
             context_management=context_management,
             betas=betas,
         )
 
     call_kwargs = mock_provider.messages.call_args.kwargs
+    assert call_kwargs["prompt_cache_key"] == "tenant-1"
     assert call_kwargs["context_management"] == context_management
     assert call_kwargs["betas"] == betas
 
@@ -656,6 +696,7 @@ async def test_default_amessages_non_streaming() -> None:
         model="gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=100,
+        prompt_cache_key="tenant-1",
     )
     result = await AnyLLM._amessages(mock_provider, params)
     assert isinstance(result, MessageResponse)
@@ -664,6 +705,9 @@ async def test_default_amessages_non_streaming() -> None:
     assert result.content[0].text == "Hi!"
     assert result.stop_reason == "end_turn"
     assert result.usage.input_tokens == 10
+    completion_params = mock_provider._acompletion.await_args.args[0]
+    assert completion_params.prompt_cache_key == "tenant-1"
+    assert "prompt_cache_key" not in mock_provider._acompletion.await_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -23,7 +23,6 @@ from pydantic import BaseModel
 from any_llm.any_llm import AnyLLM
 from any_llm.api import amessages, messages
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.providers.bedrock.bedrock import BedrockProvider
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -72,6 +71,9 @@ def test_messages_params_exposes_prompt_cache_key_in_schema() -> None:
 
 @pytest.mark.asyncio
 async def test_amessages_rejects_prompt_cache_key_for_unsupported_provider() -> None:
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
     client = Mock()
     provider = BedrockProvider(client=client)
 


### PR DESCRIPTION
## Description

`prompt_cache_key` was available only through untyped provider kwargs on Chat Completions and Messages, so schema-derived gateways (Otari) could not expose it safely. This adds it to both typed parameter models and validates provider capability before dispatch.

OpenAI accepts the field, Otari and custom OpenAI-compatible endpoints pass it to the service that resolves support, and known unsupported providers raise `UnsupportedParameterError` before an SDK or HTTP call.

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #1243

Follow-up: mozilla-ai/otari#514

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol
- AI Developer Tool used: Pi
- Any other info you'd like to share: Implemented with test-driven development and reviewed interactively with the contributor.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional prompt cache key support to completion and Messages APIs.
  * Synchronous and asynchronous requests now forward cache keys where supported.
  * Unsupported providers now return a clear validation error.

* **Tests**
  * Expanded coverage for supported, passthrough, and unsupported provider scenarios.
  * Verified cache keys are correctly forwarded across completion and Messages requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->