### PR TITLE
fix(reasoning): preserve metadata chunk order

### DIFF
--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -81,7 +81,7 @@ async def process_streaming_reasoning_chunks(
         content = get_content(original_chunk)
 
         if not content:
-            if buffer or reasoning_buffer:
+            if is_terminal(original_chunk) and (buffer or reasoning_buffer):
                 held_chunks.append(original_chunk)
             else:
                 yield original_chunk

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -24,10 +24,11 @@ def _make_chunk(
     finish_reason: Literal["stop", "length"] | None = None,
     role: Literal["assistant"] | None = "assistant",
     extra_content: dict[str, Any] | None = None,
+    chunk_id: str = "test-chunk",
 ) -> ChatCompletionChunk:
     """Create a minimal ChatCompletionChunk for testing."""
     return ChatCompletionChunk(
-        id="test-chunk",
+        id=chunk_id,
         choices=[
             ChunkChoice(
                 index=0,
@@ -338,6 +339,23 @@ async def test_wrap_chunks_preserves_terminal_metadata_after_partial_tag() -> No
 
     assert _accumulate(result) == ("prefix answer", "reasoning")
     assert [chunk.choices[0].finish_reason for chunk in result] == [None, "stop"]
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_preserves_metadata_order_around_partial_tag() -> None:
+    """Metadata chunks stay in order while a partial tag is buffered."""
+    chunks = [
+        _make_chunk(content="<think", chunk_id="opening"),
+        _make_chunk(content=None, role=None, extra_content={"marker": "metadata"}, chunk_id="metadata"),
+        _make_chunk(content=">reasoning</think>answer", role=None, chunk_id="content"),
+        _make_chunk(content=None, finish_reason="stop", role=None, chunk_id="terminal"),
+    ]
+
+    result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks(chunks)))
+
+    assert [chunk.id for chunk in result] == ["metadata", "content", "terminal"]
+    assert _accumulate(result) == ("answer", "reasoning")
+    assert result[0].choices[0].delta.extra_content == {"marker": "metadata"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
The XML reasoning stream wrapper currently delays every contentless chunk while a partial reasoning tag is buffered. This can move metadata such as role, tool calls, or provider extensions after later content and terminal chunks.

This change keeps ordinary metadata chunks in their original stream order while continuing to defer contentless terminal chunks until buffered content is flushed.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1252

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] AI Usage:
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: The change was validated with the repository unit suite and local pre-commit checks.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming behaviour so empty terminal chunks are no longer unnecessarily delayed.
  * Preserved the correct ordering and metadata of metadata-only chunks when reasoning content spans multiple streamed chunks.
  * Ensured final content and terminal chunks remain correctly processed during reasoning extraction.

* **Tests**
  * Added coverage for chunk ordering, metadata preservation, and reasoning/content extraction across streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->