### PR TITLE
feat(openrouter): enable Responses API support

### DIFF
--- a/src/any_llm/providers/openrouter/openrouter.py
+++ b/src/any_llm/providers/openrouter/openrouter.py
@@ -18,7 +18,12 @@ class OpenrouterProvider(BaseOpenAIProvider):
 
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True
-    SUPPORTS_RESPONSES = False
+    # OpenRouter serves a native, OpenAI-compatible /responses endpoint, so the inherited
+    # BaseOpenAIProvider._aresponses passthrough works as-is (no override needed here). One
+    # caveat: OpenRouter's Responses API is stateless, so it rejects requests where the caller
+    # explicitly passes store=True or previous_response_id. Those fields default to None and are
+    # omitted from the request otherwise, so this only surfaces for callers who opt into them.
+    SUPPORTS_RESPONSES = True
     SUPPORTS_COMPLETION_REASONING = True
     SUPPORTS_EMBEDDING = True
     # OpenRouter does not expose a moderation endpoint.

--- a/tests/unit/providers/test_openrouter_provider.py
+++ b/tests/unit/providers/test_openrouter_provider.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from any_llm.providers.openrouter import OpenrouterProvider
 from any_llm.providers.openrouter.utils import _convert_models_list
@@ -13,6 +14,27 @@ from any_llm.types.completion import (
     Reasoning,
 )
 from any_llm.types.model import Model
+from any_llm.types.responses import Response
+
+
+def _make_response(text: str) -> Response:
+    message = ResponseOutputMessage(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[message],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
 
 
 @pytest.mark.asyncio
@@ -255,6 +277,65 @@ async def test_streaming_with_reasoning() -> None:
         assert call_args.kwargs["stream"] is True
         assert "extra_body" in call_args.kwargs
         assert call_args.kwargs["extra_body"]["reasoning"]["effort"] == "high"
+
+
+def test_openrouter_supports_responses() -> None:
+    """OpenRouter now serves a native /responses endpoint, so the flag should be enabled."""
+    assert OpenrouterProvider.SUPPORTS_RESPONSES is True
+
+
+@pytest.mark.asyncio
+async def test_aresponses_calls_native_responses_endpoint() -> None:
+    """aresponses() reaches OpenRouter's native client.responses.create, not a conversion shim."""
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.responses.create = AsyncMock(return_value=_make_response("Paris"))
+
+        provider = OpenrouterProvider(api_key="sk-test")
+        result = await provider.aresponses("openai/gpt-5-nano", "What is the capital of France?")
+
+        mock_client.responses.create.assert_awaited_once()
+        call_kwargs = mock_client.responses.create.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-5-nano"
+        assert call_kwargs["input"] == "What is the capital of France?"
+        assert isinstance(result, Response)
+
+
+@pytest.mark.asyncio
+async def test_aresponses_omits_store_and_previous_response_id_when_not_passed() -> None:
+    """OpenRouter's Responses API is stateless and rejects store/previous_response_id.
+
+    Both fields default to None and are excluded from the request unless the caller opts in,
+    so the common case must not send them.
+    """
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.responses.create = AsyncMock(return_value=_make_response("Paris"))
+
+        provider = OpenrouterProvider(api_key="sk-test")
+        await provider.aresponses("openai/gpt-5-nano", "hi")
+
+        call_kwargs = mock_client.responses.create.call_args.kwargs
+        assert "store" not in call_kwargs
+        assert "previous_response_id" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_aresponses_forwards_store_when_explicitly_set() -> None:
+    """A caller who explicitly opts into store=True still has it forwarded as-is.
+
+    OpenRouter will reject this upstream (stateless API); any-llm does not add bespoke
+    validation for it, matching how other unsupported-parameter cases are handled.
+    """
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.responses.create = AsyncMock(return_value=_make_response("Paris"))
+
+        provider = OpenrouterProvider(api_key="sk-test")
+        await provider.aresponses("openai/gpt-5-nano", "hi", store=True)
+
+        call_kwargs = mock_client.responses.create.call_args.kwargs
+        assert call_kwargs["store"] is True
 
 
 def test_openrouter_remaps_max_tokens_to_max_completion_tokens() -> None:

--- a/tests/unit/providers/test_openrouter_provider.py
+++ b/tests/unit/providers/test_openrouter_provider.py
@@ -338,6 +338,24 @@ async def test_aresponses_forwards_store_when_explicitly_set() -> None:
         assert call_kwargs["store"] is True
 
 
+@pytest.mark.asyncio
+async def test_aresponses_forwards_previous_response_id_when_explicitly_set() -> None:
+    """A caller who explicitly opts into previous_response_id still has it forwarded as-is.
+
+    OpenRouter will reject this upstream (stateless API); any-llm does not add bespoke
+    validation for it, matching how other unsupported-parameter cases are handled.
+    """
+    with patch("any_llm.providers.openai.base.AsyncOpenAI") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.responses.create = AsyncMock(return_value=_make_response("Paris"))
+
+        provider = OpenrouterProvider(api_key="sk-test")
+        await provider.aresponses("openai/gpt-5-nano", "hi", previous_response_id="resp-0")
+
+        call_kwargs = mock_client.responses.create.call_args.kwargs
+        assert call_kwargs["previous_response_id"] == "resp-0"
+
+
 def test_openrouter_remaps_max_tokens_to_max_completion_tokens() -> None:
     params = CompletionParams(model_id="openai/gpt-4", messages=[{"role": "user", "content": "Hello"}], max_tokens=8192)
     result = OpenrouterProvider._convert_completion_params(params)


### PR DESCRIPTION
## Description

OpenRouter now serves a native, OpenAI-compatible `/responses` endpoint ([docs](https://openrouter.ai/docs/api/reference/responses/overview)) described as "a drop-in replacement for OpenAI's Responses API." This PR flips `OpenrouterProvider.SUPPORTS_RESPONSES` to `True`, so `OpenrouterProvider` relies on the inherited `BaseOpenAIProvider._aresponses` native passthrough — the same pattern already used by `openai`, `gmi`, `meta`, `fireworks`, and `otari`. No conversion shim is needed since the endpoint genuinely exists.

One caveat: OpenRouter's Responses API is stateless and rejects requests that set `store=True` or `previous_response_id`. Both fields default to `None` in `ResponsesParams` and are omitted from the request unless a caller explicitly opts in, so the common case is unaffected; only callers who explicitly pass those fields will see OpenRouter's own rejection surface as an upstream API error (consistent with how other unsupported-parameter cases are handled elsewhere in the codebase).

Added unit tests in `tests/unit/providers/test_openrouter_provider.py` covering the native passthrough call and the `store`/`previous_response_id` omission/forwarding behavior. `tests/integration/test_responses.py` already parametrizes over every provider and will automatically pick up OpenRouter now that the flag is flipped, no test-file changes needed there.

**Note on verification:** I don't have a local `OPENROUTER_API_KEY`, so I was not able to run the integration suite against the real endpoint myself. Could a maintainer apply the `run-integration-tests` label (or run `pytest tests/integration/test_responses.py -k openrouter -v` locally) to confirm the existing test model (`google/gemini-2.5-flash-lite`, already used for OpenRouter's other tests) works through OpenRouter's Responses endpoint? If it doesn't, the fix is a small model-map override in `tests/conftest.py`/`tests/integration/test_responses.py`, not a change to the provider code itself.

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #1141

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue. (unit tests pass locally; integration test against the real OpenRouter endpoint needs a maintainer with an `OPENROUTER_API_KEY` or the `run-integration-tests` label, see note above)
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (the provider support matrix in `docs/providers.md` is CI-generated from `SUPPORTS_RESPONSES`, no manual doc edit needed)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Investigated the base-class Responses/Completions architecture and OpenRouter's current API docs before making the change; implementation is a minimal flag flip following an existing codebase pattern (see `GmiProvider` for comparison).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenAI-compatible Responses API through OpenRouter.
  * Responses can now be created using the standard API interface.
  * Requests remain stateless by default, while explicitly provided response storage and continuation options are handled consistently.
* **Bug Fixes**
  * Improved Responses API request handling when optional parameters are omitted or supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->