### PR TITLE
test(integration): add sync streaming coverage for completion and messages

### DIFF
--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 from typing import TYPE_CHECKING, Any
@@ -118,6 +119,15 @@ class XaiProvider(AnyLLM):
 
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
+        # grpc.aio's channel construction binds to "the current event loop" for this
+        # thread via asyncio.get_event_loop(). That call raises once a previous loop
+        # (e.g. from an earlier asyncio.run()) has been created and closed on this
+        # thread, which _init_client can hit when constructed synchronously and
+        # outside of any active event loop.
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
         self.client = XaiAsyncClient(api_key=api_key, **kwargs)
 
     @override

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import json
 from typing import TYPE_CHECKING, Any
@@ -34,6 +35,20 @@ if TYPE_CHECKING:
     from any_llm.types.model import Model
 
 
+def _close_client(client: XaiAsyncClient) -> None:
+    """Release the grpc sockets held by a client whose event loop has already closed.
+
+    XaiAsyncClient.close() is a coroutine and its channels belong to a loop that is gone, so
+    there is nothing left to await it on; the cygrpc channel underneath is what actually
+    holds the socket and closes synchronously. Cleanup must never break a request, so if
+    either library moves these internals this degrades to the previous behavior, an idle
+    socket held until the process exits, rather than raising.
+    """
+    for channel in (client._api_channel, client._management_channel):
+        with contextlib.suppress(Exception):
+            channel._channel.close()  # type: ignore[union-attr]
+
+
 class XaiProvider(AnyLLM):
     API_BASE = "https://api.x.ai/v1"
     ENV_API_KEY_NAME = "XAI_API_KEY"
@@ -57,8 +72,6 @@ class XaiProvider(AnyLLM):
     TIMEOUT_SUPPORT = "unsupported"
 
     MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
-
-    client: XaiAsyncClient
 
     @staticmethod
     @override
@@ -119,16 +132,49 @@ class XaiProvider(AnyLLM):
 
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
-        # grpc.aio's channel construction binds to "the current event loop" for this
-        # thread via asyncio.get_event_loop(). That call raises once a previous loop
-        # (e.g. from an earlier asyncio.run()) has been created and closed on this
-        # thread, which _init_client can hit when constructed synchronously and
-        # outside of any active event loop.
+        # The xAI SDK builds its grpc.aio channels eagerly, and grpc binds a channel to
+        # whatever event loop is current in the constructing thread. The sync API runs each
+        # request on a fresh worker loop (see any_llm.utils.aio), so a client built here
+        # would always belong to a different loop than the one driving the RPC, and every
+        # call would fail with "attached to a different loop". Defer construction instead,
+        # keyed by loop, so the channel always belongs to the loop that will use it.
+        self._client_kwargs: dict[str, Any] = {"api_key": api_key, **kwargs}
+        self._clients_by_loop: dict[asyncio.AbstractEventLoop, XaiAsyncClient] = {}
+
+    @property
+    def client(self) -> XaiAsyncClient:
+        """The xAI client for the running event loop, built on first use.
+
+        Accessing this outside of async code raises: the grpc channel underneath can only
+        be driven by the loop it was created on, so there is no correct client to hand back
+        when no loop is running.
+        """
         try:
-            asyncio.get_event_loop()
-        except RuntimeError:
-            asyncio.set_event_loop(asyncio.new_event_loop())
-        self.client = XaiAsyncClient(api_key=api_key, **kwargs)
+            loop = asyncio.get_running_loop()
+        except RuntimeError as exc:
+            msg = (
+                "XaiProvider.client is bound to the running event loop, so it is only available from async code. "
+                "Use the sync API (completion, list_models) or await the async one instead of touching the client."
+            )
+            raise RuntimeError(msg) from exc
+
+        self._discard_clients_for_closed_loops()
+
+        client = self._clients_by_loop.get(loop)
+        if client is None:
+            client = XaiAsyncClient(**self._client_kwargs)
+            self._clients_by_loop[loop] = client
+        return client
+
+    def _discard_clients_for_closed_loops(self) -> None:
+        """Drop clients whose loop has been closed, releasing their grpc socket.
+
+        The sync API gives every request a throwaway loop, so a provider used from sync code
+        would otherwise accumulate one live channel per call for its whole life. A closed
+        loop can never serve another request, so its client is dead weight.
+        """
+        for loop in [loop for loop in self._clients_by_loop if loop.is_closed()]:
+            _close_client(self._clients_by_loop.pop(loop))
 
     @override
     async def _acompletion(

--- a/tests/integration/test_messages.py
+++ b/tests/integration/test_messages.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
 import httpx
@@ -74,6 +74,50 @@ async def test_messages_streaming(
 
     event_types: list[str] = []
     async for event in result:
+        assert isinstance(event, MessageStreamEvent)
+        event_types.append(event.type)
+
+    assert "message_start" in event_types
+    assert "message_stop" in event_types
+
+
+def test_messages_streaming_sync(
+    provider: LLMProvider,
+    provider_model_map: dict[LLMProvider, str],
+    provider_client_config: dict[LLMProvider, dict[str, Any]],
+) -> None:
+    """Test that the sync Messages streaming path works for supported providers.
+
+    Mirrors test_messages_streaming, but drives the sync `messages()` wrapper
+    instead of `amessages()`. This is the path that regressed in #1253 (the
+    response was opened and consumed on two different event loops); see #1260.
+    """
+    try:
+        llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
+        if not llm.SUPPORTS_COMPLETION:
+            pytest.skip(f"{provider.value} does not support completion, skipping")
+        if not llm.SUPPORTS_COMPLETION_STREAMING:
+            pytest.skip(f"{provider.value} does not support streaming")
+        model_id = provider_model_map[provider]
+        result = llm.messages(
+            model=model_id,
+            messages=[{"role": "user", "content": "Say hello in exactly one word."}],
+            max_tokens=64,
+            stream=True,
+        )
+    except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
+        pytest.skip(f"{provider.value} API key not provided, skipping")
+    except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
+        if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
+            pytest.skip("Local Model host is not set up, skipping")
+        raise
+
+    assert isinstance(result, Iterator)
+
+    event_types: list[str] = []
+    for event in result:
         assert isinstance(event, MessageStreamEvent)
         event_types.append(event.type)
 

--- a/tests/integration/test_messages.py
+++ b/tests/integration/test_messages.py
@@ -105,6 +105,15 @@ def test_messages_streaming_sync(
             max_tokens=64,
             stream=True,
         )
+        assert isinstance(result, Iterator)
+
+        # The sync bridge opens the connection lazily: request/auth/connection
+        # errors surface from the first next() here, not from the messages() call
+        # above, so the skip guards must cover this loop too.
+        event_types: list[str] = []
+        for event in result:
+            assert isinstance(event, MessageStreamEvent)
+            event_types.append(event.type)
     except MissingApiKeyError:
         if provider in EXPECTED_PROVIDERS:
             raise
@@ -113,13 +122,6 @@ def test_messages_streaming_sync(
         if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
             pytest.skip("Local Model host is not set up, skipping")
         raise
-
-    assert isinstance(result, Iterator)
-
-    event_types: list[str] = []
-    for event in result:
-        assert isinstance(event, MessageStreamEvent)
-        event_types.append(event.type)
 
     assert "message_start" in event_types
     assert "message_stop" in event_types

--- a/tests/integration/test_openai_compatible.py
+++ b/tests/integration/test_openai_compatible.py
@@ -55,6 +55,26 @@ async def test_custom_path_streaming() -> None:
     assert content
 
 
+def test_custom_path_streaming_sync() -> None:
+    """Mirrors test_custom_path_streaming, but drives the sync `completion()` wrapper.
+
+    This is the custom/OpenAI-compatible path where #1253 actually manifested: the
+    sync streaming bridge opened the response on one worker event loop and consumed
+    it on another, which httpx/anyio's loop-bound objects don't tolerate.
+    """
+    llm = _create_custom_provider()
+    chunks = []
+    for chunk in llm.completion(
+        model=MODEL_ID,
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=True,
+    ):
+        assert isinstance(chunk, ChatCompletionChunk)
+        chunks.append(chunk)
+    content = "".join(chunk.choices[0].delta.content or "" for chunk in chunks if chunk.choices)
+    assert content
+
+
 @pytest.mark.asyncio
 async def test_custom_path_list_models() -> None:
     llm = _create_custom_provider()

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -58,3 +58,53 @@ async def test_streaming_completion_async(
         if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
             pytest.skip("Local Model host is not set up, skipping")
         raise
+
+
+def test_streaming_completion_sync(
+    provider: LLMProvider,
+    provider_model_map: dict[LLMProvider, str],
+    provider_client_config: dict[LLMProvider, dict[str, Any]],
+) -> None:
+    """Test that the sync streaming completion path works for supported providers.
+
+    Mirrors test_streaming_completion_async, but drives the sync `completion()`
+    wrapper instead of `acompletion()`. The sync streaming bridge (opening the
+    response and consuming it on the same worker event loop) has no dedicated
+    integration coverage otherwise; see #1253/#1260.
+    """
+    try:
+        llm = AnyLLM.create(provider, **provider_client_config.get(provider, {}))
+        if not llm.SUPPORTS_COMPLETION_STREAMING:
+            pytest.skip(f"{provider.value} does not support streaming completion")
+        model_id = provider_model_map[provider]
+        output = ""
+        reasoning = ""
+        num_chunks = 0
+        stream = llm.completion(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant that exactly follows the user request."},
+                {"role": "user", "content": "Say the exact phrase:'Hello World' with no fancy formatting"},
+            ],
+            stream=True,
+        )
+
+        for result in stream:
+            num_chunks += 1
+            assert isinstance(result, ChatCompletionChunk)
+            if len(result.choices) > 0:
+                output += result.choices[0].delta.content or ""
+                if result.choices[0].delta.reasoning:
+                    reasoning += result.choices[0].delta.reasoning.content or ""
+        assert num_chunks >= 1, f"Expected at least 1 chunk, got {num_chunks}"
+        assert "hello world" in output.lower()
+    except MissingApiKeyError:
+        if provider in EXPECTED_PROVIDERS:
+            raise
+        pytest.skip(f"{provider.value} API key not provided, skipping")
+    except UnsupportedParameterError:
+        pytest.skip(f"Streaming is not supported for {provider.value}")
+    except (httpx.HTTPStatusError, httpx.ConnectError, APIConnectionError):
+        if provider in LOCAL_PROVIDERS and provider not in EXPECTED_PROVIDERS:
+            pytest.skip("Local Model host is not set up, skipping")
+        raise

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -169,3 +170,28 @@ def test_per_request_timeout_is_declared_unsupported() -> None:
     from any_llm.providers.xai.xai import XaiProvider
 
     assert XaiProvider.TIMEOUT_SUPPORT == "unsupported"
+
+
+def test_client_construction_survives_a_closed_event_loop_on_this_thread() -> None:
+    """Constructing the provider synchronously, after a prior asyncio.run() has
+    closed this thread's event loop, must not raise.
+
+    grpc.aio's channel construction binds to "the current event loop" for the
+    calling thread via asyncio.get_event_loop(). On Python's default policy that
+    call raises RuntimeError once a previously-created loop on this thread has
+    been closed and no new one has been set - exactly what happens when a sync
+    caller constructs XaiProvider directly (e.g. AnyLLM.create("xai", ...)
+    outside of any active event loop, as any-llm's own sync integration tests do
+    after an earlier async test has run on the same worker). This deliberately
+    does not mock XaiAsyncClient: the bug is in the real grpc.aio channel
+    construction, and a mock would hide it.
+    """
+    from any_llm.providers.xai.xai import XaiProvider
+
+    async def _noop() -> None:
+        return None
+
+    asyncio.run(_noop())
+
+    provider = XaiProvider(api_key="test-api-key")
+    assert provider.client is not None

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -172,19 +172,14 @@ def test_per_request_timeout_is_declared_unsupported() -> None:
     assert XaiProvider.TIMEOUT_SUPPORT == "unsupported"
 
 
-def test_client_construction_survives_a_closed_event_loop_on_this_thread() -> None:
-    """Constructing the provider synchronously, after a prior asyncio.run() has
-    closed this thread's event loop, must not raise.
+def test_construction_outside_a_running_loop_does_not_raise() -> None:
+    """Constructing the provider synchronously, after a prior asyncio.run() closed this
+    thread's loop, must not raise.
 
-    grpc.aio's channel construction binds to "the current event loop" for the
-    calling thread via asyncio.get_event_loop(). On Python's default policy that
-    call raises RuntimeError once a previously-created loop on this thread has
-    been closed and no new one has been set - exactly what happens when a sync
-    caller constructs XaiProvider directly (e.g. AnyLLM.create("xai", ...)
-    outside of any active event loop, as any-llm's own sync integration tests do
-    after an earlier async test has run on the same worker). This deliberately
-    does not mock XaiAsyncClient: the bug is in the real grpc.aio channel
-    construction, and a mock would hide it.
+    This deliberately does not mock XaiAsyncClient. Building the real grpc.aio channel here
+    is what used to fail: grpc resolves "the current event loop" for the calling thread at
+    channel construction, and that raises once a previous loop has been created and closed.
+    Nothing loop-bound is built at construction now, so the state is harmless.
     """
     from any_llm.providers.xai.xai import XaiProvider
 
@@ -193,5 +188,86 @@ def test_client_construction_survives_a_closed_event_loop_on_this_thread() -> No
 
     asyncio.run(_noop())
 
+    XaiProvider(api_key="test-api-key")
+
+
+def test_client_is_built_on_the_loop_that_will_drive_it() -> None:
+    """The client must be constructed on the loop that will run the RPC, not on whatever
+    loop happened to be around at provider construction.
+
+    grpc binds a channel to the loop that is current when it is built, so building it
+    anywhere else fails at the first call with "attached to a different loop". That is what
+    broke every sync xAI request, since the sync bridge runs each one on a fresh worker loop.
+    """
+    from any_llm.providers.xai.xai import XaiProvider
+
+    construction_loops: list[asyncio.AbstractEventLoop] = []
+
+    def _record(**_: Any) -> MagicMock:
+        construction_loops.append(asyncio.get_running_loop())
+        return MagicMock()
+
+    with patch("any_llm.providers.xai.xai.XaiAsyncClient", side_effect=_record):
+        provider = XaiProvider(api_key="test-api-key")
+        assert construction_loops == []
+
+        async def _use() -> None:
+            _ = provider.client
+            assert construction_loops == [asyncio.get_running_loop()]
+
+        asyncio.run(_use())
+
+
+def test_each_event_loop_gets_its_own_client() -> None:
+    """A provider reused across sync calls sees a new worker loop each time, so it needs a
+    new client each time; within one loop it must reuse the channel rather than rebuild it.
+    """
+    from any_llm.providers.xai.xai import XaiProvider
+
     provider = XaiProvider(api_key="test-api-key")
-    assert provider.client is not None
+    clients = []
+
+    async def _collect() -> None:
+        clients.append(provider.client)
+        assert provider.client is clients[-1]
+
+    asyncio.run(_collect())
+    asyncio.run(_collect())
+
+    assert clients[0] is not clients[1]
+
+
+def test_clients_for_closed_loops_are_dropped_and_closed() -> None:
+    """Sync callers get a throwaway loop per request, so the per-loop cache has to shed the
+    dead ones. Left alone it would hold a live grpc channel, and its socket, per call made
+    for the whole life of the provider.
+    """
+    from any_llm.providers.xai.xai import XaiProvider
+
+    built: list[MagicMock] = []
+
+    def _build(**_: Any) -> MagicMock:
+        built.append(MagicMock())
+        return built[-1]
+
+    with patch("any_llm.providers.xai.xai.XaiAsyncClient", side_effect=_build):
+        provider = XaiProvider(api_key="test-api-key")
+
+        async def _use() -> None:
+            _ = provider.client
+
+        asyncio.run(_use())
+        asyncio.run(_use())
+
+        assert len(built) == 2
+        assert len(provider._clients_by_loop) == 1
+        built[0]._api_channel._channel.close.assert_called_once()
+
+
+def test_client_outside_async_code_raises_a_clear_error() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    provider = XaiProvider(api_key="test-api-key")
+
+    with pytest.raises(RuntimeError, match="bound to the running event loop"):
+        _ = provider.client


### PR DESCRIPTION
## Description
The integration suite only ever exercised the async (`a`-prefixed) streaming methods — `acompletion()`, `amessages()`, `aresponses()` — so nothing covered the sync bridge (`run_async_in_sync()` / `async_coro_to_sync_iter()`) against a real streaming HTTP response. That gap is exactly why #1253 shipped without CI catching it: the bug was specific to the sync bridge opening and consuming the response on two different event loops.

Adds sync twins of the existing async streaming integration tests, reusing the same fixtures, `MissingApiKeyError`/`UnsupportedParameterError` skip guards, and assertions, just swapping the call site from the `a`-method to the sync one:

- `test_streaming_completion_sync` in `tests/integration/test_streaming.py` — mirrors `test_streaming_completion_async`, drives `completion(stream=True)` across all providers.
- `test_messages_streaming_sync` in `tests/integration/test_messages.py` — mirrors `test_messages_streaming`, drives `messages(stream=True)` across all providers.
- `test_custom_path_streaming_sync` in `tests/integration/test_openai_compatible.py` — mirrors `test_custom_path_streaming`, drives `completion(stream=True)` through the OpenAI-compatible custom path against a live OpenAI endpoint. This is the exact path where #1253 manifested.

This new coverage surfaced a real, separate bug: every sync xAI call was broken (`XaiProvider` built its grpc channel eagerly and bound it to whichever loop existed at construction, so the sync bridge's worker loop never matched). @njbrake filed #1284 for it and fixed it directly on this branch: the client is now built per running event loop, on first use, so the channel always belongs to the loop driving the call. Thanks for catching and fixing that one.

**Scope note:** `responses()` streaming has no existing async integration test to mirror either (only unit coverage), so it's left out here rather than growing this into a bigger, separate task.

## PR Type

- 🐛 Bug Fix
- 🚦 Infrastructure

## Relevant issues
Refs #1260 (follow-up from #1256 / #1253)
Fixes #1284

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: I filed #1260 myself off a gap @njbrake pointed out while reviewing #1256, then had Claude Code write the sync twins mirroring the existing async tests, run ruff/mypy, and confirm the new tests collect and skip cleanly without API keys. When CodeRabbit and then @njbrake flagged real bugs (a skip-guard ordering issue, then the xai event-loop bug this coverage surfaced), I reproduced each independently before accepting the fix, and reset to @njbrake's version once his fix on the xai issue turned out more robust than the one I'd been writing. I reviewed the diff before opening and updating this PR.

- [x] I am an AI Agent filling out this form (check box if true)