### PR TITLE
chore(cohere): move cohere from verified to community tier

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Set expected providers for integration tests
         id: set_providers
-        run: echo "expected_providers=anthropic,azureopenai,bedrock,cerebras,cohere,deepseek,fireworks,gemini,groq,inception,mistral,moonshot,nebius,openai,openrouter,otari,portkey,together,sambanova,voyage,xai,zai,minimax" >> $GITHUB_OUTPUT
+        run: echo "expected_providers=anthropic,azureopenai,bedrock,cerebras,deepseek,fireworks,gemini,groq,inception,mistral,moonshot,nebius,openai,openrouter,otari,portkey,together,sambanova,voyage,xai,zai,minimax" >> $GITHUB_OUTPUT
 
       - name: Set expected providers for local integration tests
         id: set_local_providers
@@ -148,7 +148,6 @@ jobs:
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -122,7 +122,6 @@ VERIFIED_PROVIDERS: frozenset[LLMProvider] = VERIFIED_LOCAL_PROVIDERS | frozense
         LLMProvider.AZUREOPENAI,
         LLMProvider.BEDROCK,
         LLMProvider.CEREBRAS,
-        LLMProvider.COHERE,
         LLMProvider.DEEPSEEK,
         LLMProvider.FIREWORKS,
         LLMProvider.GEMINI,


### PR DESCRIPTION
## Description

Cohere's CI account returns 402 "add or update your payment method" on every request, which failed 15 integration tests on the last main run ([job log](https://github.com/mozilla-ai/any-llm/actions/runs/31465633246/job/93697909013)). Keeping the key funded isn't worth the recurring triage. Dropping the support promise rather than the provider.

Reverses the promotion checklist in CONTRIBUTING.md: remove the name from `VERIFIED_PROVIDERS`, remove it from `EXPECTED_PROVIDERS`, and drop `COHERE_API_KEY` from the integration job. Removing the key is the load-bearing part; `EXPECTED_PROVIDERS` only decides whether a missing key raises instead of skips, so leaving the key would keep the tests calling the delinquent account. The provider code, `LLMProvider` member, and pyproject extra all stay, so cohere keeps working for users who bring their own key.

Two judgment calls to flag:

`tests/conftest.py` keeps its cohere model entries. CONTRIBUTING says community providers skip those maps, but atlascloud, telnyx, and deepinfra are already in them, and keeping cohere's means the suite stays runnable locally with a funded key.

The `COHERE_API_KEY` repository secret is untouched; only the workflow reference is gone. Delete the secret separately if you want it fully retired.

Not addressed here: the same run had 23 gemini failures (403, Google dunning block on project 394432324879) and 2 otari failures (insufficient wallet balance). Both are billing, not code.

## PR Type

- 🚦 Infrastructure

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

Notes on the checklist: no new tests were needed, since `tests/unit/test_provider_tiers.py` already asserts `VERIFIED_PROVIDERS` matches the workflow's `EXPECTED_PROVIDERS` list, so this change is covered by an existing test that would fail if only one side were edited. The provider table at docs/providers.md is generated from provider metadata, so the tier column updates without a doc edit.

Verification: full unit suite green (1995 passed, 93 skipped). With no `COHERE_API_KEY` set and cohere out of `EXPECTED_PROVIDERS`, 26 cohere integration tests skip and the 2 that still run are the bad-key exception tests, which pass. `pre-commit run --all-files` is clean apart from 5 pre-existing mypy `import-not-found` errors in `voyage/` and `watsonx/`, from SDKs missing locally in files this PR doesn't touch.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Triaged the red integration run, then made the tier change at njbrake's direction. The decision to demote cohere rather than refund the account is his.

- [x] I am an AI Agent filling out this form (check box if true)
