### PR TITLE
feat: expose service_tier on completion and messages params

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -577,6 +577,7 @@ class AnyLLM(ABC):
         response_format: dict[str, Any] | type | None = None,
         stream: bool | None = None,
         prompt_cache_key: str | None = None,
+        service_tier: str | None = None,
         timeout: float | None = None,
         allow_running_loop: bool | None = None,
         **kwargs: Any,
@@ -595,6 +596,7 @@ class AnyLLM(ABC):
                     response_format=response_format,
                     stream=stream,
                     prompt_cache_key=prompt_cache_key,
+                    service_tier=service_tier,
                     timeout=timeout,
                     **kwargs,
                 ),
@@ -608,6 +610,7 @@ class AnyLLM(ABC):
                 response_format=response_format,
                 stream=stream,
                 prompt_cache_key=prompt_cache_key,
+                service_tier=service_tier,
                 timeout=timeout,
                 **kwargs,
             ),
@@ -690,6 +693,7 @@ class AnyLLM(ABC):
         max_completion_tokens: int | None = None,
         reasoning_effort: ReasoningEffort | None = "auto",
         prompt_cache_key: str | None = None,
+        service_tier: str | None = None,
         timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
         **kwargs: Any,
     ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk] | ParsedChatCompletion[Any]:
@@ -720,6 +724,7 @@ class AnyLLM(ABC):
             max_completion_tokens: Maximum number of tokens for the completion
             reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
             prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+            service_tier: The service tier to use for this request.
             timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
                 An explicit ``None`` is treated the same as omitting it (the provider's default
                 applies), so it cannot request an unbounded timeout.
@@ -765,6 +770,7 @@ class AnyLLM(ABC):
             max_completion_tokens=max_completion_tokens,
             reasoning_effort=reasoning_effort,
             prompt_cache_key=prompt_cache_key,
+            service_tier=service_tier,
         )
 
         self._validate_prompt_cache_key(prompt_cache_key)
@@ -815,6 +821,7 @@ class AnyLLM(ABC):
         *,
         allow_running_loop: bool | None = None,
         prompt_cache_key: str | None = None,
+        service_tier: str | None = None,
         context_management: dict[str, Any] | None = None,
         betas: list[str] | None = None,
         **kwargs: Any,
@@ -839,6 +846,7 @@ class AnyLLM(ABC):
                     "Coroutine[Any, Any, AsyncIterator[MessageStreamEvent]]",
                     self.amessages(
                         prompt_cache_key=prompt_cache_key,
+                        service_tier=service_tier,
                         context_management=context_management,
                         betas=betas,
                         **kwargs,
@@ -850,6 +858,7 @@ class AnyLLM(ABC):
         response = run_async_in_sync(
             self.amessages(
                 prompt_cache_key=prompt_cache_key,
+                service_tier=service_tier,
                 context_management=context_management,
                 betas=betas,
                 **kwargs,
@@ -879,6 +888,7 @@ class AnyLLM(ABC):
         thinking: dict[str, Any] | None = None,
         cache_control: dict[str, Any] | None = None,
         prompt_cache_key: str | None = None,
+        service_tier: str | None = None,
         context_management: dict[str, Any] | None = None,
         betas: list[str] | None = None,
         output_format: type | dict[str, Any] | None = None,
@@ -905,6 +915,7 @@ class AnyLLM(ABC):
             thinking: Thinking/reasoning configuration.
             cache_control: Cache control configuration for prompt caching.
             prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+            service_tier: The service tier to use for this request.
             context_management: Anthropic context management configuration. The
                 `compact_20260112` strategy requires a supported model. Its `input_tokens`
                 trigger value must be at least 50,000 when provided; see
@@ -947,6 +958,7 @@ class AnyLLM(ABC):
             thinking=thinking,
             cache_control=cache_control,
             prompt_cache_key=prompt_cache_key,
+            service_tier=service_tier,
             context_management=context_management,
             betas=betas,
             output_format=output_format,

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -50,6 +50,7 @@ def completion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
+    service_tier: str | None = None,
     prompt_cache_key: str | None = None,
     timeout: float | None = None,
     client_args: dict[str, Any] | None = None,
@@ -87,6 +88,7 @@ def completion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
+        service_tier: The service tier to use for this request.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
             An explicit ``None`` is treated the same as omitting it (the provider's default
@@ -133,6 +135,7 @@ def completion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        service_tier=service_tier,
         prompt_cache_key=prompt_cache_key,
         timeout=timeout,
         **kwargs,
@@ -167,6 +170,7 @@ async def acompletion(
     stream_options: dict[str, Any] | None = None,
     max_completion_tokens: int | None = None,
     reasoning_effort: ReasoningEffort | None = "auto",
+    service_tier: str | None = None,
     prompt_cache_key: str | None = None,
     timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
     client_args: dict[str, Any] | None = None,
@@ -204,6 +208,7 @@ async def acompletion(
         stream_options: Additional options controlling streaming behavior
         max_completion_tokens: Maximum number of tokens for the completion
         reasoning_effort: Reasoning effort level for models that support it. "auto" will map to each provider's default.
+        service_tier: The service tier to use for this request.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
         timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
             An explicit ``None`` is treated the same as omitting it (the provider's default
@@ -250,6 +255,7 @@ async def acompletion(
         stream_options=stream_options,
         max_completion_tokens=max_completion_tokens,
         reasoning_effort=reasoning_effort,
+        service_tier=service_tier,
         prompt_cache_key=prompt_cache_key,
         timeout=timeout,
         **kwargs,
@@ -572,6 +578,7 @@ def messages(
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
     prompt_cache_key: str | None = None,
+    service_tier: str | None = None,
     context_management: dict[str, Any] | None = None,
     betas: list[str] | None = None,
     output_format: type | dict[str, Any] | None = None,
@@ -600,6 +607,7 @@ def messages(
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+        service_tier: The service tier to use for this request.
         context_management: Anthropic context management configuration. The `compact_20260112`
             strategy requires a supported model. Its `input_tokens` trigger value must be at
             least 50,000 when provided; see [Anthropic's compaction documentation](https://platform.claude.com/docs/en/build-with-claude/compaction).
@@ -642,6 +650,7 @@ def messages(
         thinking=thinking,
         cache_control=cache_control,
         prompt_cache_key=prompt_cache_key,
+        service_tier=service_tier,
         context_management=context_management,
         betas=betas,
         output_format=output_format,
@@ -667,6 +676,7 @@ async def amessages(
     thinking: dict[str, Any] | None = None,
     cache_control: dict[str, Any] | None = None,
     prompt_cache_key: str | None = None,
+    service_tier: str | None = None,
     context_management: dict[str, Any] | None = None,
     betas: list[str] | None = None,
     output_format: type | dict[str, Any] | None = None,
@@ -695,6 +705,7 @@ async def amessages(
         thinking: Thinking/reasoning configuration.
         cache_control: Cache control configuration for prompt caching.
         prompt_cache_key: A key to use when reading from or writing to a provider's prompt cache.
+        service_tier: The service tier to use for this request.
         context_management: Anthropic context management configuration. The `compact_20260112`
             strategy requires a supported model. Its `input_tokens` trigger value must be at
             least 50,000 when provided; see [Anthropic's compaction documentation](https://platform.claude.com/docs/en/build-with-claude/compaction).
@@ -737,6 +748,7 @@ async def amessages(
         thinking=thinking,
         cache_control=cache_control,
         prompt_cache_key=prompt_cache_key,
+        service_tier=service_tier,
         context_management=context_management,
         betas=betas,
         output_format=output_format,

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -140,6 +140,8 @@ class GoogleProvider(AnyLLM):
                 )
         if params.seed is not None:
             kwargs["seed"] = params.seed
+        if params.service_tier is not None:
+            kwargs["service_tier"] = params.service_tier
         if params.temperature is not None:
             kwargs["temperature"] = params.temperature
         if params.tools is not None:

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -235,3 +235,6 @@ class CompletionParams(BaseModel):
 
     prompt_cache_key: str | None = None
     """A key to use when reading from or writing to a provider's prompt cache."""
+
+    service_tier: str | None = None
+    """The service tier to use for this request."""

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -215,6 +215,9 @@ class MessagesParams(BaseModel):
     prompt_cache_key: str | None = None
     """A key to use when reading from or writing to a provider's prompt cache."""
 
+    service_tier: str | None = None
+    """The service tier to use for this request."""
+
     context_management: dict[str, Any] | None = None
     """Anthropic context management configuration"""
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -75,6 +75,8 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
 
     if params.prompt_cache_key is not None:
         result["prompt_cache_key"] = params.prompt_cache_key
+    if params.service_tier is not None:
+        result["service_tier"] = params.service_tier
     if params.temperature is not None:
         result["temperature"] = params.temperature
     if params.top_p is not None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -2014,3 +2014,32 @@ async def test_acompletion_raises_content_filter_error_for_filtered_structured_o
                 messages=[{"role": "user", "content": "Hello"}],
                 response_format=StructuredAnswer,
             )
+
+
+@pytest.mark.asyncio
+async def test_service_tier_is_forwarded_to_generate_content_config() -> None:
+    """A typed service_tier must still reach GenerateContentConfig, which models it natively."""
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="gemini-pro",
+                messages=[{"role": "user", "content": "Hello"}],
+                service_tier="flex",
+            ),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        assert call_kwargs["config"].service_tier == types.ServiceTier.FLEX
+
+
+@pytest.mark.asyncio
+async def test_service_tier_omitted_when_not_requested() -> None:
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-key")
+        await provider._acompletion(
+            CompletionParams(model_id="gemini-pro", messages=[{"role": "user", "content": "Hello"}]),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        assert call_kwargs["config"].service_tier is None

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -40,6 +40,31 @@ def test_completion_params_exposes_prompt_cache_key() -> None:
     assert mock_provider.completion.call_args.kwargs["prompt_cache_key"] == "tenant-1"
 
 
+def test_completion_params_exposes_service_tier() -> None:
+    params = CompletionParams(
+        model_id="gpt-5.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        service_tier="flex",
+    )
+
+    assert params.service_tier == "flex"
+    assert "service_tier" in CompletionParams.model_json_schema()["properties"]
+    assert "service_tier" in signature(completion).parameters
+    assert "service_tier" in signature(acompletion).parameters
+    assert "service_tier" in signature(AnyLLM.completion).parameters
+    assert "service_tier" in signature(AnyLLM.acompletion).parameters
+
+    mock_provider = Mock()
+    with patch("any_llm.any_llm.AnyLLM.create", return_value=mock_provider):
+        completion(
+            model="openai:gpt-5.6",
+            messages=[{"role": "user", "content": "Hello"}],
+            service_tier="flex",
+        )
+
+    assert mock_provider.completion.call_args.kwargs["service_tier"] == "flex"
+
+
 def test_completion_exposes_timeout_parameter() -> None:
     assert "timeout" in signature(completion).parameters
     assert "timeout" in signature(acompletion).parameters
@@ -130,6 +155,7 @@ async def test_acompletion_parameter_capture() -> None:
             max_tokens=100,
             stream=False,
             reasoning_effort="high",
+            service_tier="flex",
             prompt_cache_key="tenant-1",
             api_key="sk-test-key-123",
             api_base="https://custom-openai.example.com/v1",
@@ -151,6 +177,7 @@ async def test_acompletion_parameter_capture() -> None:
         assert call_args.kwargs["max_tokens"] == 100
         assert call_args.kwargs["stream"] is False
         assert call_args.kwargs["reasoning_effort"] == "high"
+        assert call_args.kwargs["service_tier"] == "flex"
         assert call_args.kwargs["prompt_cache_key"] == "tenant-1"
         assert call_args.kwargs["custom_param"] == "custom_value"
 

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -77,6 +77,18 @@ def test_messages_params_exposes_prompt_cache_key_in_schema() -> None:
     assert "prompt_cache_key" in MessagesParams.model_json_schema()["properties"]
 
 
+def test_messages_params_exposes_service_tier_in_schema() -> None:
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        service_tier="standard_only",
+    )
+
+    assert params.service_tier == "standard_only"
+    assert "service_tier" in MessagesParams.model_json_schema()["properties"]
+
+
 @pytest.mark.asyncio
 async def test_amessages_rejects_prompt_cache_key_for_unsupported_provider() -> None:
     pytest.importorskip("boto3")
@@ -508,6 +520,7 @@ async def test_amessages_parameter_capture() -> None:
             metadata={"user_id": "u1"},
             thinking={"type": "enabled", "budget_tokens": 4096},
             prompt_cache_key="tenant-1",
+            service_tier="standard_only",
             api_key="sk-test",
             api_base="https://custom.example.com",
         )
@@ -535,14 +548,17 @@ async def test_amessages_parameter_capture() -> None:
         assert call_args.kwargs["metadata"] == {"user_id": "u1"}
         assert call_args.kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
         assert call_args.kwargs["prompt_cache_key"] == "tenant-1"
+        assert call_args.kwargs["service_tier"] == "standard_only"
 
 
 @pytest.mark.asyncio
 async def test_amessages_forwards_typed_messages_params() -> None:
     assert "prompt_cache_key" in signature(amessages).parameters
+    assert "service_tier" in signature(amessages).parameters
     assert "context_management" in signature(amessages).parameters
     assert "betas" in signature(amessages).parameters
     assert "prompt_cache_key" in signature(AnyLLM.amessages).parameters
+    assert "service_tier" in signature(AnyLLM.amessages).parameters
     assert "context_management" in signature(AnyLLM.amessages).parameters
     assert "betas" in signature(AnyLLM.amessages).parameters
 
@@ -558,12 +574,14 @@ async def test_amessages_forwards_typed_messages_params() -> None:
             messages=[{"role": "user", "content": "Hello"}],
             max_tokens=1024,
             prompt_cache_key="tenant-1",
+            service_tier="standard_only",
             context_management=context_management,
             betas=betas,
         )
 
     call_kwargs = mock_provider.amessages.await_args.kwargs
     assert call_kwargs["prompt_cache_key"] == "tenant-1"
+    assert call_kwargs["service_tier"] == "standard_only"
     assert call_kwargs["context_management"] == context_management
     assert call_kwargs["betas"] == betas
 
@@ -605,9 +623,11 @@ def test_messages_returns_parsed_beta_message_without_treating_it_as_a_stream() 
 
 def test_messages_forwards_typed_messages_params() -> None:
     assert "prompt_cache_key" in signature(messages).parameters
+    assert "service_tier" in signature(messages).parameters
     assert "context_management" in signature(messages).parameters
     assert "betas" in signature(messages).parameters
     assert "prompt_cache_key" in signature(AnyLLM.messages).parameters
+    assert "service_tier" in signature(AnyLLM.messages).parameters
     assert "context_management" in signature(AnyLLM.messages).parameters
     assert "betas" in signature(AnyLLM.messages).parameters
 
@@ -623,12 +643,14 @@ def test_messages_forwards_typed_messages_params() -> None:
             messages=[{"role": "user", "content": "Hello"}],
             max_tokens=1024,
             prompt_cache_key="tenant-1",
+            service_tier="standard_only",
             context_management=context_management,
             betas=betas,
         )
 
     call_kwargs = mock_provider.messages.call_args.kwargs
     assert call_kwargs["prompt_cache_key"] == "tenant-1"
+    assert call_kwargs["service_tier"] == "standard_only"
     assert call_kwargs["context_management"] == context_management
     assert call_kwargs["betas"] == betas
 
@@ -707,6 +729,7 @@ async def test_default_amessages_non_streaming() -> None:
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=100,
         prompt_cache_key="tenant-1",
+        service_tier="standard_only",
     )
     result = await AnyLLM._amessages(mock_provider, params)
     assert isinstance(result, MessageResponse)
@@ -717,7 +740,9 @@ async def test_default_amessages_non_streaming() -> None:
     assert result.usage.input_tokens == 10
     completion_params = mock_provider._acompletion.await_args.args[0]
     assert completion_params.prompt_cache_key == "tenant-1"
+    assert completion_params.service_tier == "standard_only"
     assert "prompt_cache_key" not in mock_provider._acompletion.await_args.kwargs
+    assert "service_tier" not in mock_provider._acompletion.await_args.kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Expose `service_tier` as a typed parameter on `CompletionParams` and `MessagesParams`, matching the existing Responses API surface. The value now flows through the public completion/messages helpers, `AnyLLM` entry points, and the Messages-to-Completions compatibility bridge so providers can map or reject it instead of receiving an untyped extra kwarg.

## PR Type

- New Feature

## Relevant issues

Fixes #1269

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: Implemented the narrow issue scope in an isolated worktree and added offline regression coverage for schema exposure, public forwarding, and the Messages compatibility bridge.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional service tier setting to completion and messaging requests.
  - Supported the setting across synchronous and asynchronous APIs and provider integrations.
  - Preserved the selected tier when converting between messaging and completion requests.
- **Documentation**
  - Documented the new service tier option.
- **Tests**
  - Added coverage for validation, forwarding, provider integration and request conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->