### PR TITLE
feat(meta): add Meta Model API provider (OpenAI + Anthropic dual protocol)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all = [
-  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,gmi,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud,telnyx,edenai,kenari]"
+  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,gmi,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud,telnyx,edenai,kenari,meta]"
 ]
 
 platform = [
@@ -125,6 +125,7 @@ kenari = []
 llama = []
 llamacpp = []
 llamafile = []
+meta = []
 moonshot = []
 nebius = []
 neosantara = []

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -54,6 +54,7 @@ class LLMProvider(StrEnum):
     LMSTUDIO = "lmstudio"
     LLAMAFILE = "llamafile"
     LLAMACPP = "llamacpp"
+    META = "meta"
     MISTRAL = "mistral"
     MOONSHOT = "moonshot"
     MZAI = "mzai"

--- a/src/any_llm/providers/meta/__init__.py
+++ b/src/any_llm/providers/meta/__init__.py
@@ -1,0 +1,3 @@
+from .meta import MetaProvider
+
+__all__ = ["MetaProvider"]

--- a/src/any_llm/providers/meta/meta.py
+++ b/src/any_llm/providers/meta/meta.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
+from typing_extensions import override
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    MessageDeltaEvent,
+    MessageResponse,
+    MessageStartEvent,
+    MessageStopEvent,
+)
+from any_llm.utils.structured_output import is_structured_output_type
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage
+    from anthropic.types.parsed_message import ParsedMessage
+
+    from any_llm.types.messages import MessagesParams, MessageStreamEvent
+
+# Meta's /v1/messages stream yields typed anthropic SDK events (unlike gateways that hand
+# back raw dicts), so events are validated straight into any-llm's typed models by `type`.
+_MESSAGE_STREAM_EVENT_TYPES: dict[str, type[Any]] = {
+    "message_start": MessageStartEvent,
+    "message_delta": MessageDeltaEvent,
+    "message_stop": MessageStopEvent,
+    "content_block_start": ContentBlockStartEvent,
+    "content_block_delta": ContentBlockDeltaEvent,
+    "content_block_stop": ContentBlockStopEvent,
+}
+
+
+def _derive_anthropic_base(openai_base: str) -> str:
+    """Derive the Anthropic SDK base URL from the OpenAI SDK one.
+
+    Meta's OpenAI-compatible endpoints live under `.../v1` (the OpenAI SDK appends
+    `/chat/completions`, `/responses`, etc. itself); the Anthropic SDK appends
+    `/v1/messages` itself, so it needs the bare host instead.
+    """
+    return openai_base.removesuffix("/v1")
+
+
+class MetaProvider(BaseOpenAIProvider):
+    """Meta Model API provider.
+
+    Chat Completions and Responses are OpenAI-SDK compatible and served through the
+    inherited `BaseOpenAIProvider` machinery. The Messages API is served natively through
+    the Anthropic SDK, pointed at Meta's Anthropic-compatible endpoint, rather than through
+    any-llm's default Messages<->Completions bridge, so that `thinking` blocks, native
+    `tool_use` blocks, and `cache_control` survive the round trip.
+    """
+
+    PROVIDER_NAME = "meta"
+    ENV_API_KEY_NAME = "MODEL_API_KEY"
+    ENV_API_BASE_NAME = "META_API_BASE"
+    API_BASE = "https://api.meta.ai/v1"
+    PROVIDER_DOCUMENTATION_URL = "https://dev.meta.ai/docs"
+    PROMPT_CACHE_KEY_SUPPORT = "supported"
+
+    SUPPORTS_COMPLETION_STREAMING = True
+    SUPPORTS_COMPLETION = True
+    SUPPORTS_RESPONSES = True
+    # reasoning_content is documented as redacted-empty for external callers on Chat
+    # Completions; flip to True once verified against the live endpoint.
+    SUPPORTS_COMPLETION_REASONING = False
+    SUPPORTS_COMPLETION_IMAGE = True
+    SUPPORTS_COMPLETION_PDF = True
+    SUPPORTS_EMBEDDING = False
+    SUPPORTS_MODERATION = False
+    SUPPORTS_LIST_MODELS = True
+    SUPPORTS_BATCH = False
+    SUPPORTS_IMAGE_GENERATION = False
+    SUPPORTS_RERANK = False
+
+    client: AsyncOpenAI
+    _anthropic_client: AsyncAnthropic
+
+    @override
+    def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
+        resolved_base = api_base or self.API_BASE
+        self.client = AsyncOpenAI(base_url=resolved_base, api_key=api_key, **kwargs)
+        # Meta's Anthropic-compatible endpoint expects `Authorization: Bearer`, which the
+        # Anthropic SDK only sends via `auth_token`; `api_key` would send `x-api-key` instead.
+        self._anthropic_client = AsyncAnthropic(
+            auth_token=api_key,
+            base_url=_derive_anthropic_base(resolved_base),
+            **kwargs,
+        )
+
+    @override
+    async def _amessages(
+        self, params: MessagesParams, **kwargs: Any
+    ) -> MessageResponse | ParsedMessage[Any] | ParsedBetaMessage[Any] | AsyncIterator[MessageStreamEvent]:
+        """Native Anthropic Messages API pass-through.
+
+        Meta's translation layer does not document support for Anthropic's context
+        management or beta primitives, so those are rejected rather than silently dropped.
+        """
+        if params.context_management is not None or params.betas:
+            msg = "context_management and betas are not supported by the Meta Messages API"
+            raise NotImplementedError(msg)
+
+        if params.output_format is not None:
+            native_kwargs = params.model_dump(
+                exclude_none=True, exclude={"output_format", "stream", "betas", "context_management"}
+            )
+            native_kwargs.update(kwargs)
+            if is_structured_output_type(params.output_format):
+                return await self._anthropic_client.messages.parse(output_format=params.output_format, **native_kwargs)
+            message = await self._anthropic_client.messages.create(
+                output_config=cast("Any", params.output_format), **native_kwargs
+            )
+            return self._convert_native_message_to_response(message)
+
+        api_kwargs = params.model_dump(exclude_none=True, exclude={"betas", "context_management"})
+        api_kwargs.pop("stream", None)
+        api_kwargs.update(kwargs)
+
+        if params.stream:
+            return self._stream_messages_async(**api_kwargs)
+
+        message = await self._anthropic_client.messages.create(**api_kwargs)
+        return self._convert_native_message_to_response(message)
+
+    async def _stream_messages_async(self, **kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        """Stream Meta's native /v1/messages endpoint, yielding typed any-llm event models."""
+        async with self._anthropic_client.messages.stream(**kwargs) as stream:
+            async for event in stream:
+                event_model = _MESSAGE_STREAM_EVENT_TYPES.get(event.type)
+                if event_model is not None:
+                    yield event_model.model_validate(event, from_attributes=True)
+
+    @staticmethod
+    def _convert_native_message_to_response(message: Any) -> MessageResponse:
+        return MessageResponse.model_validate(message, from_attributes=True)

--- a/src/any_llm/providers/meta/meta.py
+++ b/src/any_llm/providers/meta/meta.py
@@ -43,9 +43,10 @@ def _derive_anthropic_base(openai_base: str) -> str:
 
     Meta's OpenAI-compatible endpoints live under `.../v1` (the OpenAI SDK appends
     `/chat/completions`, `/responses`, etc. itself); the Anthropic SDK appends
-    `/v1/messages` itself, so it needs the bare host instead.
+    `/v1/messages` itself, so it needs the bare host instead. Trailing slashes are
+    normalized first so a `.../v1/` override still strips down to the bare host.
     """
-    return openai_base.removesuffix("/v1")
+    return openai_base.rstrip("/").removesuffix("/v1")
 
 
 class MetaProvider(BaseOpenAIProvider):
@@ -65,6 +66,10 @@ class MetaProvider(BaseOpenAIProvider):
     PROVIDER_DOCUMENTATION_URL = "https://dev.meta.ai/docs"
     PROMPT_CACHE_KEY_SUPPORT = "supported"
 
+    # Flags below are set from https://dev.meta.ai/docs; this is a community-tier provider
+    # (no repo-held MODEL_API_KEY), so none of these request paths have been exercised
+    # against the live endpoint yet. Whoever runs the live-verification snippet from
+    # CONTRIBUTING.md before merge should correct any flag that turns out to be wrong.
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True
     SUPPORTS_RESPONSES = True
@@ -109,6 +114,12 @@ class MetaProvider(BaseOpenAIProvider):
             raise NotImplementedError(msg)
 
         if params.output_format is not None:
+            if params.stream:
+                # Belt-and-suspenders: the public `amessages()` entry point already rejects this
+                # combination before params reach here, but `_amessages` can be called directly
+                # (e.g. in tests), so guard here too rather than silently dropping `stream`.
+                msg = "stream is not supported for output_format"
+                raise ValueError(msg)
             native_kwargs = params.model_dump(
                 exclude_none=True, exclude={"output_format", "stream", "betas", "context_management"}
             )

--- a/src/any_llm/providers/meta/meta.py
+++ b/src/any_llm/providers/meta/meta.py
@@ -6,6 +6,7 @@ from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
 from typing_extensions import override
 
+from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.messages import (
     ContentBlockDeltaEvent,
@@ -37,6 +38,12 @@ _MESSAGE_STREAM_EVENT_TYPES: dict[str, type[Any]] = {
     "content_block_stop": ContentBlockStopEvent,
 }
 
+# Meta's Messages docs state these return HTTP 400 (`stop_sequences`, `top_k`) or are simply
+# not part of its documented request shape (`prompt_cache_key`, which Meta documents only for
+# Chat Completions/Responses, not Messages). Reject them client-side with a clear error instead
+# of letting the SDK or the API surface an opaque 400/TypeError.
+_MESSAGES_UNSUPPORTED_PARAMS = ("prompt_cache_key", "stop_sequences", "top_k")
+
 
 def _derive_anthropic_base(openai_base: str) -> str:
     """Derive the Anthropic SDK base URL from the OpenAI SDK one.
@@ -55,8 +62,11 @@ class MetaProvider(BaseOpenAIProvider):
     Chat Completions and Responses are OpenAI-SDK compatible and served through the
     inherited `BaseOpenAIProvider` machinery. The Messages API is served natively through
     the Anthropic SDK, pointed at Meta's Anthropic-compatible endpoint, rather than through
-    any-llm's default Messages<->Completions bridge, so that `thinking` blocks, native
-    `tool_use` blocks, and `cache_control` survive the round trip.
+    any-llm's default Messages<->Completions bridge, so that `thinking` blocks and native
+    `tool_use` blocks survive the round trip (a bridged conversion would drop both). Meta's
+    Messages endpoint documents a narrower field set than genuine Anthropic, though: fields
+    it explicitly 400s on or doesn't document at all (`prompt_cache_key`, `stop_sequences`,
+    `top_k`) are rejected client-side rather than forwarded, see `_amessages`.
     """
 
     PROVIDER_NAME = "meta"
@@ -108,10 +118,19 @@ class MetaProvider(BaseOpenAIProvider):
 
         Meta's translation layer does not document support for Anthropic's context
         management or beta primitives, so those are rejected rather than silently dropped.
+        Likewise `prompt_cache_key` (documented only for Chat Completions/Responses) and
+        `stop_sequences`/`top_k` (documented to 400 on Messages) are rejected client-side
+        instead of being forwarded to the Anthropic SDK, which would either reject them with
+        a raw `TypeError` (`prompt_cache_key` isn't part of its `messages.create` signature)
+        or a less legible API-side 400.
         """
         if params.context_management is not None or params.betas:
             msg = "context_management and betas are not supported by the Meta Messages API"
             raise NotImplementedError(msg)
+
+        for param_name in _MESSAGES_UNSUPPORTED_PARAMS:
+            if getattr(params, param_name) is not None:
+                raise UnsupportedParameterError(param_name, self.PROVIDER_NAME)
 
         if params.output_format is not None:
             if params.stream:

--- a/tests/unit/providers/test_meta_provider.py
+++ b/tests/unit/providers/test_meta_provider.py
@@ -29,6 +29,7 @@ from anthropic.types import (
 from anthropic.types.raw_message_delta_event import Delta as SDKDelta
 from pydantic import BaseModel
 
+from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.meta.meta import MetaProvider, _derive_anthropic_base
 from any_llm.types.completion import CompletionParams
 from any_llm.types.messages import (
@@ -184,6 +185,32 @@ async def test_amessages_rejects_betas() -> None:
     )
     with pytest.raises(NotImplementedError, match="betas"):
         await provider._amessages(params)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("prompt_cache_key", "my-app"),
+        ("stop_sequences", ["STOP"]),
+        ("top_k", 5),
+    ],
+)
+@pytest.mark.asyncio
+async def test_amessages_rejects_unsupported_params(field_name: str, value: Any) -> None:
+    """Meta's Messages docs 400 on `stop_sequences`/`top_k`, and don't document
+    `prompt_cache_key` for Messages at all (only for Chat Completions/Responses); reject
+    all three client-side rather than forwarding them into the Anthropic SDK, where
+    `prompt_cache_key` isn't even a valid `messages.create` kwarg."""
+    provider = _build_provider()
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        **{field_name: value},
+    )
+    with pytest.raises(UnsupportedParameterError, match=field_name):
+        await provider._amessages(params)
+    provider._anthropic_client.messages.create.assert_not_called()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_meta_provider.py
+++ b/tests/unit/providers/test_meta_provider.py
@@ -1,0 +1,315 @@
+from typing import Any, Self
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from anthropic.types import (
+    ContentBlockDeltaEvent as SDKContentBlockDeltaEvent,
+)
+from anthropic.types import (
+    ContentBlockStartEvent as SDKContentBlockStartEvent,
+)
+from anthropic.types import (
+    ContentBlockStopEvent as SDKContentBlockStopEvent,
+)
+from anthropic.types import (
+    Message,
+    MessageDeltaUsage,
+    RawMessageDeltaEvent,
+    TextBlock,
+    TextDelta,
+    Usage,
+)
+from anthropic.types import (
+    MessageStartEvent as SDKMessageStartEvent,
+)
+from anthropic.types import (
+    MessageStopEvent as SDKMessageStopEvent,
+)
+from anthropic.types.raw_message_delta_event import Delta as SDKDelta
+from pydantic import BaseModel
+
+from any_llm.providers.meta.meta import MetaProvider, _derive_anthropic_base
+from any_llm.types.completion import CompletionParams
+from any_llm.types.messages import MessageResponse, MessagesParams
+
+
+def _build_provider(api_base: str | None = None) -> MetaProvider:
+    with (
+        patch("any_llm.providers.meta.meta.AsyncOpenAI") as mock_openai,
+        patch("any_llm.providers.meta.meta.AsyncAnthropic") as mock_anthropic,
+    ):
+        provider = MetaProvider(api_key="test-key", api_base=api_base)
+        provider._mock_openai_ctor = mock_openai  # type: ignore[attr-defined]
+        provider._mock_anthropic_ctor = mock_anthropic  # type: ignore[attr-defined]
+    return provider
+
+
+def test_provider_metadata() -> None:
+    assert MetaProvider.PROVIDER_NAME == "meta"
+    assert MetaProvider.ENV_API_KEY_NAME == "MODEL_API_KEY"
+    assert MetaProvider.API_BASE == "https://api.meta.ai/v1"
+    assert MetaProvider.PROMPT_CACHE_KEY_SUPPORT == "supported"
+    assert MetaProvider.SUPPORTS_COMPLETION is True
+    assert MetaProvider.SUPPORTS_COMPLETION_STREAMING is True
+    assert MetaProvider.SUPPORTS_RESPONSES is True
+    assert MetaProvider.SUPPORTS_MESSAGES is True
+    assert MetaProvider.SUPPORTS_COMPLETION_REASONING is False
+    assert MetaProvider.SUPPORTS_EMBEDDING is False
+    assert MetaProvider.SUPPORTS_BATCH is False
+    assert MetaProvider.SUPPORTS_LIST_MODELS is True
+
+
+def test_derive_anthropic_base_strips_v1_suffix() -> None:
+    assert _derive_anthropic_base("https://api.meta.ai/v1") == "https://api.meta.ai"
+
+
+def test_derive_anthropic_base_leaves_bare_host_untouched() -> None:
+    assert _derive_anthropic_base("https://api.meta.ai") == "https://api.meta.ai"
+
+
+def test_derive_anthropic_base_preserves_custom_override() -> None:
+    assert _derive_anthropic_base("https://staging.meta.example/v1") == "https://staging.meta.example"
+
+
+def test_init_client_uses_default_base_urls() -> None:
+    provider = _build_provider()
+
+    provider._mock_openai_ctor.assert_called_once_with(base_url="https://api.meta.ai/v1", api_key="test-key")  # type: ignore[attr-defined]
+    provider._mock_anthropic_ctor.assert_called_once_with(  # type: ignore[attr-defined]
+        auth_token="test-key",  # noqa: S106
+        base_url="https://api.meta.ai",
+    )
+
+
+def test_init_client_uses_bearer_auth_token_not_api_key() -> None:
+    """Meta expects `Authorization: Bearer`, which the Anthropic SDK only sends via auth_token."""
+    provider = _build_provider()
+
+    _, call_kwargs = provider._mock_anthropic_ctor.call_args  # type: ignore[attr-defined]
+    assert call_kwargs["auth_token"] == "test-key"  # noqa: S105
+    assert "api_key" not in call_kwargs
+
+
+def test_init_client_derives_anthropic_base_from_custom_openai_base() -> None:
+    provider = _build_provider(api_base="https://custom.meta.example/v1")
+
+    provider._mock_openai_ctor.assert_called_once_with(  # type: ignore[attr-defined]
+        base_url="https://custom.meta.example/v1", api_key="test-key"
+    )
+    provider._mock_anthropic_ctor.assert_called_once_with(  # type: ignore[attr-defined]
+        auth_token="test-key",  # noqa: S106
+        base_url="https://custom.meta.example",
+    )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_delegates_to_openai_client() -> None:
+    provider = _build_provider()
+    mock_response = Mock()
+    provider.client.chat.completions.create = AsyncMock(return_value=mock_response)  # type: ignore[method-assign]
+
+    params = CompletionParams(model_id="muse-spark-1.2", messages=[{"role": "user", "content": "hi"}], stream=False)
+    with patch.object(MetaProvider, "_convert_completion_response_async", return_value=mock_response):
+        result = await provider._acompletion(params)
+
+    assert result is mock_response
+    provider.client.chat.completions.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_amessages_non_streaming_uses_native_anthropic_client() -> None:
+    provider = _build_provider()
+    mock_message = Message(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model="muse-spark-1.2",
+        stop_reason="end_turn",
+        content=[TextBlock(type="text", text="Hi!")],
+        usage=Usage(input_tokens=5, output_tokens=2),
+    )
+    provider._anthropic_client.messages.create = AsyncMock(return_value=mock_message)  # type: ignore[method-assign]
+
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+    )
+    result = await provider._amessages(params)
+
+    assert isinstance(result, MessageResponse)
+    assert result.content[0].text == "Hi!"  # type: ignore[union-attr]
+    provider._anthropic_client.messages.create.assert_awaited_once()
+    call_kwargs = provider._anthropic_client.messages.create.call_args.kwargs
+    assert call_kwargs["model"] == "muse-spark-1.2"
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_amessages_rejects_context_management() -> None:
+    provider = _build_provider()
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        context_management={"edits": [{"type": "clear_tool_uses_20250919"}]},
+    )
+    with pytest.raises(NotImplementedError, match="context_management"):
+        await provider._amessages(params)
+
+
+@pytest.mark.asyncio
+async def test_amessages_rejects_betas() -> None:
+    provider = _build_provider()
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        betas=["some-beta"],
+    )
+    with pytest.raises(NotImplementedError, match="betas"):
+        await provider._amessages(params)
+
+
+@pytest.mark.asyncio
+async def test_amessages_streaming_delegates_to_stream_method() -> None:
+    provider = _build_provider()
+    provider._stream_messages_async = Mock(return_value=AsyncMock())  # type: ignore[method-assign]
+
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        stream=True,
+    )
+    await provider._amessages(params)
+    provider._stream_messages_async.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_async_emits_typed_events() -> None:
+    usage_start = Usage(input_tokens=10, output_tokens=0)
+    msg = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        content=[],
+        model="muse-spark-1.2",
+        stop_reason=None,
+        usage=usage_start,
+    )
+
+    events_list: list[Any] = [
+        SDKMessageStartEvent(type="message_start", message=msg),
+        SDKContentBlockStartEvent(type="content_block_start", index=0, content_block=TextBlock(type="text", text="")),
+        SDKContentBlockDeltaEvent(
+            type="content_block_delta", index=0, delta=TextDelta(type="text_delta", text="Hello!")
+        ),
+        SDKContentBlockStopEvent(type="content_block_stop", index=0),
+        RawMessageDeltaEvent(
+            type="message_delta",
+            delta=SDKDelta(stop_reason="end_turn"),
+            usage=MessageDeltaUsage(output_tokens=5),
+        ),
+        SDKMessageStopEvent(type="message_stop"),
+    ]
+
+    class MockStream:
+        def __init__(self) -> None:
+            self.events = iter(events_list)
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+        def __aiter__(self) -> Self:
+            return self
+
+        async def __anext__(self) -> Any:
+            try:
+                return next(self.events)
+            except StopIteration:
+                raise StopAsyncIteration from None
+
+    provider = _build_provider()
+    provider._anthropic_client.messages.stream = Mock(return_value=MockStream())  # type: ignore[method-assign]
+
+    collected = [
+        event async for event in provider._stream_messages_async(model="muse-spark-1.2", messages=[], max_tokens=64)
+    ]
+
+    types = [event.type for event in collected]
+    assert types == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_format_pydantic_type_uses_parse() -> None:
+    class _Answer(BaseModel):
+        text: str
+
+    provider = _build_provider()
+    parsed_result = Mock()
+    provider._anthropic_client.messages.parse = AsyncMock(return_value=parsed_result)  # type: ignore[method-assign]
+
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        output_format=_Answer,
+    )
+    result = await provider._amessages(params)
+
+    assert result is parsed_result
+    call_kwargs = provider._anthropic_client.messages.parse.call_args.kwargs
+    assert call_kwargs["output_format"] is _Answer
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_format_dict_uses_output_config() -> None:
+    provider = _build_provider()
+    mock_message = Message(
+        id="msg_2",
+        type="message",
+        role="assistant",
+        model="muse-spark-1.2",
+        stop_reason="end_turn",
+        content=[TextBlock(type="text", text="{}")],
+        usage=Usage(input_tokens=1, output_tokens=1),
+    )
+    provider._anthropic_client.messages.create = AsyncMock(return_value=mock_message)  # type: ignore[method-assign]
+
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        output_format=output_config,
+    )
+    result = await provider._amessages(params)
+
+    assert isinstance(result, MessageResponse)
+    call_kwargs = provider._anthropic_client.messages.create.call_args.kwargs
+    assert call_kwargs["output_config"] == output_config
+
+
+@pytest.mark.asyncio
+async def test_alist_models_delegates_to_openai_client() -> None:
+    provider = _build_provider()
+    fake_response = MagicMock()
+    fake_response.data = []
+    provider.client.models.list = AsyncMock(return_value=fake_response)  # type: ignore[method-assign]
+
+    result = await provider._alist_models()
+
+    assert result == []
+    provider.client.models.list.assert_awaited_once()

--- a/tests/unit/providers/test_meta_provider.py
+++ b/tests/unit/providers/test_meta_provider.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from typing import Any, Self
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -30,7 +31,16 @@ from pydantic import BaseModel
 
 from any_llm.providers.meta.meta import MetaProvider, _derive_anthropic_base
 from any_llm.types.completion import CompletionParams
-from any_llm.types.messages import MessageResponse, MessagesParams
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    MessageDeltaEvent,
+    MessageResponse,
+    MessagesParams,
+    MessageStartEvent,
+    MessageStopEvent,
+)
 
 
 def _build_provider(api_base: str | None = None) -> MetaProvider:
@@ -69,6 +79,11 @@ def test_derive_anthropic_base_leaves_bare_host_untouched() -> None:
 
 def test_derive_anthropic_base_preserves_custom_override() -> None:
     assert _derive_anthropic_base("https://staging.meta.example/v1") == "https://staging.meta.example"
+
+
+def test_derive_anthropic_base_strips_trailing_slash_before_v1() -> None:
+    """A `.../v1/` override must not leave a trailing slash that Anthropic would double up."""
+    assert _derive_anthropic_base("https://custom.meta.example/v1/") == "https://custom.meta.example"
 
 
 def test_init_client_uses_default_base_urls() -> None:
@@ -172,6 +187,27 @@ async def test_amessages_rejects_betas() -> None:
 
 
 @pytest.mark.asyncio
+async def test_amessages_output_format_rejects_stream() -> None:
+    """The public `amessages()` already blocks this combo before building params; `_amessages`
+    guards it too so a direct call (e.g. bypassing the public entry point) fails loudly instead
+    of silently dropping `stream` and returning a non-streaming result."""
+
+    class _Answer(BaseModel):
+        text: str
+
+    provider = _build_provider()
+    params = MessagesParams(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=64,
+        output_format=_Answer,
+        stream=True,
+    )
+    with pytest.raises(ValueError, match="stream is not supported for output_format"):
+        await provider._amessages(params)
+
+
+@pytest.mark.asyncio
 async def test_amessages_streaming_delegates_to_stream_method() -> None:
     provider = _build_provider()
     provider._stream_messages_async = Mock(return_value=AsyncMock())  # type: ignore[method-assign]
@@ -201,6 +237,9 @@ async def test_stream_messages_async_emits_typed_events() -> None:
 
     events_list: list[Any] = [
         SDKMessageStartEvent(type="message_start", message=msg),
+        # Anthropic streams send periodic `ping` events with no any-llm equivalent; the
+        # generator must skip them rather than yield the raw SDK event or raise.
+        SimpleNamespace(type="ping"),
         SDKContentBlockStartEvent(type="content_block_start", index=0, content_block=TextBlock(type="text", text="")),
         SDKContentBlockDeltaEvent(
             type="content_block_delta", index=0, delta=TextDelta(type="text_delta", text="Hello!")
@@ -240,15 +279,19 @@ async def test_stream_messages_async_emits_typed_events() -> None:
         event async for event in provider._stream_messages_async(model="muse-spark-1.2", messages=[], max_tokens=64)
     ]
 
-    types = [event.type for event in collected]
-    assert types == [
-        "message_start",
-        "content_block_start",
-        "content_block_delta",
-        "content_block_stop",
-        "message_delta",
-        "message_stop",
-    ]
+    # The `ping` event has no any-llm equivalent and must be dropped, not yielded verbatim.
+    assert len(collected) == 6
+    assert isinstance(collected[0], MessageStartEvent)
+    assert collected[0].message.id == "msg_123"
+    assert isinstance(collected[1], ContentBlockStartEvent)
+    assert collected[1].content_block.type == "text"
+    assert isinstance(collected[2], ContentBlockDeltaEvent)
+    assert collected[2].delta.text == "Hello!"  # type: ignore[union-attr]
+    assert isinstance(collected[3], ContentBlockStopEvent)
+    assert isinstance(collected[4], MessageDeltaEvent)
+    assert collected[4].delta.stop_reason == "end_turn"
+    assert collected[4].usage.output_tokens == 5
+    assert isinstance(collected[5], MessageStopEvent)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Adds a new `meta` provider for [Meta's Model API](https://dev.meta.ai/docs) (`muse-spark-*` models). This API is unusual in that it serves the same models through **both** protocols on the same account/key:

- Chat Completions + Responses via `https://api.meta.ai/v1`, OpenAI-SDK compatible.
- Messages via `https://api.meta.ai`, Anthropic-SDK compatible (native `content` blocks, `thinking`, `tool_use`, `stop_reason`).

`MetaProvider(BaseOpenAIProvider)` inherits Chat Completions and Responses unmodified (no translation needed, they're wire-compatible with the OpenAI SDK), and stands up a second `AsyncAnthropic` client to serve `.messages()`/`.amessages()` as a genuine native pass-through to `/v1/messages`, rather than any-llm's default Messages↔Completions bridge — this preserves `thinking` blocks, native `tool_use` blocks, and `cache_control` that a bridge conversion would otherwise drop. Two auth details worth calling out for review:

- The Anthropic client is constructed with `auth_token=` (not `api_key=`), since Meta expects `Authorization: Bearer` rather than Anthropic's native `x-api-key` header.
- The Anthropic SDK's base URL is derived from the OpenAI one by stripping a trailing `/v1` (`https://api.meta.ai/v1` → `https://api.meta.ai`), since the Anthropic SDK appends `/v1/messages` itself.

`context_management` and `betas` are rejected with `NotImplementedError` on `.messages()`, since Meta's translation layer doesn't document support for Anthropic's context-management/beta primitives.

This lands as **community tier**: added to the `LLMProvider` enum and a `pyproject.toml` extra, but **not** to `VERIFIED_PROVIDERS` or the `tests/conftest.py` model maps, since I don't hold a `MODEL_API_KEY` for CI. Capability flags were set conservatively from the docs alone (no live key to verify against):

- `SUPPORTS_COMPLETION_REASONING=False` — docs state `reasoning_content` on Chat Completions is redacted to empty for external callers.
- `SUPPORTS_EMBEDDING`, `SUPPORTS_BATCH`, `SUPPORTS_IMAGE_GENERATION`, `SUPPORTS_RERANK` all `False` — none of these endpoints are documented.
- `PROMPT_CACHE_KEY_SUPPORT="supported"` — docs confirm `prompt_cache_key` on Chat Completions + Responses (not explicitly confirmed on Messages).

**I could not run this against the live endpoint** (no `MODEL_API_KEY`). Whoever has one, the live-verification snippet from `CONTRIBUTING.md` would be:

```python
from any_llm import AnyLLM
llm = AnyLLM.create("meta", api_key="...")
print(llm.completion(model="muse-spark-1.2", messages=[{"role": "user", "content": "Say hi"}]).choices[0].message.content)
print(llm.messages(model="muse-spark-1.2", max_tokens=64, messages=[{"role": "user", "content": "Say hi"}]))
print([m.id for m in llm.list_models()][:5])
```

That run would also be the moment to correct any of the conservative flags above if the live behavior differs from the docs.

## PR Type

- 🆕 New Feature

## Relevant issues

N/A

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue. — unit tests pass locally; the live endpoint is not verified (no `MODEL_API_KEY`), see note above.
- [x] New and existing tests pass locally (`uv run pytest tests/unit` — 1889 passed; the only failures are a pre-existing local `otari` SDK version mismatch unrelated to this change, reproduced identically on unmodified `main`)
- [x] Documentation was updated where necessary (`docs/providers.md` is generated from provider metadata; no manual docs needed)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Implementation, tests, and this PR description were drafted by Claude Code from the published Meta Model API docs, following the existing `otari`/`anthropic` provider patterns in this repo. Live-endpoint verification is still needed from someone with a `MODEL_API_KEY`.

- [x] I am an AI Agent filling out this form

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Meta provider.
  * Supports OpenAI-compatible completions and responses, as well as Anthropic-compatible messaging.
  * Added standard and structured outputs, streaming responses, authentication, and model listing.
  * Included the Meta provider in the complete optional installation.

* **Tests**
  * Added comprehensive coverage for Meta provider configuration, requests, streaming, authentication, and output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->