### PR TITLE
fix(bedrock): use explicit credential kwargs for verification session

### DIFF
--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -78,11 +78,19 @@ class BedrockProvider(AnyLLM):
         "botocore_session",
     )
 
+    @override
     def __init__(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self._custom_client: Any = kwargs.pop("client", None)
         self._custom_control_client: Any = kwargs.pop("control_client", None)
         self._custom_s3_client: Any = kwargs.pop("s3_client", None)
         self._session_credential_kwargs = {k: v for k, v in kwargs.items() if k in self._SESSION_CREDENTIAL_KWARGS}
+        # profile_name/botocore_session are boto3.Session-only parameters; Session.client() (used
+        # to build the runtime/control-plane/S3 clients below) doesn't accept them, so they must
+        # not remain in the kwargs forwarded to those calls. aws_access_key_id/
+        # aws_secret_access_key/aws_session_token/region_name are valid on both Session() and
+        # Session.client() and are left in kwargs unchanged.
+        kwargs.pop("profile_name", None)
+        kwargs.pop("botocore_session", None)
         super().__init__(api_key=api_key, api_base=api_base, **kwargs)
 
     @staticmethod
@@ -153,13 +161,17 @@ class BedrockProvider(AnyLLM):
     def _build_boto_session(self, api_key: str | None) -> Any:
         """Build a ``boto3.Session`` dedicated to this provider instance.
 
+        Built with the same explicit credential kwargs (``aws_access_key_id``, ``profile_name``,
+        etc) used for verification, so e.g. an explicit ``profile_name`` is actually honored by
+        the real session and not just by the verification check in ``_verify_and_set_api_key``.
+
         When ``api_key`` (an AWS Bedrock bearer token) is provided, a token provider scoped to
         this session's own in-memory environ mapping is registered on the underlying botocore
         session. This resolves the token per instance instead of requiring the process-wide
         ``AWS_BEARER_TOKEN_BEDROCK`` env var, which is unsafe to mutate under concurrent,
         multi-tenant use.
         """
-        session = boto3.Session()  # type: ignore[attr-defined]
+        session = boto3.Session(**self._session_credential_kwargs)  # type: ignore[attr-defined]
         if api_key:
             session._session.register_component(
                 "token_provider",

--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -66,10 +66,23 @@ class BedrockProvider(AnyLLM):
     # (and its underlying connection pools) without limit.
     _MAX_TIMEOUT_CLIENTS = 8
 
+    # Keyword arguments that `boto3.Session(...)` itself accepts. Used to build the session in
+    # `_verify_and_set_api_key` with the same explicit credentials the real client is later
+    # built with, instead of a bare `boto3.Session()` that only sees ambient credentials.
+    _SESSION_CREDENTIAL_KWARGS = (
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "region_name",
+        "profile_name",
+        "botocore_session",
+    )
+
     def __init__(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         self._custom_client: Any = kwargs.pop("client", None)
         self._custom_control_client: Any = kwargs.pop("control_client", None)
         self._custom_s3_client: Any = kwargs.pop("s3_client", None)
+        self._session_credential_kwargs = {k: v for k, v in kwargs.items() if k in self._SESSION_CREDENTIAL_KWARGS}
         super().__init__(api_key=api_key, api_base=api_base, **kwargs)
 
     @staticmethod
@@ -178,7 +191,12 @@ class BedrockProvider(AnyLLM):
         if self._custom_client is not None:
             return api_key
 
-        session = boto3.Session()  # type: ignore[attr-defined]
+        # Bedrock supports two independent auth mechanisms: a bearer-token API key, or standard
+        # AWS credentials (aws_access_key_id/aws_secret_access_key/aws_session_token, IAM roles,
+        # SSO, etc). A bare boto3.Session() only resolves the *ambient* default credential chain
+        # and ignores explicit credential kwargs passed to AnyLLM.create(...), which made this
+        # check fail even when valid credentials were explicitly provided (see #1183).
+        session = boto3.Session(**self._session_credential_kwargs)  # type: ignore[attr-defined]
         credentials = session.get_credentials()
 
         api_key = api_key or os.getenv(self.ENV_API_KEY_NAME)

--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -170,6 +170,13 @@ class BedrockProvider(AnyLLM):
         session. This resolves the token per instance instead of requiring the process-wide
         ``AWS_BEARER_TOKEN_BEDROCK`` env var, which is unsafe to mutate under concurrent,
         multi-tenant use.
+
+        Note: passing the *same* ``botocore_session`` object to multiple ``BedrockProvider``
+        instances with different ``api_key`` values is not isolated by this scoping, since
+        ``register_component`` on a shared botocore session simply overwrites the previous
+        registration (last-registration-wins is botocore's own documented behavior). Give each
+        provider instance its own ``botocore_session`` if per-instance bearer tokens must not
+        interfere with each other.
         """
         session = boto3.Session(**self._session_credential_kwargs)  # type: ignore[attr-defined]
         if api_key:
@@ -205,15 +212,20 @@ class BedrockProvider(AnyLLM):
 
         # Bedrock supports two independent auth mechanisms: a bearer-token API key, or standard
         # AWS credentials (aws_access_key_id/aws_secret_access_key/aws_session_token, IAM roles,
-        # SSO, etc). A bare boto3.Session() only resolves the *ambient* default credential chain
-        # and ignores explicit credential kwargs passed to AnyLLM.create(...), which made this
-        # check fail even when valid credentials were explicitly provided (see #1183).
+        # SSO, etc). Resolve the bearer token first and short-circuit on it, since it alone is
+        # sufficient: this avoids an unnecessary (and potentially slow, or erroring on an invalid
+        # explicit profile_name) credential-chain lookup when a bearer token is already provided.
+        api_key = api_key or os.getenv(self.ENV_API_KEY_NAME)
+        if api_key is not None:
+            return api_key
+
+        # A bare boto3.Session() only resolves the *ambient* default credential chain and ignores
+        # explicit credential kwargs passed to AnyLLM.create(...), which made this check fail even
+        # when valid credentials were explicitly provided (see #1183).
         session = boto3.Session(**self._session_credential_kwargs)  # type: ignore[attr-defined]
         credentials = session.get_credentials()
 
-        api_key = api_key or os.getenv(self.ENV_API_KEY_NAME)
-
-        if credentials is None and api_key is None:
+        if credentials is None:
             raise MissingApiKeyError(provider_name=self.PROVIDER_NAME, env_var_name=self.ENV_API_KEY_NAME)
 
         return api_key
@@ -371,12 +383,19 @@ class BedrockProvider(AnyLLM):
         as the runtime client, so overrides applied at construction time aren't silently
         bypassed for model listing and batch operations. An explicit ``control_client=``
         constructor kwarg always takes precedence.
+
+        When a custom ``client=`` was supplied (so there's no shared ``_boto_session`` to reuse),
+        a fresh session is still built from the caller's explicit credential kwargs rather than
+        falling back to a bare, ambient-only ``boto3.client(...)``: otherwise an explicit
+        ``profile_name``/``botocore_session`` would be silently dropped for this client.
         """
         if self._custom_control_client is not None:
             return self._custom_control_client
         if self._boto_session is not None:
             return self._boto_session.client("bedrock", **self._bedrock_client_kwargs(self.kwargs))
-        return boto3.client("bedrock", **self.kwargs)
+        return boto3.Session(**self._session_credential_kwargs).client(  # type: ignore[attr-defined]
+            "bedrock", **self._bedrock_client_kwargs(self.kwargs)
+        )
 
     def _get_s3_client(self) -> Any:
         """Return an ``s3`` client for reading batch output files.
@@ -386,12 +405,18 @@ class BedrockProvider(AnyLLM):
         a caller-supplied ``config=``) is stripped before forwarding, otherwise every S3 call
         would fail to authenticate. An explicit ``s3_client=`` constructor kwarg always takes
         precedence.
+
+        When a custom ``client=`` was supplied (so there's no shared ``_boto_session`` to reuse),
+        a fresh session is still built from the caller's explicit credential kwargs; see
+        ``_get_bedrock_control_client`` for why a bare ``boto3.client(...)`` isn't used instead.
         """
         if self._custom_s3_client is not None:
             return self._custom_s3_client
         if self._boto_session is not None:
             return self._boto_session.client("s3", **self._non_bearer_client_kwargs(self.kwargs))
-        return boto3.client("s3", **self.kwargs)
+        return boto3.Session(**self._session_credential_kwargs).client(  # type: ignore[attr-defined]
+            "s3", **self._non_bearer_client_kwargs(self.kwargs)
+        )
 
     @staticmethod
     def _non_bearer_client_kwargs(extra_kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -385,17 +385,18 @@ class BedrockProvider(AnyLLM):
         constructor kwarg always takes precedence.
 
         When a custom ``client=`` was supplied (so there's no shared ``_boto_session`` to reuse),
-        a fresh session is still built from the caller's explicit credential kwargs rather than
-        falling back to a bare, ambient-only ``boto3.client(...)``: otherwise an explicit
-        ``profile_name``/``botocore_session`` would be silently dropped for this client.
+        a fresh session is still built via ``_build_boto_session``, from the caller's explicit
+        credential kwargs and with the same bearer-token scoping as the runtime client would have
+        had: a bare ``boto3.Session(...)`` here would silently drop an explicit
+        ``profile_name``/``botocore_session``, and would leave the bearer ``Config`` forced by
+        ``_bedrock_client_kwargs`` (whenever ``api_key`` was supplied) without a matching scoped
+        token provider, so the request would fall through to an ambient (or missing) token.
         """
         if self._custom_control_client is not None:
             return self._custom_control_client
         if self._boto_session is not None:
             return self._boto_session.client("bedrock", **self._bedrock_client_kwargs(self.kwargs))
-        return boto3.Session(**self._session_credential_kwargs).client(  # type: ignore[attr-defined]
-            "bedrock", **self._bedrock_client_kwargs(self.kwargs)
-        )
+        return self._build_boto_session(self._api_key).client("bedrock", **self._bedrock_client_kwargs(self.kwargs))
 
     def _get_s3_client(self) -> Any:
         """Return an ``s3`` client for reading batch output files.
@@ -406,17 +407,17 @@ class BedrockProvider(AnyLLM):
         would fail to authenticate. An explicit ``s3_client=`` constructor kwarg always takes
         precedence.
 
-        When a custom ``client=`` was supplied (so there's no shared ``_boto_session`` to reuse),
-        a fresh session is still built from the caller's explicit credential kwargs; see
-        ``_get_bedrock_control_client`` for why a bare ``boto3.client(...)`` isn't used instead.
+        When a custom ``client=`` was supplied (so there's no shared ``_boto_session`` to reuse), a
+        fresh session is still built via ``_build_boto_session``; see ``_get_bedrock_control_client``
+        for why a bare ``boto3.client(...)``/``boto3.Session(...)`` isn't used instead. The scoped
+        token provider registered by ``_build_boto_session`` is harmless here since
+        ``_non_bearer_client_kwargs`` already strips ``signature_version="bearer"`` for S3.
         """
         if self._custom_s3_client is not None:
             return self._custom_s3_client
         if self._boto_session is not None:
             return self._boto_session.client("s3", **self._non_bearer_client_kwargs(self.kwargs))
-        return boto3.Session(**self._session_credential_kwargs).client(  # type: ignore[attr-defined]
-            "s3", **self._non_bearer_client_kwargs(self.kwargs)
-        )
+        return self._build_boto_session(self._api_key).client("s3", **self._non_bearer_client_kwargs(self.kwargs))
 
     @staticmethod
     def _non_bearer_client_kwargs(extra_kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -139,13 +139,15 @@ def test_explicit_aws_credentials_satisfy_verification_without_ambient_credentia
     `~/.aws/credentials`, instance role), so it must not be what verification relies on: it should
     fail here since there are no ambient credentials, but verification must still succeed because
     `aws_access_key_id`/`aws_secret_access_key`/`aws_session_token`/`region_name` were passed
-    explicitly to the constructor.
+    explicitly to the constructor. The same explicit kwargs must also be used to build the real
+    session the runtime client is constructed from, not just the verification session.
     """
     monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
 
     def session_factory(**kwargs: Any) -> Mock:
         session = Mock()
         session.get_credentials.return_value = Mock() if kwargs else None
+        session.client.return_value = Mock()
         return session
 
     with (
@@ -159,13 +161,59 @@ def test_explicit_aws_credentials_satisfy_verification_without_ambient_credentia
             region_name="us-west-2",
         )
 
-    verify_call_kwargs = mock_session_cls.call_args_list[0].kwargs
-    assert verify_call_kwargs == {
+    expected_session_kwargs = {
         "aws_access_key_id": "AKIAEXAMPLE",
         "aws_secret_access_key": "secret",
         "aws_session_token": "token",
         "region_name": "us-west-2",
     }
+    # The verification session (first call, in _verify_and_set_api_key) and the runtime session
+    # (second call, in _build_boto_session) must both be built with the explicit kwargs.
+    assert mock_session_cls.call_args_list[0].kwargs == expected_session_kwargs
+    assert mock_session_cls.call_args_list[1].kwargs == expected_session_kwargs
+
+
+def test_profile_name_and_botocore_session_go_to_session_not_client() -> None:
+    """Test that profile_name/botocore_session reach boto3.Session but never Session.client().
+
+    boto3.Session() accepts `profile_name`/`botocore_session`, but `Session.client()` does not;
+    if they leaked into the `.client()` call, real boto3 would raise a TypeError.
+    """
+    fake_botocore_session = Mock()
+
+    def session_factory(**kwargs: Any) -> Mock:
+        session = Mock()
+        session.get_credentials.return_value = Mock()
+        session.client.return_value = Mock()
+        return session
+
+    with (
+        patch("boto3.Session", side_effect=session_factory) as mock_session_cls,
+        patch("any_llm.providers.bedrock.bedrock._convert_response"),
+    ):
+        provider = BedrockProvider(profile_name="my-profile", botocore_session=fake_botocore_session)
+
+    expected_session_kwargs = {"profile_name": "my-profile", "botocore_session": fake_botocore_session}
+    for call in mock_session_cls.call_args_list:
+        assert call.kwargs == expected_session_kwargs
+
+    assert provider._boto_session is not None
+    client_call_kwargs = provider._boto_session.client.call_args.kwargs
+    assert "profile_name" not in client_call_kwargs
+    assert "botocore_session" not in client_call_kwargs
+
+
+def test_profile_name_without_resolvable_credentials_raises_missing_api_key_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that an unresolvable profile_name still raises MissingApiKeyError (no api_key either)."""
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+    with patch("boto3.Session") as mock_session_cls:
+        mock_session_cls.return_value.get_credentials.return_value = None
+
+        with pytest.raises(MissingApiKeyError):
+            BedrockProvider(profile_name="nonexistent-profile")
 
 
 def test_no_credentials_and_no_api_key_raises_missing_api_key_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -12,7 +12,7 @@ import pytest
 from botocore.tokens import ScopedEnvTokenProvider
 from pydantic import BaseModel
 
-from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
+from any_llm.exceptions import InvalidRequestError, MissingApiKeyError, UnsupportedParameterError
 from any_llm.providers.bedrock import BedrockProvider
 from any_llm.providers.bedrock.utils import (
     _STRUCTURED_OUTPUT_TOOL_NAME,
@@ -128,6 +128,55 @@ def test_no_api_key_skips_bearer_token_setup(monkeypatch: pytest.MonkeyPatch) ->
     assert provider._boto_session is not None
     provider._boto_session._session.register_component.assert_not_called()
     assert "config" not in mock_client_call.call_args[1]
+
+
+def test_explicit_aws_credentials_satisfy_verification_without_ambient_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that explicit AWS credential kwargs satisfy verification (regression test for #1183).
+
+    A bare `boto3.Session()` only resolves credentials from the ambient default chain (env vars,
+    `~/.aws/credentials`, instance role), so it must not be what verification relies on: it should
+    fail here since there are no ambient credentials, but verification must still succeed because
+    `aws_access_key_id`/`aws_secret_access_key`/`aws_session_token`/`region_name` were passed
+    explicitly to the constructor.
+    """
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+    def session_factory(**kwargs: Any) -> Mock:
+        session = Mock()
+        session.get_credentials.return_value = Mock() if kwargs else None
+        return session
+
+    with (
+        patch("boto3.Session", side_effect=session_factory) as mock_session_cls,
+        patch("any_llm.providers.bedrock.bedrock._convert_response"),
+    ):
+        BedrockProvider(
+            aws_access_key_id="AKIAEXAMPLE",
+            aws_secret_access_key="secret",  # noqa: S106
+            aws_session_token="token",  # noqa: S106
+            region_name="us-west-2",
+        )
+
+    verify_call_kwargs = mock_session_cls.call_args_list[0].kwargs
+    assert verify_call_kwargs == {
+        "aws_access_key_id": "AKIAEXAMPLE",
+        "aws_secret_access_key": "secret",
+        "aws_session_token": "token",
+        "region_name": "us-west-2",
+    }
+
+
+def test_no_credentials_and_no_api_key_raises_missing_api_key_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that MissingApiKeyError is still raised with neither credentials nor an api_key."""
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+    with patch("boto3.Session") as mock_session_cls:
+        mock_session_cls.return_value.get_credentials.return_value = None
+
+        with pytest.raises(MissingApiKeyError):
+            BedrockProvider()
 
 
 def test_completion_with_timeout_builds_distinct_client_with_timeout_config() -> None:

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -4,11 +4,13 @@ import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, get_args
 from unittest.mock import Mock, patch
 
 import botocore.session
 import pytest
+from botocore.exceptions import ProfileNotFound
 from botocore.tokens import ScopedEnvTokenProvider
 from pydantic import BaseModel
 
@@ -177,7 +179,9 @@ def test_profile_name_and_botocore_session_go_to_session_not_client() -> None:
     """Test that profile_name/botocore_session reach boto3.Session but never Session.client().
 
     boto3.Session() accepts `profile_name`/`botocore_session`, but `Session.client()` does not;
-    if they leaked into the `.client()` call, real boto3 would raise a TypeError.
+    if they leaked into the `.client()` call, real boto3 would raise a TypeError. Checked for the
+    runtime client as well as the control-plane and S3 clients, which are built from the same
+    kwargs.
     """
     fake_botocore_session = Mock()
 
@@ -192,28 +196,39 @@ def test_profile_name_and_botocore_session_go_to_session_not_client() -> None:
         patch("any_llm.providers.bedrock.bedrock._convert_response"),
     ):
         provider = BedrockProvider(profile_name="my-profile", botocore_session=fake_botocore_session)
+        control_client = provider._get_bedrock_control_client()
+        s3_client = provider._get_s3_client()
 
     expected_session_kwargs = {"profile_name": "my-profile", "botocore_session": fake_botocore_session}
     for call in mock_session_cls.call_args_list:
         assert call.kwargs == expected_session_kwargs
 
     assert provider._boto_session is not None
-    client_call_kwargs = provider._boto_session.client.call_args.kwargs
-    assert "profile_name" not in client_call_kwargs
-    assert "botocore_session" not in client_call_kwargs
+    # The control-plane and S3 clients are built from the same shared `_boto_session`, so they
+    # share its `.client` mock; every call recorded on it (runtime, control, S3) must be free of
+    # session-only kwargs.
+    assert control_client is provider._boto_session.client.return_value
+    assert s3_client is provider._boto_session.client.return_value
+    for call_args in provider._boto_session.client.call_args_list:
+        assert "profile_name" not in call_args.kwargs
+        assert "botocore_session" not in call_args.kwargs
 
 
-def test_profile_name_without_resolvable_credentials_raises_missing_api_key_error(
-    monkeypatch: pytest.MonkeyPatch,
+def test_profile_name_resolution_uses_real_botocore_and_raises_profile_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Test that an unresolvable profile_name still raises MissingApiKeyError (no api_key either)."""
+    """Test that a nonexistent `profile_name` surfaces botocore's own `ProfileNotFound`.
+
+    Exercises real botocore profile resolution (no `boto3.Session` mocking), isolated from the
+    real environment via an empty, temporary AWS config/credentials directory, so a nonexistent
+    profile can't accidentally resolve to a real ambient one.
+    """
     monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "credentials"))
 
-    with patch("boto3.Session") as mock_session_cls:
-        mock_session_cls.return_value.get_credentials.return_value = None
-
-        with pytest.raises(MissingApiKeyError):
-            BedrockProvider(profile_name="nonexistent-profile")
+    with pytest.raises(ProfileNotFound):
+        BedrockProvider(profile_name="nonexistent-profile")
 
 
 def test_no_credentials_and_no_api_key_raises_missing_api_key_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/providers/test_bedrock_batch.py
+++ b/tests/unit/providers/test_bedrock_batch.py
@@ -874,6 +874,54 @@ async def test_control_and_s3_client_build_session_from_credentials_with_custom_
 
 
 @pytest.mark.asyncio
+async def test_control_client_fallback_registers_scoped_bearer_token_with_custom_runtime_client() -> None:
+    """The control-client fallback (custom `client=`, no `control_client=`) is bearer-token-aware.
+
+    It must build its session via `_build_boto_session` (which registers a scoped token provider
+    and gets its `Config` forced to `signature_version="bearer"` via `_bedrock_client_kwargs`),
+    not a bare `boto3.Session(...)`: otherwise the forced bearer `Config` would have no matching
+    token source, and the request would fall through to an ambient (or missing) token.
+    """
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(client=MagicMock(), api_key="test-token")
+
+        fallback_session = mock_boto3.Session.return_value
+        provider._get_bedrock_control_client()
+
+        component_name, token_provider = fallback_session._session.register_component.call_args[0]
+        assert component_name == "token_provider"
+        assert token_provider.environ == {"AWS_BEARER_TOKEN_BEDROCK": "test-token"}
+
+        call_kwargs = fallback_session.client.call_args[1]
+        assert call_kwargs["config"].signature_version == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_control_client_fallback_skips_bearer_setup_without_api_key() -> None:
+    """Without an api_key, the control-client fallback doesn't force bearer auth either.
+
+    Ambient (env-var) bearer tokens aren't separately handled for a custom-client provider: a
+    custom `client=` skips credential verification/resolution entirely (see
+    `_verify_and_set_api_key`), so this behaves the same whether `AWS_BEARER_TOKEN_BEDROCK` is
+    set in the real environment or not, exactly like the runtime client in that case.
+    """
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(client=MagicMock())
+
+        fallback_session = mock_boto3.Session.return_value
+        provider._get_bedrock_control_client()
+
+        fallback_session._session.register_component.assert_not_called()
+        assert "config" not in fallback_session.client.call_args[1]
+
+
+@pytest.mark.asyncio
 async def test_control_client_inherits_bearer_session() -> None:
     """The control-plane client is built from the same bearer-token-aware session as the runtime client."""
     pytest.importorskip("boto3")

--- a/tests/unit/providers/test_bedrock_batch.py
+++ b/tests/unit/providers/test_bedrock_batch.py
@@ -850,11 +850,13 @@ async def test_control_and_s3_client_overrides_bypass_shared_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_control_and_s3_client_fall_back_to_bare_boto3_with_custom_runtime_client() -> None:
-    """With a custom runtime `client=` and no control/S3 overrides, fall back to a bare boto3 client.
+async def test_control_and_s3_client_build_session_from_credentials_with_custom_runtime_client() -> None:
+    """With a custom runtime `client=` and no control/S3 overrides, still honor explicit credentials.
 
-    any-llm doesn't own the custom client's session, so it can't build a matching control-plane
-    or S3 client from it; this preserves the pre-existing behavior for that case.
+    any-llm doesn't own the custom client's session, so it can't reuse it for the control-plane or
+    S3 client, but it must still build them from a session constructed with the caller's explicit
+    credential kwargs (e.g. `region_name`, `profile_name`) rather than a bare, ambient-only
+    `boto3.client(...)`, which would silently drop those kwargs.
     """
     pytest.importorskip("boto3")
     from any_llm.providers.bedrock.bedrock import BedrockProvider
@@ -865,8 +867,10 @@ async def test_control_and_s3_client_fall_back_to_bare_boto3_with_custom_runtime
         provider._get_bedrock_control_client()
         provider._get_s3_client()
 
-        mock_boto3.client.assert_any_call("bedrock", region_name="us-west-2")
-        mock_boto3.client.assert_any_call("s3", region_name="us-west-2")
+        mock_boto3.Session.assert_any_call(region_name="us-west-2")
+        mock_session_client = mock_boto3.Session.return_value.client
+        mock_session_client.assert_any_call("bedrock", region_name="us-west-2")
+        mock_session_client.assert_any_call("s3", region_name="us-west-2")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_bedrock_batch.py
+++ b/tests/unit/providers/test_bedrock_batch.py
@@ -922,6 +922,32 @@ async def test_control_client_fallback_skips_bearer_setup_without_api_key() -> N
 
 
 @pytest.mark.asyncio
+async def test_s3_client_fallback_registers_token_provider_but_not_bearer_auth_with_custom_runtime_client() -> None:
+    """The S3-client fallback (custom `client=`, no `s3_client=`) still builds via `boto3.Session`.
+
+    A scoped token provider is still registered on it when an `api_key` is supplied (harmless,
+    since S3 doesn't support bearer auth), but `_non_bearer_client_kwargs` must ensure the S3
+    client call itself never receives `signature_version="bearer"`, unlike the control-plane
+    fallback.
+    """
+    pytest.importorskip("boto3")
+    from any_llm.providers.bedrock.bedrock import BedrockProvider
+
+    with patch("any_llm.providers.bedrock.bedrock.boto3") as mock_boto3:
+        provider = BedrockProvider(client=MagicMock(), api_key="test-token")
+
+        fallback_session = mock_boto3.Session.return_value
+        provider._get_s3_client()
+
+        component_name, token_provider = fallback_session._session.register_component.call_args[0]
+        assert component_name == "token_provider"
+        assert token_provider.environ == {"AWS_BEARER_TOKEN_BEDROCK": "test-token"}
+
+        call_kwargs = fallback_session.client.call_args[1]
+        assert "config" not in call_kwargs
+
+
+@pytest.mark.asyncio
 async def test_control_client_inherits_bearer_session() -> None:
     """The control-plane client is built from the same bearer-token-aware session as the runtime client."""
     pytest.importorskip("boto3")


### PR DESCRIPTION
## Description

`BedrockProvider._verify_and_set_api_key` built a bare `boto3.Session()` to probe whether AWS credentials exist. That only resolves boto3's *ambient* default credential chain (env vars, `~/.aws/credentials`, SSO cache, instance role) and ignores `aws_access_key_id`/`aws_secret_access_key`/`aws_session_token`/`region_name`/`profile_name` kwargs passed explicitly to `AnyLLM.create(...)`. As a result, construction failed with `MissingApiKeyError` ("No bedrock API key provided...") even when valid AWS credentials were supplied explicitly — inconsistently across machines, depending on whether unrelated ambient credentials happened to be present.

Per [AWS's Bedrock API keys docs](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html), Bedrock supports two independent, non-fallback auth mechanisms: a bearer-token API key, or standard AWS credentials. This fix makes the verification step correctly accept the latter when passed explicitly, by capturing the `boto3.Session`-relevant kwargs at construction time and building the verification session with them, matching how the real client is later constructed.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1183

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Investigated and reproduced the reported bug, then implemented and tested the fix.

- [ ] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AWS Bedrock now correctly validates explicitly provided credentials, regions and profiles.
  * Credentials and regional settings are applied consistently across AWS service connections, including custom runtime clients.
  * Session-specific options are handled correctly and are not passed as unsupported client settings.
  * Clearer errors are provided when credentials are missing or cannot be resolved.
  * Bearer-token authentication no longer triggers unnecessary AWS credential lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->