### PR TITLE
fix(bedrock): forward api_key as bearer token, share session with control/S3 clients, accept timeout

### DIFF
--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -5,6 +5,7 @@ import asyncio
 import functools
 import json
 import os
+import threading
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
@@ -59,6 +60,11 @@ class BedrockProvider(AnyLLM):
     SUPPORTS_RERANK = False
 
     MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
+
+    # Bounds the per-timeout client cache in `_client_for_timeout`, so callers deriving
+    # `timeout` from a remaining deadline (a different value on every call) can't grow it
+    # (and its underlying connection pools) without limit.
+    _MAX_TIMEOUT_CLIENTS = 8
 
     def __init__(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self._custom_client: Any = kwargs.pop("client", None)
@@ -121,6 +127,7 @@ class BedrockProvider(AnyLLM):
         self.kwargs = kwargs
         self._api_key = api_key
         self._timeout_clients: dict[float, Any] = {}
+        self._timeout_clients_lock = threading.Lock()
         if self._custom_client is not None:
             self.client = self._custom_client
             self._boto_session = None
@@ -244,6 +251,11 @@ class BedrockProvider(AnyLLM):
         client-construction time via ``botocore.config.Config``. When a custom client was
         supplied, any-llm doesn't own its construction, so `timeout` is dropped with a warning
         instead of being silently ignored or crashing.
+
+        ``_completion`` runs on executor threads (via ``_acompletion``), so the cache miss path
+        is locked: concurrent calls with the same not-yet-cached timeout must not each build and
+        leak their own client. The cache is also bounded, since a caller deriving `timeout` from
+        a remaining deadline would otherwise produce a new distinct value (and client) per call.
         """
         if timeout is None or self._boto_session is None:
             if timeout is not None:
@@ -253,16 +265,19 @@ class BedrockProvider(AnyLLM):
                 )
             return self.client
 
-        cached = self._timeout_clients.get(timeout)
-        if cached is None:
-            timeout_config = Config(connect_timeout=timeout, read_timeout=timeout)
-            client_kwargs = self._bedrock_client_kwargs(self.kwargs)
-            client_kwargs["config"] = (
-                client_kwargs["config"].merge(timeout_config) if "config" in client_kwargs else timeout_config
-            )
-            cached = self._boto_session.client("bedrock-runtime", endpoint_url=self.api_base, **client_kwargs)
-            self._timeout_clients[timeout] = cached
-        return cached
+        with self._timeout_clients_lock:
+            cached = self._timeout_clients.get(timeout)
+            if cached is None:
+                timeout_config = Config(connect_timeout=timeout, read_timeout=timeout)
+                client_kwargs = self._bedrock_client_kwargs(self.kwargs)
+                client_kwargs["config"] = (
+                    client_kwargs["config"].merge(timeout_config) if "config" in client_kwargs else timeout_config
+                )
+                cached = self._boto_session.client("bedrock-runtime", endpoint_url=self.api_base, **client_kwargs)
+                if len(self._timeout_clients) >= self._MAX_TIMEOUT_CLIENTS:
+                    self._timeout_clients.pop(next(iter(self._timeout_clients)))
+                self._timeout_clients[timeout] = cached
+            return cached
 
     @override
     async def _aembedding(
@@ -336,15 +351,26 @@ class BedrockProvider(AnyLLM):
     def _get_s3_client(self) -> Any:
         """Return an ``s3`` client for reading batch output files.
 
-        Built from the same session as the runtime client (S3 doesn't support Bedrock's bearer
-        token auth, so no bearer-specific config is applied here). An explicit ``s3_client=``
-        constructor kwarg always takes precedence.
+        Built from the same session as the runtime client. S3 doesn't support Bedrock's bearer
+        token auth, so any ``signature_version="bearer"`` (forced by us elsewhere, or present in
+        a caller-supplied ``config=``) is stripped before forwarding, otherwise every S3 call
+        would fail to authenticate. An explicit ``s3_client=`` constructor kwarg always takes
+        precedence.
         """
         if self._custom_s3_client is not None:
             return self._custom_s3_client
         if self._boto_session is not None:
-            return self._boto_session.client("s3", **self.kwargs)
+            return self._boto_session.client("s3", **self._non_bearer_client_kwargs(self.kwargs))
         return boto3.client("s3", **self.kwargs)
+
+    @staticmethod
+    def _non_bearer_client_kwargs(extra_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Strip a ``signature_version="bearer"`` from a caller-supplied ``config=``, if present."""
+        call_kwargs = dict(extra_kwargs)
+        config = call_kwargs.get("config")
+        if config is not None and getattr(config, "signature_version", None) == "bearer":
+            call_kwargs["config"] = config.merge(Config(signature_version=None))
+        return call_kwargs
 
     @override
     async def _acreate_batch(

--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -18,6 +18,8 @@ from any_llm.types.model import Model
 MISSING_PACKAGES_ERROR = None
 try:
     import boto3
+    from botocore.config import Config
+    from botocore.tokens import ScopedEnvTokenProvider
 
     from .utils import (
         _convert_bedrock_batch_output_to_result,
@@ -60,6 +62,8 @@ class BedrockProvider(AnyLLM):
 
     def __init__(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self._custom_client: Any = kwargs.pop("client", None)
+        self._custom_control_client: Any = kwargs.pop("control_client", None)
+        self._custom_s3_client: Any = kwargs.pop("s3_client", None)
         super().__init__(api_key=api_key, api_base=api_base, **kwargs)
 
     @staticmethod
@@ -115,10 +119,51 @@ class BedrockProvider(AnyLLM):
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self.api_base = api_base
         self.kwargs = kwargs
+        self._api_key = api_key
+        self._timeout_clients: dict[float, Any] = {}
         if self._custom_client is not None:
             self.client = self._custom_client
-        else:
-            self.client = boto3.client("bedrock-runtime", endpoint_url=api_base, **kwargs)
+            self._boto_session = None
+            return
+        self._boto_session = self._build_boto_session(api_key)
+        self.client = self._boto_session.client(
+            "bedrock-runtime", endpoint_url=api_base, **self._bedrock_client_kwargs(kwargs)
+        )
+
+    def _build_boto_session(self, api_key: str | None) -> Any:
+        """Build a ``boto3.Session`` dedicated to this provider instance.
+
+        When ``api_key`` (an AWS Bedrock bearer token) is provided, a token provider scoped to
+        this session's own in-memory environ mapping is registered on the underlying botocore
+        session. This resolves the token per instance instead of requiring the process-wide
+        ``AWS_BEARER_TOKEN_BEDROCK`` env var, which is unsafe to mutate under concurrent,
+        multi-tenant use.
+        """
+        session = boto3.Session()  # type: ignore[attr-defined]
+        if api_key:
+            session._session.register_component(
+                "token_provider",
+                ScopedEnvTokenProvider(session._session, environ={self.ENV_API_KEY_NAME: api_key}),
+            )
+        return session
+
+    def _bedrock_client_kwargs(self, extra_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Merge caller-supplied kwargs with a bearer-token-aware ``Config``.
+
+        Forces ``signature_version="bearer"`` when an api_key/bearer token was provided, since
+        botocore's own auto-detection of bearer auth only looks at the real process environment,
+        not the per-instance token provider set up in ``_build_boto_session``. Does not mutate
+        ``extra_kwargs`` (typically ``self.kwargs``), so it can be reused for the control-plane
+        client too.
+        """
+        call_kwargs = dict(extra_kwargs)
+        user_config = call_kwargs.pop("config", None)
+        merged_config = Config(signature_version="bearer") if self._api_key else None
+        if user_config is not None:
+            merged_config = user_config.merge(merged_config) if merged_config is not None else user_config
+        if merged_config is not None:
+            call_kwargs["config"] = merged_config
+        return call_kwargs
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
@@ -167,10 +212,15 @@ class BedrockProvider(AnyLLM):
         params: CompletionParams,
         **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
+        # boto3's Converse API has no `timeout` parameter; it must be pulled out here so it
+        # never reaches `converse`/`converse_stream`, and applied via a client whose connection
+        # is configured with that timeout instead (see `_client_for_timeout`).
+        timeout = kwargs.pop("timeout", None)
         completion_kwargs = self._convert_completion_params(params, **kwargs)
+        client = self._client_for_timeout(timeout)
 
         if params.stream:
-            response_stream = self.client.converse_stream(
+            response_stream = client.converse_stream(
                 **completion_kwargs,
             )
             stream_generator = response_stream["stream"]
@@ -183,9 +233,36 @@ class BedrockProvider(AnyLLM):
                         yield chunk
 
             return _stream_with_state()
-        response = self.client.converse(**completion_kwargs)
+        response = client.converse(**completion_kwargs)
 
         return self._convert_completion_response(response)
+
+    def _client_for_timeout(self, timeout: float | None) -> Any:
+        """Return a boto3 client configured for ``timeout``, building/caching one if needed.
+
+        boto3 has no per-request timeout; connect/read timeouts are only configurable at
+        client-construction time via ``botocore.config.Config``. When a custom client was
+        supplied, any-llm doesn't own its construction, so `timeout` is dropped with a warning
+        instead of being silently ignored or crashing.
+        """
+        if timeout is None or self._boto_session is None:
+            if timeout is not None:
+                logger.warning(
+                    "Bedrock does not support a per-request 'timeout' when a custom client is provided; "
+                    "ignoring it. Configure timeouts via botocore.config.Config when constructing your client."
+                )
+            return self.client
+
+        cached = self._timeout_clients.get(timeout)
+        if cached is None:
+            timeout_config = Config(connect_timeout=timeout, read_timeout=timeout)
+            client_kwargs = self._bedrock_client_kwargs(self.kwargs)
+            client_kwargs["config"] = (
+                client_kwargs["config"].merge(timeout_config) if "config" in client_kwargs else timeout_config
+            )
+            cached = self._boto_session.client("bedrock-runtime", endpoint_url=self.api_base, **client_kwargs)
+            self._timeout_clients[timeout] = cached
+        return cached
 
     @override
     async def _aembedding(
@@ -243,11 +320,30 @@ class BedrockProvider(AnyLLM):
         return self._convert_list_models_response(response)
 
     def _get_bedrock_control_client(self) -> Any:
-        """Return a ``bedrock`` control-plane client for batch and model management operations."""
+        """Return a ``bedrock`` control-plane client for batch and model management operations.
+
+        Built from the same session (and, when applicable, the same bearer-token credentials)
+        as the runtime client, so overrides applied at construction time aren't silently
+        bypassed for model listing and batch operations. An explicit ``control_client=``
+        constructor kwarg always takes precedence.
+        """
+        if self._custom_control_client is not None:
+            return self._custom_control_client
+        if self._boto_session is not None:
+            return self._boto_session.client("bedrock", **self._bedrock_client_kwargs(self.kwargs))
         return boto3.client("bedrock", **self.kwargs)
 
     def _get_s3_client(self) -> Any:
-        """Return an ``s3`` client for reading batch output files."""
+        """Return an ``s3`` client for reading batch output files.
+
+        Built from the same session as the runtime client (S3 doesn't support Bedrock's bearer
+        token auth, so no bearer-specific config is applied here). An explicit ``s3_client=``
+        constructor kwarg always takes precedence.
+        """
+        if self._custom_s3_client is not None:
+            return self._custom_s3_client
+        if self._boto_session is not None:
+            return self._boto_session.client("s3", **self.kwargs)
         return boto3.client("s3", **self.kwargs)
 
     @override

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -5,7 +5,9 @@ from contextlib import contextmanager
 from typing import Any, get_args
 from unittest.mock import Mock, patch
 
+import botocore.session
 import pytest
+from botocore.tokens import ScopedEnvTokenProvider
 
 from any_llm.exceptions import InvalidRequestError
 from any_llm.providers.bedrock import BedrockProvider
@@ -85,8 +87,34 @@ def test_api_key_registers_scoped_bearer_token_provider() -> None:
     assert token_provider.environ == {"AWS_BEARER_TOKEN_BEDROCK": "my-bearer-token"}
 
 
-def test_no_api_key_skips_bearer_token_setup() -> None:
+def test_scoped_token_provider_resolves_bearer_token_via_real_botocore_session() -> None:
+    """Test the registered token provider against the real botocore session contract.
+
+    Goes one level deeper than asserting `register_component` was called with the right
+    arguments: registers the provider on a real `botocore.session.Session` (no boto3/botocore
+    mocking at all) and confirms botocore's own `get_auth_token(signing_name="bedrock")` actually
+    resolves our token through it, exactly as it would when a real client is constructed.
+    """
+    real_session = botocore.session.Session()  # type: ignore[no-untyped-call]
+    real_session.register_component(  # type: ignore[no-untyped-call]
+        "token_provider",
+        ScopedEnvTokenProvider(  # type: ignore[no-untyped-call]
+            real_session, environ={"AWS_BEARER_TOKEN_BEDROCK": "my-bearer-token"}
+        ),
+    )
+
+    auth_token = real_session.get_auth_token(signing_name="bedrock")  # type: ignore[no-untyped-call]
+
+    assert auth_token is not None
+    assert auth_token.token == "my-bearer-token"  # noqa: S105
+
+
+def test_no_api_key_skips_bearer_token_setup(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that no token provider is registered and no bearer config is forced without api_key."""
+    # Guard against a real AWS_BEARER_TOKEN_BEDROCK in the ambient environment, which would make
+    # the provider resolve a bearer token anyway and fail this test for unrelated reasons.
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
     with mock_aws_provider() as mock_client_call:
         provider = BedrockProvider()
         provider._completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
@@ -120,8 +148,10 @@ def test_completion_with_timeout_builds_distinct_client_with_timeout_config() ->
         assert "timeout" not in converse_call_kwargs
 
 
-def test_completion_with_timeout_and_no_api_key_uses_plain_timeout_config() -> None:
+def test_completion_with_timeout_and_no_api_key_uses_plain_timeout_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the timeout-only branch (no bearer config to merge into) still works."""
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
     with mock_aws_provider() as mock_client_call:
         provider = BedrockProvider()
         provider._completion(
@@ -159,6 +189,36 @@ def test_completion_timeout_client_is_cached_per_timeout_value() -> None:
         # base client + one timeout-scoped client, reused across both calls
         assert mock_client_call.call_count == 2
         assert len(provider._timeout_clients) == 1
+
+
+def test_timeout_client_cache_is_bounded() -> None:
+    """Test that the timeout-client cache evicts old entries instead of growing without limit."""
+    with mock_aws_provider():
+        provider = BedrockProvider(api_key="test_key")
+
+        for timeout in range(provider._MAX_TIMEOUT_CLIENTS + 5):
+            provider._client_for_timeout(float(timeout))
+
+        assert len(provider._timeout_clients) == provider._MAX_TIMEOUT_CLIENTS
+
+
+def test_timeout_client_creation_is_thread_safe() -> None:
+    """Test that concurrent calls with the same uncached timeout build exactly one client.
+
+    `_completion` runs on executor threads via `_acompletion`; without locking the cache-miss
+    path, concurrent callers could each build (and leak) their own client for the same timeout.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    with mock_aws_provider() as mock_client_call:
+        provider = BedrockProvider(api_key="test_key")
+
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            results = list(executor.map(lambda _: provider._client_for_timeout(5.0), range(16)))
+
+        assert len({id(client) for client in results}) == 1
+        # base client (built at construction) + exactly one timeout-scoped client
+        assert mock_client_call.call_count == 2
 
 
 def test_completion_timeout_with_custom_client_logs_warning_and_is_ignored(
@@ -268,21 +328,27 @@ def test_completion_streaming_uses_converse_stream_on_resolved_client() -> None:
     """Test that streaming completions call converse_stream on the client resolved for the call.
 
     Guards against a regression where the timeout-aware client resolution (`_client_for_timeout`)
-    is only wired into the non-streaming `converse` call and not `converse_stream`.
+    is only wired into the non-streaming `converse` call and not `converse_stream`. Uses distinct
+    base/timeout-scoped client mocks (rather than relying on `Mock().return_value` being the same
+    object for every construction call) so the assertion would actually fail if `converse_stream`
+    were called on the wrong client.
     """
     with mock_aws_provider() as mock_client_call:
-        mock_client_call.return_value.converse_stream.return_value = {
-            "stream": [{"messageStart": {"role": "assistant"}}]
-        }
+        base_client = Mock()
+        timeout_client = Mock()
+        timeout_client.converse_stream.return_value = {"stream": [{"messageStart": {"role": "assistant"}}]}
+        mock_client_call.side_effect = [base_client, timeout_client]
 
         provider = BedrockProvider(api_key="test_key")
         chunks = list(
             provider._completion(
                 CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}], stream=True),
+                timeout=5,
             )
         )
 
-        mock_client_call.return_value.converse_stream.assert_called_once()
+        timeout_client.converse_stream.assert_called_once()
+        base_client.converse_stream.assert_not_called()
         assert len(chunks) == 1
 
 

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 from contextlib import contextmanager
 from typing import Any, get_args
 from unittest.mock import Mock, patch
@@ -21,36 +22,167 @@ from any_llm.types.completion import CompletionParams, ReasoningEffort
 
 @contextmanager
 def mock_aws_provider():  # type: ignore[no-untyped-def]
+    """Mock boto3.Session so the provider builds its runtime client from a mocked session.
+
+    Yields the mocked ``session.client`` callable (the equivalent of the old bare
+    ``boto3.client`` mock), since BedrockProvider now builds a dedicated ``boto3.Session``
+    per instance instead of calling the module-level ``boto3.client`` directly.
+    """
     with (
         patch("any_llm.providers.bedrock.bedrock._convert_response"),
-        patch("boto3.Session"),
-        patch("boto3.client") as mock_boto3_client,
+        patch("boto3.Session") as mock_session_cls,
     ):
         mock_client = Mock()
-        mock_boto3_client.return_value = mock_client
+        mock_session_cls.return_value.client.return_value = mock_client
         mock_client.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
-        yield mock_boto3_client
+        yield mock_session_cls.return_value.client
 
 
 def test_boto3_client_created_with_api_base() -> None:
-    """Test that boto3.client is created with api_base as endpoint_url when provided."""
+    """Test that the session's client is created with api_base as endpoint_url when provided."""
     custom_endpoint = "https://custom-bedrock-endpoint.amazonaws.com"
 
-    with mock_aws_provider() as mock_boto3_client:
+    with mock_aws_provider() as mock_client_call:
         provider = BedrockProvider(api_base=custom_endpoint, api_key="test_key")
         provider._completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
 
-        mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=custom_endpoint)
+        mock_client_call.assert_called_once()
+        call_args, call_kwargs = mock_client_call.call_args
+        assert call_args == ("bedrock-runtime",)
+        assert call_kwargs["endpoint_url"] == custom_endpoint
+        # api_key was provided, so the client is configured to sign with the bearer token.
+        assert call_kwargs["config"].signature_version == "bearer"
 
 
 def test_boto3_client_created_without_api_base() -> None:
-    """Test that boto3.client is created with None endpoint_url when api_base is not provided."""
+    """Test that the session's client is created with None endpoint_url when api_base is not provided."""
 
-    with mock_aws_provider() as mock_boto3_client:
+    with mock_aws_provider() as mock_client_call:
         provider = BedrockProvider(api_key="test_key")
         provider._completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
 
-        mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None)
+        mock_client_call.assert_called_once()
+        call_args, call_kwargs = mock_client_call.call_args
+        assert call_args == ("bedrock-runtime",)
+        assert call_kwargs["endpoint_url"] is None
+        assert call_kwargs["config"].signature_version == "bearer"
+
+
+def test_api_key_registers_scoped_bearer_token_provider() -> None:
+    """Test that api_key is forwarded as a bearer token via a per-instance token provider.
+
+    This is what actually makes api_key/AWS_BEARER_TOKEN_BEDROCK usable per-request/per-tenant,
+    instead of requiring a process-wide env var mutation.
+    """
+    with mock_aws_provider():
+        provider = BedrockProvider(api_key="my-bearer-token")
+
+    mock_session = provider._boto_session
+    assert mock_session is not None
+    mock_session._session.register_component.assert_called_once()
+    component_name, token_provider = mock_session._session.register_component.call_args[0]
+    assert component_name == "token_provider"
+    assert token_provider.environ == {"AWS_BEARER_TOKEN_BEDROCK": "my-bearer-token"}
+
+
+def test_no_api_key_skips_bearer_token_setup() -> None:
+    """Test that no token provider is registered and no bearer config is forced without api_key."""
+    with mock_aws_provider() as mock_client_call:
+        provider = BedrockProvider()
+        provider._completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
+
+    assert provider._boto_session is not None
+    provider._boto_session._session.register_component.assert_not_called()
+    assert "config" not in mock_client_call.call_args[1]
+
+
+def test_completion_with_timeout_builds_distinct_client_with_timeout_config() -> None:
+    """Test that a `timeout` kwarg is popped before reaching converse and applied via client config.
+
+    boto3's Converse API has no `timeout` parameter, so it must never be forwarded to it.
+    """
+    with mock_aws_provider() as mock_client_call:
+        provider = BedrockProvider(api_key="test_key")
+        provider._completion(
+            CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=5,
+        )
+
+        # one call to build the base client, one to build the timeout-scoped client
+        assert mock_client_call.call_count == 2
+        timeout_call_kwargs = mock_client_call.call_args_list[1][1]
+        assert timeout_call_kwargs["config"].connect_timeout == 5
+        assert timeout_call_kwargs["config"].read_timeout == 5
+        # bearer auth (from api_key) must still be honored on the timeout-scoped client
+        assert timeout_call_kwargs["config"].signature_version == "bearer"
+
+        converse_call_kwargs = mock_client_call.return_value.converse.call_args[1]
+        assert "timeout" not in converse_call_kwargs
+
+
+def test_completion_with_timeout_and_no_api_key_uses_plain_timeout_config() -> None:
+    """Test the timeout-only branch (no bearer config to merge into) still works."""
+    with mock_aws_provider() as mock_client_call:
+        provider = BedrockProvider()
+        provider._completion(
+            CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=5,
+        )
+
+        timeout_call_kwargs = mock_client_call.call_args_list[1][1]
+        assert timeout_call_kwargs["config"].connect_timeout == 5
+        assert timeout_call_kwargs["config"].signature_version is None
+
+
+def test_user_supplied_config_is_merged_with_bearer_signature_version() -> None:
+    """A caller-supplied `config=` kwarg is preserved and merged with the forced bearer signature_version."""
+    from botocore.config import Config
+
+    user_config = Config(region_name="us-west-2")  # type: ignore[no-untyped-call]
+    with mock_aws_provider() as mock_client_call:
+        BedrockProvider(api_key="test_key", config=user_config)
+
+    call_kwargs = mock_client_call.call_args[1]
+    assert call_kwargs["config"].region_name == "us-west-2"
+    assert call_kwargs["config"].signature_version == "bearer"
+
+
+def test_completion_timeout_client_is_cached_per_timeout_value() -> None:
+    """Test that repeated calls with the same timeout reuse a single cached client."""
+    with mock_aws_provider() as mock_client_call:
+        provider = BedrockProvider(api_key="test_key")
+        params = CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}])
+
+        provider._completion(params, timeout=5)
+        provider._completion(params, timeout=5)
+
+        # base client + one timeout-scoped client, reused across both calls
+        assert mock_client_call.call_count == 2
+        assert len(provider._timeout_clients) == 1
+
+
+def test_completion_timeout_with_custom_client_logs_warning_and_is_ignored(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that `timeout` is dropped with a warning (not a crash) when a custom client is used.
+
+    any-llm doesn't own a custom client's construction, so it can't safely reconfigure its
+    connection timeouts.
+    """
+    custom_client = Mock()
+    custom_client.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
+
+    with patch("any_llm.providers.bedrock.bedrock._convert_response"):
+        provider = BedrockProvider(client=custom_client)
+        with caplog.at_level(logging.WARNING, logger="any_llm"):
+            provider._completion(
+                CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]),
+                timeout=5,
+            )
+
+    custom_client.converse.assert_called_once()
+    assert "timeout" not in custom_client.converse.call_args[1]
+    assert "timeout" in caplog.text.lower()
 
 
 def test_custom_client_used_when_provided() -> None:
@@ -132,6 +264,28 @@ def test_completion_with_kwargs() -> None:
         )
 
 
+def test_completion_streaming_uses_converse_stream_on_resolved_client() -> None:
+    """Test that streaming completions call converse_stream on the client resolved for the call.
+
+    Guards against a regression where the timeout-aware client resolution (`_client_for_timeout`)
+    is only wired into the non-streaming `converse` call and not `converse_stream`.
+    """
+    with mock_aws_provider() as mock_client_call:
+        mock_client_call.return_value.converse_stream.return_value = {
+            "stream": [{"messageStart": {"role": "assistant"}}]
+        }
+
+        provider = BedrockProvider(api_key="test_key")
+        chunks = list(
+            provider._completion(
+                CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}], stream=True),
+            )
+        )
+
+        mock_client_call.return_value.converse_stream.assert_called_once()
+        assert len(chunks) == 1
+
+
 @pytest.mark.parametrize("reasoning_effort", [None, *get_args(ReasoningEffort)])
 def test_completion_with_custom_reasoning_effort(reasoning_effort: ReasoningEffort | None) -> None:
     """Test that reasoning_effort is correctly passed to Bedrock API."""
@@ -164,13 +318,10 @@ def test_completion_with_custom_reasoning_effort(reasoning_effort: ReasoningEffo
 @contextmanager
 def mock_aws_embedding_provider():  # type: ignore[no-untyped-def]
     """Mock AWS provider specifically for embedding tests."""
-    with (
-        patch("boto3.Session"),
-        patch("boto3.client") as mock_boto3_client,
-    ):
+    with patch("boto3.Session") as mock_session_cls:
         mock_client = Mock()
-        mock_boto3_client.return_value = mock_client
-        yield mock_boto3_client, mock_client
+        mock_session_cls.return_value.client.return_value = mock_client
+        yield mock_session_cls.return_value.client, mock_client
 
 
 def test_embedding_single_string() -> None:
@@ -180,13 +331,17 @@ def test_embedding_single_string() -> None:
 
     mock_response_body = {"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}
 
-    with mock_aws_embedding_provider() as (mock_boto3_client, mock_client):
+    with mock_aws_embedding_provider() as (mock_client_call, mock_client):
         mock_client.invoke_model.return_value = {"body": Mock(read=Mock(return_value=json.dumps(mock_response_body)))}
 
         provider = BedrockProvider(api_key="test_key")
         response = provider._embedding(model_id, input_text)
 
-        mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None)
+        mock_client_call.assert_called_once()
+        call_args, call_kwargs = mock_client_call.call_args
+        assert call_args == ("bedrock-runtime",)
+        assert call_kwargs["endpoint_url"] is None
+        assert call_kwargs["config"].signature_version == "bearer"
 
         expected_request_body = {"inputText": input_text}
         mock_client.invoke_model.assert_called_once_with(modelId=model_id, body=json.dumps(expected_request_body))
@@ -210,7 +365,7 @@ def test_embedding_list_of_strings() -> None:
         {"embedding": [0.4, 0.5, 0.6], "inputTextTokenCount": 6},
     ]
 
-    with mock_aws_embedding_provider() as (mock_boto3_client, mock_client):
+    with mock_aws_embedding_provider() as (mock_client_call, mock_client):
         mock_client.invoke_model.side_effect = [
             {"body": Mock(read=Mock(return_value=json.dumps(mock_response_bodies[0])))},
             {"body": Mock(read=Mock(return_value=json.dumps(mock_response_bodies[1])))},
@@ -219,7 +374,11 @@ def test_embedding_list_of_strings() -> None:
         provider = BedrockProvider(api_key="test_key")
         response = provider._embedding(model_id, input_texts)
 
-        mock_boto3_client.assert_called_once_with("bedrock-runtime", endpoint_url=None)
+        mock_client_call.assert_called_once()
+        call_args, call_kwargs = mock_client_call.call_args
+        assert call_args == ("bedrock-runtime",)
+        assert call_kwargs["endpoint_url"] is None
+        assert call_kwargs["config"].signature_version == "bearer"
 
         assert mock_client.invoke_model.call_count == 2
         expected_calls = [({"inputText": "Hello world"}, model_id), ({"inputText": "Goodbye world"}, model_id)]

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, get_args
 from unittest.mock import Mock, patch
@@ -208,8 +209,6 @@ def test_timeout_client_creation_is_thread_safe() -> None:
     `_completion` runs on executor threads via `_acompletion`; without locking the cache-miss
     path, concurrent callers could each build (and leak) their own client for the same timeout.
     """
-    from concurrent.futures import ThreadPoolExecutor
-
     with mock_aws_provider() as mock_client_call:
         provider = BedrockProvider(api_key="test_key")
 

--- a/tests/unit/providers/test_bedrock_batch.py
+++ b/tests/unit/providers/test_bedrock_batch.py
@@ -901,3 +901,30 @@ async def test_s3_client_does_not_force_bearer_auth() -> None:
 
         call_kwargs = mock_session_client.call_args[1]
         assert "config" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_s3_client_strips_caller_supplied_bearer_signature_version() -> None:
+    """A caller-supplied `config=Config(signature_version="bearer")` must not leak into S3.
+
+    self.kwargs (the raw constructor kwargs) is forwarded as-is to the S3 client. If a caller
+    passed their own bearer config (e.g. matching what we force for Bedrock), every S3 call
+    would otherwise fail to authenticate.
+    """
+    pytest.importorskip("boto3")
+    from botocore.config import Config
+
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(
+            api_key="test-token",
+            config=Config(signature_version="bearer"),  # type: ignore[no-untyped-call]
+        )
+
+        mock_session_client = mock_boto3.Session.return_value.client
+        mock_session_client.reset_mock()
+        provider._get_s3_client()
+
+        call_kwargs = mock_session_client.call_args[1]
+        assert call_kwargs["config"].signature_version is None

--- a/tests/unit/providers/test_bedrock_batch.py
+++ b/tests/unit/providers/test_bedrock_batch.py
@@ -815,13 +815,89 @@ async def test_control_client_does_not_use_runtime_endpoint() -> None:
     from any_llm.providers.bedrock.bedrock import BedrockProvider
 
     with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
-        mock_runtime = MagicMock()
-        mock_boto3.client.return_value = mock_runtime
         mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
 
         provider = BedrockProvider(api_base="https://bedrock-runtime.us-east-1.amazonaws.com")
 
-        mock_boto3.client.reset_mock()
+        mock_session_client = mock_boto3.Session.return_value.client
+        mock_session_client.reset_mock()
         provider._get_bedrock_control_client()
 
-        mock_boto3.client.assert_called_once_with("bedrock")
+        mock_session_client.assert_called_once()
+        call_args, call_kwargs = mock_session_client.call_args
+        assert call_args == ("bedrock",)
+        assert "endpoint_url" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_control_and_s3_client_overrides_bypass_shared_session() -> None:
+    """Test that explicit control_client=/s3_client= overrides are used as-is.
+
+    This lets callers who inject a custom runtime `client=` also inject matching
+    control-plane/S3 clients, instead of these being silently unoverridable.
+    """
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    mock_runtime_client = MagicMock()
+    mock_control_client = MagicMock()
+    mock_s3_client = MagicMock()
+
+    provider = BedrockProvider(client=mock_runtime_client, control_client=mock_control_client, s3_client=mock_s3_client)
+
+    assert provider._get_bedrock_control_client() is mock_control_client
+    assert provider._get_s3_client() is mock_s3_client
+
+
+@pytest.mark.asyncio
+async def test_control_and_s3_client_fall_back_to_bare_boto3_with_custom_runtime_client() -> None:
+    """With a custom runtime `client=` and no control/S3 overrides, fall back to a bare boto3 client.
+
+    any-llm doesn't own the custom client's session, so it can't build a matching control-plane
+    or S3 client from it; this preserves the pre-existing behavior for that case.
+    """
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(client=MagicMock(), region_name="us-west-2")
+
+        provider._get_bedrock_control_client()
+        provider._get_s3_client()
+
+        mock_boto3.client.assert_any_call("bedrock", region_name="us-west-2")
+        mock_boto3.client.assert_any_call("s3", region_name="us-west-2")
+
+
+@pytest.mark.asyncio
+async def test_control_client_inherits_bearer_session() -> None:
+    """The control-plane client is built from the same bearer-token-aware session as the runtime client."""
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(api_key="test-token")
+
+        mock_session_client = mock_boto3.Session.return_value.client
+        mock_session_client.reset_mock()
+        provider._get_bedrock_control_client()
+
+        call_kwargs = mock_session_client.call_args[1]
+        assert call_kwargs["config"].signature_version == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_s3_client_does_not_force_bearer_auth() -> None:
+    """S3 doesn't support Bedrock's bearer token auth, so no bearer config is applied to it."""
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(api_key="test-token")
+
+        mock_session_client = mock_boto3.Session.return_value.client
+        mock_session_client.reset_mock()
+        provider._get_s3_client()
+
+        call_kwargs = mock_session_client.call_args[1]
+        assert "config" not in call_kwargs


### PR DESCRIPTION
## Description

Fixes four related gaps in `BedrockProvider` reported in #1240 that make it unusable for multi-tenant backends needing per-request AWS credentials:

1. **`api_key` was validated but never forwarded to boto3.** A caller passing `api_key=<token>` silently authenticated as the process's ambient AWS identity (or failed with `NoCredentialsError`).
2. **No real bearer-token support.** `AWS_BEARER_TOKEN_BEDROCK` was only used as a presence-check; botocore's own auto-detection only reads the real process environment, so per-tenant forwarding wasn't possible without unsafe `os.environ` mutation.
3. **Control-plane/S3 clients bypassed overrides.** `alist_models` and all batch/S3 operations built independent `boto3.client(...)` calls, ignoring any credentials/custom-client override applied to the runtime client.
4. **`timeout` crashed completions.** It was forwarded verbatim into `converse()`/`converse_stream()`, and boto3's Converse API has no such parameter, so it raised `ParamValidationError`.

### Fix

- Each `BedrockProvider` instance now builds its own `boto3.Session`. When `api_key` is provided, a botocore `ScopedEnvTokenProvider` scoped to an **in-memory** environ mapping (not real `os.environ`) is registered on that session, and `Config(signature_version="bearer")` is forced. This makes the AWS Bedrock bearer token resolve correctly per-instance/per-tenant, safely under concurrent use, without any global env mutation. (Verified against the actual botocore signing/token-resolution pipeline, not just the docs.)
- `_get_bedrock_control_client`/`_get_s3_client` now build from that same shared session (inheriting credentials/bearer config where applicable), closing the gap where model listing and batch operations silently ignored the runtime client's credentials. New `control_client=`/`s3_client=` constructor kwargs let callers who inject a custom runtime `client=` also inject matching control-plane/S3 clients.
- `timeout` is popped out before it reaches `converse`/`converse_stream`, and applied via a cached, timeout-scoped client built with `botocore.config.Config(connect_timeout=..., read_timeout=...)` (boto3 has no per-request timeout; it's a client-construction-time setting). With a custom client (whose construction any-llm doesn't own), `timeout` is dropped with a clear warning instead of crashing.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1240

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Investigated the issue end-to-end (including reading the installed botocore source to confirm the exact bearer-token/auth-resolution mechanism) and implemented the fix in a dedicated worktree. Verified with `pytest tests/unit` (full suite, no regressions), targeted coverage on the changed provider file (~87%, remaining gaps are pre-existing/unrelated), and `pre-commit run --all-files` (clean aside from two pre-existing mypy errors for optional SDKs not installed in this environment, confirmed identical on `main`). Not run against a live AWS Bedrock account (no credentials available in this environment) — verification is via mocked boto3/botocore, consistent with the existing test strategy for this provider (there's no dedicated Bedrock integration test in CI either, per `tests/integration/test_batch.py`).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS Bedrock authentication and client configuration.
  * Ensured runtime, control-plane, and storage connections use the correct endpoints and authentication settings.
  * Improved timeout handling, including clearer behaviour when custom clients are provided.
  * Streaming responses now use the resolved Bedrock client consistently.
* **Reliability**
  * Added safe client reuse and bounded caching to improve connection efficiency and consistency.
  * Improved support for custom control-plane and storage clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->