### PR TITLE
fix(anthropic): clear error for non-streaming timeout guard; add first-class timeout param

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -577,6 +577,7 @@ class AnyLLM(ABC):
         response_format: dict[str, Any] | type | None = None,
         stream: bool | None = None,
         prompt_cache_key: str | None = None,
+        timeout: float | None = None,
         allow_running_loop: bool | None = None,
         **kwargs: Any,
     ) -> ChatCompletion | Iterator[ChatCompletionChunk] | ParsedChatCompletion[Any]:
@@ -594,6 +595,7 @@ class AnyLLM(ABC):
                     response_format=response_format,
                     stream=stream,
                     prompt_cache_key=prompt_cache_key,
+                    timeout=timeout,
                     **kwargs,
                 ),
                 allow_running_loop=allow_running_loop,
@@ -606,6 +608,7 @@ class AnyLLM(ABC):
                 response_format=response_format,
                 stream=stream,
                 prompt_cache_key=prompt_cache_key,
+                timeout=timeout,
                 **kwargs,
             ),
             allow_running_loop=allow_running_loop,
@@ -687,6 +690,7 @@ class AnyLLM(ABC):
         max_completion_tokens: int | None = None,
         reasoning_effort: ReasoningEffort | None = "auto",
         prompt_cache_key: str | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
         **kwargs: Any,
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk] | ParsedChatCompletion[Any]:
         """Create a chat completion asynchronously.
@@ -716,6 +720,7 @@ class AnyLLM(ABC):
             max_completion_tokens: Maximum number of tokens for the completion
             reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
             prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+            timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
         Returns:
@@ -761,6 +766,11 @@ class AnyLLM(ABC):
         )
 
         self._validate_prompt_cache_key(prompt_cache_key)
+        # timeout is forwarded through kwargs rather than carried on CompletionParams: providers
+        # apply it differently (per-request vs client-level), so each consumes it from kwargs.
+        # Forward it only when set, so the default path (and its provider behavior) is unchanged.
+        if timeout is not None:
+            kwargs["timeout"] = timeout
         result = await self._acompletion(params, **kwargs)
 
         if is_structured_output_type(response_format):

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -721,6 +721,8 @@ class AnyLLM(ABC):
             reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
             prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
             timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+                An explicit ``None`` is treated the same as omitting it (the provider's default
+                applies), so it cannot request an unbounded timeout.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
         Returns:

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -89,6 +89,8 @@ def completion(
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+            An explicit ``None`` is treated the same as omitting it (the provider's default
+            applies), so it cannot request an unbounded timeout.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -204,6 +206,8 @@ async def acompletion(
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+            An explicit ``None`` is treated the same as omitting it (the provider's default
+            applies), so it cannot request an unbounded timeout.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -51,6 +51,7 @@ def completion(
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
     prompt_cache_key: str | None = None,
+    timeout: float | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
@@ -87,6 +88,7 @@ def completion(
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+        timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -130,6 +132,7 @@ def completion(
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
         prompt_cache_key=prompt_cache_key,
+        timeout=timeout,
         **kwargs,
     )
 
@@ -163,6 +166,7 @@ async def acompletion(
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
     prompt_cache_key: str | None = None,
+    timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
@@ -199,6 +203,7 @@ async def acompletion(
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+        timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -242,6 +247,7 @@ async def acompletion(
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
         prompt_cache_key=prompt_cache_key,
+        timeout=timeout,
         **kwargs,
     )
 

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
-from any_llm.exceptions import BatchNotCompleteError
+from any_llm.exceptions import BatchNotCompleteError, InvalidRequestError
 from any_llm.logging import logger
 from any_llm.types.batch import Batch, BatchRequestCounts, BatchResult, BatchResultError, BatchResultItem
 from any_llm.types.messages import (
@@ -56,6 +56,12 @@ if TYPE_CHECKING:
 _COMPACTION_BETA = "compact-2026-01-12"
 _COMPACTION_MIN_TRIGGER_TOKENS = 50_000
 _CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
+
+# The SDK's client-side non-streaming guard raises a bare ValueError beginning with this text. It
+# is the only signal the SDK exposes for that condition (no error code or dedicated subtype), and
+# it has stayed stable across SDK versions. Kept as a single named constant so this is the one
+# documented point of coupling to the SDK's wording; the real-client test surfaces any future reword.
+_NONSTREAMING_TIMEOUT_GUARD_MARKER = "Streaming is required"
 
 _ANTHROPIC_TO_OPENAI_STATUS_MAP: dict[str, str] = {
     "in_progress": "in_progress",
@@ -275,7 +281,22 @@ class BaseAnthropicProvider(AnyLLM, ABC):
         if converted_kwargs.pop("stream", False):
             return self._stream_completion_async(**converted_kwargs)
 
-        message = await self.client.messages.create(**converted_kwargs)
+        try:
+            message = await self.client.messages.create(**converted_kwargs)
+        except ValueError as exc:
+            # A bare ValueError here is the SDK's pre-flight non-streaming guard (it rejects a
+            # request whose max_tokens could exceed the time limit for a single response, before
+            # anything is sent). Translate it into an actionable any-llm error and leave any
+            # unrelated ValueError untouched.
+            if not str(exc).startswith(_NONSTREAMING_TIMEOUT_GUARD_MARKER):
+                raise
+            max_tokens = converted_kwargs.get("max_tokens")
+            msg = (
+                f"A non-streaming completion with max_tokens={max_tokens} can exceed the default "
+                "per-request time limit, so it needs an explicit timeout. "
+                "Pass a `timeout` (in seconds) or use `stream=True`."
+            )
+            raise InvalidRequestError(msg, original_exception=exc, provider_name=self.PROVIDER_NAME) from exc
 
         return self._convert_completion_response(message)
 

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -40,7 +41,7 @@ except ImportError as e:
     MISSING_PACKAGES_ERROR = e
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Sequence
+    from collections.abc import AsyncIterator, Iterator, Sequence
 
     from anthropic import AsyncAnthropic, AsyncAnthropicVertex
     from anthropic.types import Message
@@ -62,6 +63,28 @@ _CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
 # it has stayed stable across SDK versions. Kept as a single named constant so this is the one
 # documented point of coupling to the SDK's wording; the real-client test surfaces any future reword.
 _NONSTREAMING_TIMEOUT_GUARD_MARKER = "Streaming is required"
+
+
+@contextmanager
+def _translating_nonstreaming_guard(provider: AnyLLM, max_tokens: int | None) -> Iterator[None]:
+    """Translate the SDK's client-side non-streaming guard into an actionable any-llm error.
+
+    The guard rejects a non-streaming request whose max_tokens could exceed the default
+    per-request time limit, raising a bare ValueError before anything is sent. Any unrelated
+    ValueError is left untouched.
+    """
+    try:
+        yield
+    except ValueError as exc:
+        if not str(exc).startswith(_NONSTREAMING_TIMEOUT_GUARD_MARKER):
+            raise
+        msg = (
+            f"A non-streaming request with max_tokens={max_tokens} can exceed the default "
+            "per-request time limit, so it needs an explicit timeout. "
+            "Pass a `timeout` (in seconds) or use `stream=True`."
+        )
+        raise InvalidRequestError(msg, original_exception=exc, provider_name=provider.PROVIDER_NAME) from exc
+
 
 _ANTHROPIC_TO_OPENAI_STATUS_MAP: dict[str, str] = {
     "in_progress": "in_progress",
@@ -281,22 +304,8 @@ class BaseAnthropicProvider(AnyLLM, ABC):
         if converted_kwargs.pop("stream", False):
             return self._stream_completion_async(**converted_kwargs)
 
-        try:
+        with _translating_nonstreaming_guard(self, converted_kwargs.get("max_tokens")):
             message = await self.client.messages.create(**converted_kwargs)
-        except ValueError as exc:
-            # A bare ValueError here is the SDK's pre-flight non-streaming guard (it rejects a
-            # request whose max_tokens could exceed the time limit for a single response, before
-            # anything is sent). Translate it into an actionable any-llm error and leave any
-            # unrelated ValueError untouched.
-            if not str(exc).startswith(_NONSTREAMING_TIMEOUT_GUARD_MARKER):
-                raise
-            max_tokens = converted_kwargs.get("max_tokens")
-            msg = (
-                f"A non-streaming completion with max_tokens={max_tokens} can exceed the default "
-                "per-request time limit, so it needs an explicit timeout. "
-                "Pass a `timeout` (in seconds) or use `stream=True`."
-            )
-            raise InvalidRequestError(msg, original_exception=exc, provider_name=self.PROVIDER_NAME) from exc
 
         return self._convert_completion_response(message)
 
@@ -324,9 +333,13 @@ class BaseAnthropicProvider(AnyLLM, ABC):
                 native_kwargs["betas"] = betas
             native_kwargs.update(kwargs)
             if is_structured_output_type(params.output_format):
-                parsed = await messages_resource.parse(output_format=params.output_format, **native_kwargs)
+                with _translating_nonstreaming_guard(self, params.max_tokens):
+                    parsed = await messages_resource.parse(output_format=params.output_format, **native_kwargs)
                 return cast("ParsedMessage[Any] | ParsedBetaMessage[Any]", parsed)
-            message = await messages_resource.create(output_config=cast("Any", params.output_format), **native_kwargs)
+            with _translating_nonstreaming_guard(self, params.max_tokens):
+                message = await messages_resource.create(
+                    output_config=cast("Any", params.output_format), **native_kwargs
+                )
             return self._convert_native_message_to_response(message)
 
         api_kwargs = params.model_dump(exclude_none=True, exclude={"betas"})
@@ -339,7 +352,8 @@ class BaseAnthropicProvider(AnyLLM, ABC):
             return self._stream_messages_async(use_beta=use_beta, **api_kwargs)
 
         messages_resource = self.client.beta.messages if use_beta else self.client.messages
-        response: Message = await messages_resource.create(**api_kwargs)
+        with _translating_nonstreaming_guard(self, params.max_tokens):
+            response: Message = await messages_resource.create(**api_kwargs)
         return self._convert_native_message_to_response(response)
 
     async def _stream_messages_async(

--- a/src/any_llm/providers/cohere/cohere.py
+++ b/src/any_llm/providers/cohere/cohere.py
@@ -82,6 +82,14 @@ class CohereProvider(AnyLLM):
                     "token_budget": REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort],
                 }
         converted_params.update(kwargs)
+
+        # Cohere's SDK carries a per-request timeout inside `request_options` rather than as a
+        # top-level keyword, so the seconds-based any-llm parameter has to be folded in there.
+        if (timeout := converted_params.pop("timeout", None)) is not None:
+            request_options = dict(converted_params.get("request_options") or {})
+            request_options.setdefault("timeout", timeout)
+            converted_params["request_options"] = request_options
+
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/lmstudio/lmstudio.py
+++ b/src/any_llm/providers/lmstudio/lmstudio.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
+from any_llm.logging import logger
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 MISSING_PACKAGES_ERROR = None
@@ -139,6 +140,14 @@ class LmstudioProvider(AnyLLM):
         if params.stop is not None:
             config["stopStrings"] = [params.stop] if isinstance(params.stop, str) else params.stop
         config.update(kwargs)
+
+        # LM Studio folds this dict into the prediction config, which has no per-request timeout,
+        # so a `timeout` cannot be honored here.
+        if config.pop("timeout", None) is not None:
+            logger.warning(
+                "LM Studio does not support a per-request 'timeout'; ignoring it. "
+                "Set it on the client via client_args instead."
+            )
         return config
 
     @staticmethod

--- a/src/any_llm/providers/mistral/mistral.py
+++ b/src/any_llm/providers/mistral/mistral.py
@@ -115,6 +115,12 @@ class MistralProvider(AnyLLM):
             converted_params["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
 
         converted_params.update(kwargs)
+
+        # Mistral's SDK names its per-request timeout `timeout_ms`, so the seconds-based any-llm
+        # parameter has to be translated; forwarding it as `timeout` is an unexpected keyword.
+        if (timeout := converted_params.pop("timeout", None)) is not None:
+            converted_params["timeout_ms"] = int(timeout * 1000)
+
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -86,6 +86,14 @@ class OllamaProvider(AnyLLM):
             converted_params["think"] = REASONING_EFFORT_TO_OLLAMA_THINK[params.reasoning_effort]
         converted_params.update(kwargs)
 
+        # The Ollama client only accepts a timeout at construction, so a per-request `timeout`
+        # cannot be honored here and would reach the SDK as an unexpected keyword.
+        if converted_params.pop("timeout", None) is not None:
+            logger.warning(
+                "Ollama does not support a per-request 'timeout'; ignoring it. "
+                "Set it on the client via client_args instead."
+            )
+
         max_tokens = converted_params.pop("max_tokens", None)
         max_completion_tokens = converted_params.pop("max_completion_tokens", None)
         requested_max_tokens = max_completion_tokens if max_completion_tokens is not None else max_tokens

--- a/src/any_llm/providers/sagemaker/sagemaker.py
+++ b/src/any_llm/providers/sagemaker/sagemaker.py
@@ -57,6 +57,13 @@ class SagemakerProvider(AnyLLM):
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """Convert CompletionParams to kwargs for SageMaker API."""
+        # SageMaker serializes these kwargs into the request body, so a per-request `timeout`
+        # cannot be honored here and would be sent as a payload field.
+        if kwargs.pop("timeout", None) is not None:
+            logger.warning(
+                "SageMaker does not support a per-request 'timeout'; ignoring it. "
+                "Set it on the client via client_args instead."
+            )
         return _convert_params(params, kwargs)
 
     @staticmethod

--- a/src/any_llm/providers/watsonx/watsonx.py
+++ b/src/any_llm/providers/watsonx/watsonx.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
+from any_llm.logging import logger
 from any_llm.utils.structured_output import is_structured_output_type
 
 MISSING_PACKAGES_ERROR: ImportError | None = None
@@ -77,6 +78,14 @@ class WatsonxProvider(AnyLLM):
         if converted_params.get("reasoning_effort") in ("auto", "none"):
             converted_params.pop("reasoning_effort")
         converted_params.update(kwargs)
+
+        # watsonx merges this dict straight into its chat payload as generation parameters, so a
+        # per-request `timeout` cannot be honored here and would be sent as an invalid model field.
+        if converted_params.pop("timeout", None) is not None:
+            logger.warning(
+                "watsonx does not support a per-request 'timeout'; ignoring it. "
+                "Set it on the client via client_args instead."
+            )
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
+from any_llm.logging import logger
 from any_llm.utils.structured_output import get_json_schema
 
 MISSING_PACKAGES_ERROR = None
@@ -77,6 +78,15 @@ class XaiProvider(AnyLLM):
         if converted_params.get("reasoning_effort") in ("auto", "none"):
             converted_params.pop("reasoning_effort")
         converted_params.update(kwargs)
+
+        # The xAI SDK sets timeouts on the gRPC client, not per request, so a per-request
+        # `timeout` cannot be honored here and would reach the SDK as an unexpected keyword.
+        if converted_params.pop("timeout", None) is not None:
+            logger.warning(
+                "xAI does not support a per-request 'timeout'; ignoring it. "
+                "Pass client_args={'timeout': seconds} to set it on the client instead."
+            )
+
         return converted_params
 
     @staticmethod

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Self, cast
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -13,7 +13,7 @@ from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usa
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage
 from pydantic import BaseModel
 
-from any_llm.exceptions import UnsupportedParameterError
+from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
 from any_llm.providers.anthropic.anthropic import AnthropicProvider
 from any_llm.providers.anthropic.base import BaseAnthropicProvider, _messages_betas, _pop_anthropic_beta_header
 from any_llm.types.messages import (
@@ -1339,3 +1339,30 @@ async def test_amessages_system_list_form() -> None:
 
     call_kwargs = mock_client.messages.create.call_args.kwargs
     assert call_kwargs["system"] == system_blocks
+
+
+@pytest.mark.asyncio
+async def test_amessages_without_timeout_translates_nonstreaming_guard() -> None:
+    """The messages API surfaces the same actionable error as completions for the pre-flight guard.
+
+    Uses a real ``AsyncAnthropic`` client so the SDK guard runs; the transport is patched to fail
+    fast so the test stays hermetic if the guard ever changes.
+    """
+    provider = AnthropicProvider(api_key="sk-test")
+
+    with (
+        patch.object(
+            provider.client, "post", new=AsyncMock(side_effect=AssertionError("network should not be reached"))
+        ),
+        pytest.raises(InvalidRequestError) as exc_info,
+    ):
+        await provider.amessages(
+            model="claude-opus-5",
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=65536,
+            stream=False,
+        )
+
+    message = str(exc_info.value)
+    assert "timeout" in message
+    assert "stream=True" in message

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -11,7 +11,7 @@ from anthropic.types import Message
 from anthropic.types.model_info import ModelInfo
 from pydantic import BaseModel
 
-from any_llm.exceptions import UnsupportedParameterError
+from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
 from any_llm.providers.anthropic.anthropic import AnthropicProvider
 from any_llm.providers.anthropic.utils import (
     DEFAULT_MAX_TOKENS,
@@ -120,6 +120,72 @@ async def test_completion_with_kwargs() -> None:
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model, messages=messages, max_tokens=100, temperature=0.5
         )
+
+
+@pytest.mark.asyncio
+async def test_completion_without_timeout_raises_clear_error() -> None:
+    """Reproduces issue #1251: without a timeout, a large-max_tokens non-streaming completion
+    surfaces an actionable any-llm error instead of the SDK's opaque pre-flight ValueError.
+
+    Uses a real ``AsyncAnthropic`` client so the SDK's client-side check runs; it raises before
+    any request is sent. The transport is patched to fail fast so the test stays hermetic even if
+    that guard ever changes. Goes through the public ``acompletion`` so the exception-handling
+    decorator is exercised too.
+    """
+    provider = AnthropicProvider(api_key="sk-test")
+
+    with (
+        patch.object(
+            provider.client, "post", new=AsyncMock(side_effect=AssertionError("network should not be reached"))
+        ),
+        pytest.raises(InvalidRequestError) as exc_info,
+    ):
+        await provider.acompletion(
+            model="claude-opus-5",
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=65536,
+            stream=False,
+        )
+
+    message = str(exc_info.value)
+    assert "timeout" in message
+    assert "stream=True" in message
+    assert isinstance(exc_info.value.original_exception, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_completion_with_timeout_bypasses_nonstreaming_guard() -> None:
+    """An explicit timeout lifts the SDK pre-flight guard so the same large request reaches transport."""
+    provider = AnthropicProvider(api_key="sk-test")
+    params = CompletionParams(
+        model_id="claude-opus-5",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=65536,
+        stream=False,
+    )
+
+    # The guard fires before the transport call, so reaching ``post`` proves it was skipped.
+    with (
+        patch.object(provider.client, "post", new=AsyncMock(side_effect=RuntimeError("reached transport"))),
+        pytest.raises(RuntimeError, match="reached transport"),
+    ):
+        await provider._acompletion(params, timeout=600)
+
+
+@pytest.mark.asyncio
+async def test_completion_reraises_unrelated_value_error() -> None:
+    """A ValueError that is not the SDK pre-flight guard propagates unchanged, not translated."""
+    unrelated = ValueError("some other problem")
+
+    with mock_anthropic_provider() as mock_anthropic:
+        mock_anthropic.return_value.messages.create = AsyncMock(side_effect=unrelated)
+        provider = AnthropicProvider(api_key="test-api-key")
+        with pytest.raises(ValueError, match="some other problem") as exc_info:
+            await provider._acompletion(
+                CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hi"}], max_tokens=100)
+            )
+
+    assert exc_info.value is unrelated
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -698,3 +698,38 @@ async def test_completion_with_image_content() -> None:
         user_msg = sent_messages[0]
         assert isinstance(user_msg["content"], list)
         assert user_msg["content"][1]["type"] == "image_url"
+
+
+def test_timeout_is_folded_into_request_options() -> None:
+    """Cohere carries a per-request timeout in ``request_options``, not as a top-level keyword."""
+    provider = _mk_provider()
+
+    converted = provider._convert_completion_params(
+        CompletionParams(model_id="command-a-03-2025", messages=[{"role": "user", "content": "Hi"}]),
+        timeout=600,
+    )
+
+    assert converted["request_options"] == {"timeout": 600}
+    assert "timeout" not in converted
+
+
+def test_timeout_does_not_override_explicit_request_options() -> None:
+    provider = _mk_provider()
+
+    converted = provider._convert_completion_params(
+        CompletionParams(model_id="command-a-03-2025", messages=[{"role": "user", "content": "Hi"}]),
+        timeout=600,
+        request_options={"timeout": 30, "max_retries": 2},
+    )
+
+    assert converted["request_options"] == {"timeout": 30, "max_retries": 2}
+
+
+def test_request_options_absent_when_timeout_not_requested() -> None:
+    provider = _mk_provider()
+
+    converted = provider._convert_completion_params(
+        CompletionParams(model_id="command-a-03-2025", messages=[{"role": "user", "content": "Hi"}])
+    )
+
+    assert "request_options" not in converted

--- a/tests/unit/providers/test_lmstudio_provider.py
+++ b/tests/unit/providers/test_lmstudio_provider.py
@@ -414,3 +414,16 @@ def test_map_stop_reason(stop_reason: str | None, expected: str) -> None:
 )
 def test_split_reasoning_from_content(content: str, expected_content: str, expected_reasoning: str | None) -> None:
     assert utils._split_reasoning_from_content(content) == (expected_content, expected_reasoning)
+
+
+def test_timeout_is_dropped_with_a_warning() -> None:
+    """LM Studio's prediction config has no per-request timeout, so it cannot be honored."""
+    with patch("any_llm.providers.lmstudio.lmstudio.logger") as mock_logger:
+        result = LmstudioProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=600,
+        )
+
+    assert "timeout" not in result
+    mock_logger.warning.assert_called_once()
+    assert "client_args" in mock_logger.warning.call_args[0][0]

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -1286,3 +1287,36 @@ def test_create_openai_chunk_captures_thinking_signature() -> None:
     assert chunk.choices[0].delta.reasoning is not None
     assert chunk.choices[0].delta.reasoning.content == "step one"
     assert chunk.choices[0].delta.extra_content == {"mistral": {"signature": "sig-abc"}}
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_translated_to_timeout_ms() -> None:
+    """The seconds-based any-llm ``timeout`` must become the SDK's ``timeout_ms``.
+
+    Binds the produced kwargs against the real ``complete_async`` signature so a
+    forwarded-but-unsupported keyword fails here instead of at request time.
+    """
+    pytest.importorskip("mistralai")
+    from mistralai.client.chat import Chat
+
+    from any_llm.providers.mistral.mistral import MistralProvider
+
+    converted = MistralProvider._convert_completion_params(
+        CompletionParams(model_id="mistral-small-latest", messages=[{"role": "user", "content": "Hi"}]),
+        timeout=600,
+    )
+
+    assert converted["timeout_ms"] == 600_000
+    assert "timeout" not in converted
+    signature(Chat.complete_async).bind_partial(Mock(), model="mistral-small-latest", **converted)
+
+
+def test_timeout_absent_when_not_requested() -> None:
+    pytest.importorskip("mistralai")
+    from any_llm.providers.mistral.mistral import MistralProvider
+
+    converted = MistralProvider._convert_completion_params(
+        CompletionParams(model_id="mistral-small-latest", messages=[{"role": "user", "content": "Hi"}])
+    )
+
+    assert "timeout_ms" not in converted

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -540,3 +540,16 @@ async def test_streaming_completion_passes_think_level_top_level() -> None:
         assert call_kwargs["think"] == "medium"
         assert "think" not in call_kwargs.get("options", {})
         assert "reasoning_effort" not in call_kwargs.get("options", {})
+
+
+def test_timeout_is_dropped_with_a_warning() -> None:
+    """Ollama only accepts a timeout at client construction, not per request."""
+    with patch("any_llm.providers.ollama.ollama.logger") as mock_logger:
+        result = OllamaProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=600,
+        )
+
+    assert "timeout" not in result
+    mock_logger.warning.assert_called_once()
+    assert "client_args" in mock_logger.warning.call_args[0][0]

--- a/tests/unit/providers/test_sagemaker_provider.py
+++ b/tests/unit/providers/test_sagemaker_provider.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from any_llm.providers.sagemaker.sagemaker import SagemakerProvider
+from any_llm.types.completion import CompletionParams
+
+
+def test_timeout_is_dropped_with_a_warning() -> None:
+    """SageMaker serializes these kwargs into the request body, so a per-request timeout can't be honored."""
+    with patch("any_llm.providers.sagemaker.sagemaker.logger") as mock_logger:
+        result = SagemakerProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=600,
+        )
+
+    assert "timeout" not in result
+    mock_logger.warning.assert_called_once()
+    assert "client_args" in mock_logger.warning.call_args[0][0]

--- a/tests/unit/providers/test_watsonx_provider.py
+++ b/tests/unit/providers/test_watsonx_provider.py
@@ -337,3 +337,16 @@ def test_convert_streaming_chunk_empty_choices() -> None:
     result = _convert_streaming_chunk(chunk)
 
     assert result.choices == []
+
+
+def test_timeout_is_dropped_with_a_warning() -> None:
+    """watsonx forwards these kwargs as generation parameters, so a per-request timeout can't be honored."""
+    with patch("any_llm.providers.watsonx.watsonx.logger") as mock_logger:
+        result = WatsonxProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=600,
+        )
+
+    assert "timeout" not in result
+    mock_logger.warning.assert_called_once()
+    assert "client_args" in mock_logger.warning.call_args[0][0]

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -162,3 +162,29 @@ def test_stream_options_filtered_out() -> None:
         )
     )
     assert "stream_options" not in result
+
+
+def test_timeout_is_dropped_with_a_warning() -> None:
+    """xAI sets timeouts on the gRPC client, so a per-request timeout cannot be honored."""
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with patch("any_llm.providers.xai.xai.logger") as mock_logger:
+        result = XaiProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=600,
+        )
+
+    assert "timeout" not in result
+    mock_logger.warning.assert_called_once()
+    assert "client_args" in mock_logger.warning.call_args[0][0]
+
+
+def test_no_warning_when_timeout_not_requested() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with patch("any_llm.providers.xai.xai.logger") as mock_logger:
+        XaiProvider._convert_completion_params(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}])
+        )
+
+    mock_logger.warning.assert_not_called()

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import AsyncIterator
 from inspect import signature
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -9,7 +10,7 @@ from any_llm import AnyLLM
 from any_llm.api import acompletion, aresponses, completion, responses
 from any_llm.constants import LLMProvider
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import ChatCompletion, CompletionParams
 
 _PYTHON_314_INCOMPATIBLE_PROVIDERS = {"voyage", "watsonx"}
 
@@ -37,6 +38,61 @@ def test_completion_params_exposes_prompt_cache_key() -> None:
         )
 
     assert mock_provider.completion.call_args.kwargs["prompt_cache_key"] == "tenant-1"
+
+
+def test_completion_exposes_timeout_parameter() -> None:
+    assert "timeout" in signature(completion).parameters
+    assert "timeout" in signature(acompletion).parameters
+    assert "timeout" in signature(AnyLLM.completion).parameters
+    assert "timeout" in signature(AnyLLM.acompletion).parameters
+
+
+@pytest.mark.asyncio
+async def test_acompletion_forwards_timeout_to_provider() -> None:
+    # Through the public acompletion() helper: a set timeout reaches the provider, None is dropped.
+    provider = AnyLLM.create("openai", api_key="sk-test")
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_acompletion", new=AsyncMock(return_value=Mock(spec=ChatCompletion))) as mock_ac,
+    ):
+        await acompletion(model="openai:gpt-4", messages=[{"role": "user", "content": "Hi"}], timeout=600)
+        assert mock_ac.call_args.kwargs.get("timeout") == 600
+
+        mock_ac.reset_mock()
+        await acompletion(model="openai:gpt-4", messages=[{"role": "user", "content": "Hi"}], timeout=None)
+        assert "timeout" not in mock_ac.call_args.kwargs
+
+
+def test_completion_forwards_timeout_to_provider_sync() -> None:
+    # Through the public completion() helper on the synchronous non-streaming path.
+    provider = AnyLLM.create("openai", api_key="sk-test")
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_acompletion", new=AsyncMock(return_value=Mock(spec=ChatCompletion))) as mock_ac,
+    ):
+        completion(model="openai:gpt-4", messages=[{"role": "user", "content": "Hi"}], timeout=600, stream=False)
+
+    assert mock_ac.call_args.kwargs.get("timeout") == 600
+
+
+def test_completion_forwards_timeout_on_streaming_path() -> None:
+    # The synchronous streaming path forwards timeout too; consume the iterator to drive the call.
+    provider = AnyLLM.create("openai", api_key="sk-test")
+
+    async def _empty_stream() -> AsyncIterator[Any]:
+        if False:
+            yield None
+
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_acompletion", new=AsyncMock(return_value=_empty_stream())) as mock_ac,
+    ):
+        stream = completion(
+            model="openai:gpt-4", messages=[{"role": "user", "content": "Hi"}], timeout=600, stream=True
+        )
+        list(stream)
+
+    assert mock_ac.call_args.kwargs.get("timeout") == 600
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes the opaque failure reported in #1251: a non-streaming Anthropic completion with a large `max_tokens` (roughly `> 128000/6 ≈ 21,333`) raises a bare `ValueError: Streaming is required for operations that may take longer than 10 minutes.` from the SDK's client-side pre-flight check, before any request is sent, even when the actual response is tiny.

While investigating I confirmed that a `timeout` **already** reaches the Anthropic SDK today (via completion `kwargs` → `messages.create(timeout=...)` and via `client_args={"timeout": ...}` → `AsyncAnthropic(timeout=...)`), and either one already lifts the guard. So the real gaps were (a) `timeout` was not a first-class, documented, typed parameter, and (b) when no timeout is set the caller hits the SDK's opaque error with no hint at the fix. This PR closes both:

- **First-class `timeout` parameter** on `completion()`/`acompletion()` and `AnyLLM.completion`/`acompletion`, mirroring how `prompt_cache_key` is surfaced. It is forwarded to the provider through `kwargs` only when set, rather than being added to `CompletionParams`. **Cross-provider handling:** because it rides `kwargs` to every provider, those whose SDK accepts a `timeout` keyword (OpenAI-based, groq, cerebras, together, anthropic) honor it directly; Gemini (#901)/Bedrock (#1240) already map it; and providers whose SDK has no per-request timeout are handled explicitly so they neither `TypeError` nor silently mis-send it — mistral (`timeout_ms`), cohere (`request_options`), and warn+drop for xai, ollama, watsonx, sagemaker, lmstudio (huggingface already stripped it). A central, enforced version of this is tracked in #1262. An explicit `timeout=None` is treated the same as omitting it, so an unbounded timeout is not expressible via the typed parameter.
- **Clearer Anthropic error**: the provider now catches the SDK's specific pre-flight guard and re-raises an `InvalidRequestError` that names the levers (`Pass a timeout (in seconds) or use stream=True`), while re-raising any unrelated `ValueError` untouched. The single point of coupling to the SDK's wording is isolated in a named constant; the SDK exposes only a bare `ValueError` (no error code/subtype) for this condition, so matching the (version-stable) message is the only available signal, and a real-client test would surface any future reword in CI.

## PR Type

- 🆕 New Feature
- 🐛 Bug Fix

## Relevant issues

Fixes #1251
Related: #901 (Gemini timeout), #1240 (Bedrock timeout)

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] AI was used for drafting/refactoring.

### Notes on tests

New tests are regression-verified (they fail on `main`, pass with the change):
- `tests/unit/test_completion.py`: `timeout` is exposed on all four entry points; forwarded to the provider only when set; explicit `None` is dropped.
- `tests/unit/providers/test_anthropic_provider.py`: without a timeout the large-`max_tokens` non-streaming path now raises a clear `InvalidRequestError` (driven through a real `AsyncAnthropic` client so the SDK guard actually runs); with a timeout it bypasses the guard and reaches transport.

`pre-commit` (ruff + format + mypy) is clean. The only failing tests in the full local `tests/unit` run are pre-existing, unrelated optional-SDK import errors (`lmstudio` not installed locally), identical to the `main` baseline.

## AI Usage Information

- AI Model used: Claude Opus 4.8
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Used collaboratively — AI assisted with investigation, drafting, and iteration under human review and direction (including auditing and fixing cross-provider timeout handling surfaced in review).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional timeout controls for synchronous and asynchronous chat completions.
  * Configured timeouts are passed to supported providers, while unset values preserve existing behaviour.

* **Bug Fixes**
  * Improved handling of oversized non-streaming Anthropic requests with clear guidance to set a timeout or enable streaming.
  * Unrelated provider errors continue to be reported unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
