### PR TITLE
fix(minimax): preserve usage-only streaming chunks

### DIFF
--- a/src/any_llm/providers/minimax/minimax.py
+++ b/src/any_llm/providers/minimax/minimax.py
@@ -44,9 +44,10 @@ class MinimaxProvider(XMLReasoningOpenAIProvider):
 
         async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
             async for chunk in response:
-                if isinstance(chunk, OpenAIChatCompletionChunk):
-                    if (chunk.choices and chunk.choices[0].delta) or chunk.usage is not None:
-                        yield self._convert_completion_chunk_response(chunk)
+                if isinstance(chunk, OpenAIChatCompletionChunk) and (
+                    (chunk.choices and chunk.choices[0].delta) or chunk.usage is not None
+                ):
+                    yield self._convert_completion_chunk_response(chunk)
 
         return wrap_chunks_with_xml_reasoning(chunk_iterator())
 

--- a/src/any_llm/providers/minimax/minimax.py
+++ b/src/any_llm/providers/minimax/minimax.py
@@ -44,10 +44,14 @@ class MinimaxProvider(XMLReasoningOpenAIProvider):
 
         async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
             async for chunk in response:
-                if isinstance(chunk, OpenAIChatCompletionChunk) and (
-                    (chunk.choices and chunk.choices[0].delta) or chunk.usage is not None
-                ):
+                if not isinstance(chunk, OpenAIChatCompletionChunk):
+                    continue
+                if chunk.choices and chunk.choices[0].delta:
                     yield self._convert_completion_chunk_response(chunk)
+                elif chunk.usage is not None:
+                    # Minimax can attach usage to a terminal chunk whose choice carries no delta,
+                    # which fails chunk validation. Keep the usage and drop the unusable choices.
+                    yield self._convert_completion_chunk_response(chunk.model_copy(update={"choices": []}))
 
         return wrap_chunks_with_xml_reasoning(chunk_iterator())
 

--- a/src/any_llm/providers/minimax/minimax.py
+++ b/src/any_llm/providers/minimax/minimax.py
@@ -45,7 +45,7 @@ class MinimaxProvider(XMLReasoningOpenAIProvider):
         async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
             async for chunk in response:
                 if isinstance(chunk, OpenAIChatCompletionChunk):
-                    if chunk.choices and chunk.choices[0].delta:
+                    if (chunk.choices and chunk.choices[0].delta) or chunk.usage is not None:
                         yield self._convert_completion_chunk_response(chunk)
 
         return wrap_chunks_with_xml_reasoning(chunk_iterator())

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -1,15 +1,36 @@
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, cast
+
 import pytest
+from openai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk as OpenAIChatCompletionChunk,
+)
+from openai.types.chat.chat_completion_chunk import (
+    Choice as OpenAIChunkChoice,
+)
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDelta as OpenAIChoiceDelta,
+)
+from openai.types.completion_usage import CompletionUsage
 from pydantic import BaseModel
 
 from any_llm import AnyLLM
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.minimax.minimax import MinimaxProvider
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+
+if TYPE_CHECKING:
+    from openai._streaming import AsyncStream
 
 
 @pytest.fixture(autouse=True)
 def _env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test-123")
+
+
+async def _iter_chunks(chunks: list[OpenAIChatCompletionChunk]) -> AsyncIterator[OpenAIChatCompletionChunk]:
+    for chunk in chunks:
+        yield chunk
 
 
 def test_provider_basics() -> None:
@@ -73,3 +94,52 @@ def test_provider_metadata() -> None:
     assert metadata.completion is True
     assert metadata.embedding is False
     assert metadata.image is False
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_usage_only_chunk() -> None:
+    """Keep usage-only tail chunks while filtering unrelated empty chunks."""
+    provider = MinimaxProvider(api_key="sk-test")
+    chunks = [
+        OpenAIChatCompletionChunk(
+            id="minimax-content",
+            choices=[
+                OpenAIChunkChoice(
+                    index=0,
+                    finish_reason=None,
+                    delta=OpenAIChoiceDelta(content="answer"),
+                )
+            ],
+            created=1234567890,
+            model="MiniMax-M3",
+            object="chat.completion.chunk",
+        ),
+        OpenAIChatCompletionChunk(
+            id="minimax-empty",
+            choices=[],
+            created=1234567890,
+            model="MiniMax-M3",
+            object="chat.completion.chunk",
+        ),
+        OpenAIChatCompletionChunk(
+            id="minimax-usage",
+            choices=[],
+            created=1234567890,
+            model="MiniMax-M3",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(prompt_tokens=11, completion_tokens=2, total_tokens=13),
+        ),
+    ]
+    stream = cast("AsyncStream[OpenAIChatCompletionChunk]", _iter_chunks(chunks))
+
+    converted = provider._convert_completion_response_async(stream)
+
+    assert not isinstance(converted, ChatCompletion)
+    result: list[ChatCompletionChunk] = [chunk async for chunk in converted]
+    assert len(result) == 2
+    assert result[0].choices[0].delta.content == "answer"
+    assert result[1].choices == []
+    assert result[1].usage is not None
+    assert result[1].usage.prompt_tokens == 11
+    assert result[1].usage.completion_tokens == 2
+    assert result[1].usage.total_tokens == 13

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -138,6 +138,7 @@ async def test_stream_preserves_usage_only_chunk() -> None:
     result: list[ChatCompletionChunk] = [chunk async for chunk in converted]
     assert len(result) == 2
     assert result[0].choices[0].delta.content == "answer"
+    assert result[0].usage is None
     assert result[1].choices == []
     assert result[1].usage is not None
     assert result[1].usage.prompt_tokens == 11

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from openai._models import construct_type
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk as OpenAIChatCompletionChunk,
 )
@@ -144,3 +145,36 @@ async def test_stream_preserves_usage_only_chunk() -> None:
     assert result[1].usage.prompt_tokens == 11
     assert result[1].usage.completion_tokens == 2
     assert result[1].usage.total_tokens == 13
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_usage_on_chunk_without_delta() -> None:
+    """Minimax attaches usage to a terminal chunk whose choice has no delta (see #657)."""
+    provider = MinimaxProvider(api_key="sk-test")
+    terminal = cast(
+        "OpenAIChatCompletionChunk",
+        construct_type(
+            value={
+                "id": "minimax-terminal",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "MiniMax-M3",
+                "choices": [
+                    {"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "answer"}}
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 2, "total_tokens": 13},
+            },
+            type_=OpenAIChatCompletionChunk,
+        ),
+    )
+    assert terminal.choices[0].delta is None
+
+    stream = cast("AsyncStream[OpenAIChatCompletionChunk]", _iter_chunks([terminal]))
+    converted = provider._convert_completion_response_async(stream)
+
+    assert not isinstance(converted, ChatCompletion)
+    result: list[ChatCompletionChunk] = [chunk async for chunk in converted]
+    assert len(result) == 1
+    assert result[0].choices == []
+    assert result[0].usage is not None
+    assert result[0].usage.total_tokens == 13


### PR DESCRIPTION
## Description

Fixes MiniMax streaming usage loss reported in #1185.

MiniMax returns token usage in a trailing streaming chunk with `choices=[]`.
`MinimaxProvider._convert_completion_response_async()` previously forwarded
only chunks containing a choice delta, so it discarded this usage-only chunk
before the Messages bridge or downstream stream handler could observe it.

This change keeps the existing MiniMax filtering behavior while also forwarding
chunks where `chunk.usage is not None`.

The regression test verifies that:

- normal content chunks remain available;
- unrelated empty chunks without usage remain filtered;
- a trailing `choices=[]` chunk with usage survives conversion;
- input, output, and total token values remain unchanged after the XML reasoning
  wrapper.

No usage is synthesized, and absent usage is not converted to zero. Non-streaming
behavior and other providers are unchanged.

### Validation

Full local unit suite:

```text
1920 passed, 68 skipped, 3 warnings
```

The warnings are existing provider exception deprecation warnings unrelated to
this change.

Full pre-commit suite passed, including Ruff, formatting, Mypy, codespell, and
repository file checks.

A live MiniMax-M3 streaming request was also verified with the patched provider.
The raw provider usage and normalized result matched:

```text
input_tokens: 191
output_tokens: 27
total_tokens: 218
cached_tokens: 128
```

No credentials, prompt text, response text, or request headers were retained.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #1185

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: OpenAI GPT-5.6 Sol
- AI Developer Tool used: Codex
- Any other info you'd like to share: The scope and acceptance criteria were
  directed by the contributor. Codex implemented the change, added the
  regression test, ran the local validation, and drafted this PR description.
  The contributor reviewed the patch before submission.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Minimax streaming reliability by preserving usage-only updates alongside response content.
  - Unrelated or empty streaming chunks are now ignored, preventing unusable data from appearing in streamed responses.
  - Usage token information remains available in terminal updates, even when those updates contain no response text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->