### PR TITLE
fix(messages): keep sync streaming on a single event loop

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -809,6 +809,14 @@ class AnyLLM(ABC):
     ) -> MessageResponse | ParsedMessage[Any] | ParsedBetaMessage[Any] | Iterator[MessageStreamEvent]:
         """Create a message using the Anthropic Messages API synchronously.
 
+        With `stream=True` the request is opened lazily on the first iteration, so errors
+        raised while opening it (a rejected `output_format` combination, an unsupported
+        `context_management`/`betas` request, or a provider auth or connection failure)
+        surface from the first `next()` rather than from this call. This matches
+        [AnyLLM.completion][any_llm.any_llm.AnyLLM.completion] and
+        [AnyLLM.responses][any_llm.any_llm.AnyLLM.responses]; wrap the iteration rather
+        than the call to catch them.
+
         See [AnyLLM.amessages][any_llm.any_llm.AnyLLM.amessages]
         """
         if allow_running_loop is None:

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -813,6 +813,20 @@ class AnyLLM(ABC):
         """
         if allow_running_loop is None:
             allow_running_loop = INSIDE_NOTEBOOK
+        if kwargs.get("stream"):
+            return async_coro_to_sync_iter(
+                cast(
+                    "Coroutine[Any, Any, AsyncIterator[MessageStreamEvent]]",
+                    self.amessages(
+                        prompt_cache_key=prompt_cache_key,
+                        context_management=context_management,
+                        betas=betas,
+                        **kwargs,
+                    ),
+                ),
+                allow_running_loop=allow_running_loop,
+            )
+
         response = run_async_in_sync(
             self.amessages(
                 prompt_cache_key=prompt_cache_key,
@@ -824,7 +838,7 @@ class AnyLLM(ABC):
         )
         if isinstance(response, (MessageResponse, ParsedMessage, ParsedBetaMessage)):
             return response
-        return async_iter_to_sync_iter(response)
+        return async_iter_to_sync_iter(response, allow_running_loop=allow_running_loop)
 
     @handle_exceptions(wrap_streaming=True)
     async def amessages(

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -54,6 +54,7 @@ from any_llm.types.messages import (
     ParsedTextBlock,
     StopReason,
 )
+from any_llm.utils.aio import async_iter_to_sync_iter
 
 
 def test_stop_reason_aliases_anthropic_beta_type() -> None:
@@ -1320,12 +1321,15 @@ def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> N
     assert text == "Hello world"
 
 
-def test_sync_messages_bridges_an_iterator_returned_without_stream() -> None:
+def test_sync_messages_bridges_an_iterator_and_forwards_allow_running_loop() -> None:
     """A provider that hands back an iterator without `stream` still bridges to a sync iterator.
 
-    The streaming branch keys off `kwargs["stream"]`, so this covers the fallback
-    that converts a non-streaming call's async iterator, mirroring the same
-    fallback in `completion()` and `responses()`.
+    The streaming branch keys off `kwargs["stream"]`, so this covers the fallback that
+    converts a non-streaming call's async iterator, mirroring the same fallback in
+    `completion()` and `responses()`. `allow_running_loop` is asserted on the bridge call
+    rather than through behavior: the fallback is only reachable with no running loop, so
+    the flag changes nothing observable there, and dropping it would silently leave the
+    bridge on its own default of True.
     """
 
     async def event_stream() -> AsyncIterator[MessageStreamEvent]:
@@ -1334,15 +1338,18 @@ def test_sync_messages_bridges_an_iterator_returned_without_stream() -> None:
     mock_provider = Mock(spec=AnyLLM)
     mock_provider.amessages = AsyncMock(return_value=event_stream())
 
-    result = AnyLLM.messages(
-        mock_provider,
-        model="gpt-5.6",
-        messages=[{"role": "user", "content": "Hello"}],
-        max_tokens=100,
-    )
+    with patch("any_llm.any_llm.async_iter_to_sync_iter", wraps=async_iter_to_sync_iter) as bridge:
+        result = AnyLLM.messages(
+            mock_provider,
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            allow_running_loop=False,
+        )
+        events = list(cast("Iterator[MessageStreamEvent]", result))
 
-    events = list(cast("Iterator[MessageStreamEvent]", result))
     assert [event.type for event in events] == ["message_stop"]
+    assert bridge.call_args.kwargs["allow_running_loop"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -2,7 +2,7 @@
 
 import json
 import threading
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from inspect import signature
 from typing import Any, cast
@@ -22,6 +22,7 @@ from anthropic.types.beta import (
 from anthropic.types.beta.beta_context_management_response import BetaContextManagementResponse
 from anthropic.types.beta.parsed_beta_message import ParsedBetaTextBlock
 from pydantic import BaseModel
+from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
 from any_llm.api import amessages, messages
@@ -39,11 +40,13 @@ from any_llm.types.completion import (
 from any_llm.types.messages import (
     BetaDiagnostics,
     ContentBlock,
+    ContentBlockDeltaEvent,
     MessageContentBlock,
     MessageDeltaEvent,
     MessageDeltaUsage,
     MessageResponse,
     MessagesParams,
+    MessageStreamEvent,
     MessageUsage,
     ParsedBetaMessage,
     ParsedMessage,
@@ -1234,9 +1237,7 @@ class _StreamingHandler(BaseHTTPRequestHandler):
                 "object": "chat.completion.chunk",
                 "created": 1234567890,
                 "model": "test-model",
-                "choices": [
-                    {"index": 0, "delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None}
-                ],
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None}],
             },
             {
                 "id": "chunk-2",
@@ -1265,7 +1266,8 @@ class _StreamingHandler(BaseHTTPRequestHandler):
         self.wfile.write(encoded)
         self.wfile.flush()
 
-    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+    @override
+    def log_message(self, format: str, *args: Any) -> None:
         return
 
 
@@ -1281,8 +1283,6 @@ def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> N
     event loop`. This exercises the real OpenAI SDK, httpx, and anyio against a
     local server, with no live provider or API key required.
     """
-    from any_llm.any_llm import AnyLLM
-
     server = ThreadingHTTPServer(("127.0.0.1", 0), _StreamingHandler)
     server.daemon_threads = True
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -1292,14 +1292,16 @@ def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> N
         api_base = f"http://127.0.0.1:{server.server_address[1]}/v1"
         provider = AnyLLM.create_openai_compatible(name="local-messages", api_base=api_base, api_key="test")
 
-        events = list(
+        stream = cast(
+            "Iterator[MessageStreamEvent]",
             provider.messages(
                 model="test-model",
                 messages=[{"role": "user", "content": "Hello"}],
                 max_tokens=32,
                 stream=True,
-            )
+            ),
         )
+        events = list(stream)
     finally:
         server.shutdown()
         server.server_close()
@@ -1307,7 +1309,14 @@ def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> N
 
     types = [event.type for event in events]
     assert "content_block_delta" in types
-    assert "message_stop" in types
+    assert types[-1] == "message_stop"
+
+    text = "".join(
+        event.delta.text
+        for event in events
+        if isinstance(event, ContentBlockDeltaEvent) and event.delta.type == "text_delta"
+    )
+    assert text == "Hello world"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,6 +1,9 @@
 """Tests for messages()/amessages() SDK API."""
 
+import json
+import threading
 from collections.abc import AsyncGenerator, AsyncIterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from inspect import signature
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -1214,6 +1217,97 @@ def test_sync_messages_returns_message_response() -> None:
 
     assert isinstance(result, MessageResponse)
     assert result.content[0].type == "text"
+
+
+class _StreamingHandler(BaseHTTPRequestHandler):
+    """Serves a fixed SSE chat-completion-chunk stream, like a real OpenAI-compatible endpoint."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(content_length)
+
+        events: list[dict[str, Any]] = [
+            {
+                "id": "chunk-1",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None}
+                ],
+            },
+            {
+                "id": "chunk-2",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [{"index": 0, "delta": {"content": " world"}, "finish_reason": None}],
+            },
+            {
+                "id": "chunk-3",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+        ]
+        body = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+        body += "data: [DONE]\n\n"
+        encoded = body.encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(encoded)
+        self.wfile.flush()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+
+def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> None:
+    """Regression test for #1253.
+
+    The sync `messages(stream=True)` path used to open the async response with
+    `run_async_in_sync()` on one worker event loop and then hand the resulting
+    async iterator to `async_iter_to_sync_iter()`, which consumed it on a second,
+    unrelated event loop. httpx/anyio objects created by the OpenAI SDK are bound
+    to the loop that opened the stream, so reading them from a different loop
+    raised `RuntimeError: <asyncio.locks.Event object ...> is bound to a different
+    event loop`. This exercises the real OpenAI SDK, httpx, and anyio against a
+    local server, with no live provider or API key required.
+    """
+    from any_llm.any_llm import AnyLLM
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StreamingHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        api_base = f"http://127.0.0.1:{server.server_address[1]}/v1"
+        provider = AnyLLM.create_openai_compatible(name="local-messages", api_base=api_base, api_key="test")
+
+        events = list(
+            provider.messages(
+                model="test-model",
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=32,
+                stream=True,
+            )
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+    types = [event.type for event in events]
+    assert "content_block_delta" in types
+    assert "message_stop" in types
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -46,6 +46,7 @@ from any_llm.types.messages import (
     MessageDeltaUsage,
     MessageResponse,
     MessagesParams,
+    MessageStopEvent,
     MessageStreamEvent,
     MessageUsage,
     ParsedBetaMessage,
@@ -1317,6 +1318,31 @@ def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> N
         if isinstance(event, ContentBlockDeltaEvent) and event.delta.type == "text_delta"
     )
     assert text == "Hello world"
+
+
+def test_sync_messages_bridges_an_iterator_returned_without_stream() -> None:
+    """A provider that hands back an iterator without `stream` still bridges to a sync iterator.
+
+    The streaming branch keys off `kwargs["stream"]`, so this covers the fallback
+    that converts a non-streaming call's async iterator, mirroring the same
+    fallback in `completion()` and `responses()`.
+    """
+
+    async def event_stream() -> AsyncIterator[MessageStreamEvent]:
+        yield MessageStopEvent(type="message_stop")
+
+    mock_provider = Mock(spec=AnyLLM)
+    mock_provider.amessages = AsyncMock(return_value=event_stream())
+
+    result = AnyLLM.messages(
+        mock_provider,
+        model="gpt-5.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    events = list(cast("Iterator[MessageStreamEvent]", result))
+    assert [event.type for event in events] == ["message_stop"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
`AnyLLM.messages(stream=True)` opened the async response via `run_async_in_sync(self.amessages(...))` on one worker event loop, then handed the resulting async iterator to `async_iter_to_sync_iter()`, which consumed it on a *different* event loop. For OpenAI-compatible providers, the SDK's httpx/anyio objects are bound to the loop that opened the stream, so consuming from a second loop raised:

```
RuntimeError: <asyncio.locks.Event object at ...> is bound to a different event loop
```

`completion()` and `Responses()` streaming don't hit this because they pass the coroutine straight into `async_coro_to_sync_iter()`, so the response is opened and consumed on the same worker loop.

- Route the `messages()` sync streaming path through `async_coro_to_sync_iter()`, mirroring the existing `completion()`/`Responses()` pattern.
- Pass `allow_running_loop` through to the non-streaming fallback's `async_iter_to_sync_iter()` call for consistency with `responses()`.
- Add a regression test in `tests/unit/test_messages.py` based on the repro from the issue: a local `ThreadingHTTPServer` emitting SSE chunks, driven through the real OpenAI SDK/httpx/anyio, no live provider or API key required. Confirmed it hangs/fails against the pre-fix code and passes with the fix.

## PR Type

- 🐛 Bug Fix

## Relevant issues
Fixes #1253

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: I picked up this issue (assigned by @nathan-brake), diagnosed and posted the fix approach in the issue thread myself, then had Claude Code implement the one-line-swap plan I'd already confirmed, write the regression test, and run the local test/lint/type-check suite. I reviewed the diff and test output before opening this PR. Happy to discuss the approach directly.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronous streaming responses with OpenAI-compatible providers.
  * Streaming now works more reliably when an event loop is already active.
  * Preserved message-specific options for streaming and non-streaming responses.
  * Streaming request errors are reported when iteration begins.
  * Improved handling of asynchronous response streams when no explicit streaming option is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->