### PR TITLE
fix(tests): move gemini reasoning tests off the retired gemini-2.5-flash

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,9 +34,11 @@ def pytest_configure(config: pytest.Config) -> None:
 def provider_reasoning_model_map() -> dict[LLMProvider, str]:
     return {
         LLMProvider.ANTHROPIC: "claude-sonnet-4-6",
-        # gemini-2.5-flash is closed to new API keys (404 "no longer available to new users"),
-        # so reasoning runs on the same Gemini 3 model the rest of the suite uses. thinking_budget
-        # stays supported there for backward compatibility, so the provider needs no change.
+        # gemini-2.5-flash is closed to new API keys (404 "no longer available to new users"), so
+        # reasoning runs on the same Gemini 3 model the rest of the suite uses. thinking_budget,
+        # which is what GoogleProvider sends for reasoning_effort, is still supported on Gemini 3.0
+        # for backward compatibility. Google has signalled it goes away for 3.5+, so the provider
+        # will need to send thinking_level before this can point at a newer model.
         LLMProvider.GEMINI: "gemini-3-flash-preview",
         # No anthropic model via otari surfaces reasoning content (tested haiku/sonnet/opus, even
         # with reasoning_effort set: OpenAI reasoning_effort is not mapped to Anthropic extended

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,10 @@ def pytest_configure(config: pytest.Config) -> None:
 def provider_reasoning_model_map() -> dict[LLMProvider, str]:
     return {
         LLMProvider.ANTHROPIC: "claude-sonnet-4-6",
-        LLMProvider.GEMINI: "gemini-2.5-flash",
+        # gemini-2.5-flash is closed to new API keys (404 "no longer available to new users"),
+        # so reasoning runs on the same Gemini 3 model the rest of the suite uses. thinking_budget
+        # stays supported there for backward compatibility, so the provider needs no change.
+        LLMProvider.GEMINI: "gemini-3-flash-preview",
         # No anthropic model via otari surfaces reasoning content (tested haiku/sonnet/opus, even
         # with reasoning_effort set: OpenAI reasoning_effort is not mapped to Anthropic extended
         # thinking). gpt-oss-120b does emit reasoning, which needs the otari SDK reasoning-string

--- a/tests/integration/test_reasoning.py
+++ b/tests/integration/test_reasoning.py
@@ -32,7 +32,11 @@ async def test_completion_reasoning(
 
         result = await llm.acompletion(
             model=model_id,
-            messages=[{"role": "user", "content": "Please say hello! Think very briefly before you respond."}],
+            # Not "think very briefly": Gemini returns a thought block with a signature and no
+            # summary text when a request is simple enough that it barely reasons, which makes the
+            # reasoning assertion below fail. See the thought summaries section of
+            # https://ai.google.dev/gemini-api/docs/thinking
+            messages=[{"role": "user", "content": "Please say hello! Think before you respond."}],
             reasoning_effort="low"
             if provider
             in (


### PR DESCRIPTION
_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`test_completion_reasoning[gemini]` and `test_completion_reasoning_streaming[gemini]` have been failing on `main` since at least run 31486350583. Two independent causes, both fixed here.

**1. Retired model.** The Gemini Developer API now 404s `gemini-2.5-flash` with "no longer available to new users", and the CI key is not grandfathered. `provider_model_map` already moved to `gemini-3-flash-preview` and its tests pass, so the key has access; only `provider_reasoning_model_map` was left behind.

**2. A prompt that suppresses the thought summary.** With the model swapped, the non-streaming test still failed on `assert message.reasoning is not None`. Its prompt asked the model to "think **very briefly**" at `reasoning_effort="low"`. Gemini [documents](https://ai.google.dev/gemini-api/docs/thinking) that a thought block may carry only a signature and no summary text for "simple requests, where the model didn't reason enough to generate a summary". `gemini-2.5-flash` happened to always emit one. The streaming variant already used "Think before you respond" and passed, so this aligns the two prompts.

No provider change is needed. Gemini 3.0 keeps `thinking_budget` for backward compatibility; the 400 people hit comes from sending `thinking_level` and `thinking_budget` together, which any-llm never does. #1276 tracks what happens when this moves to a 3.5+ model.

`LLMProvider.VERTEXAI` still points at `gemini-2.5-flash` here. Vertex is skipped entirely in CI for lack of credentials and deprecates on its own schedule, so changing it would be an unverifiable guess.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None filed for this. Evidence is CI run 31578025946. Found while reviewing: #1276 and #1277.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
    - The change is integration test configuration, so the integration tests are the test. No unit test applies.
- [x] I have run this code locally and verified it fixes the issue.
    - Via the `run-integration-tests` label rather than locally, since no `GEMINI_API_KEY` was available. Run 31623619771: both gemini reasoning tests pass, and the suite has no remaining failures.
- [x] New and existing tests pass locally
    - `uv run pytest tests/unit`: 2028 passed, 93 skipped. `pre-commit run --all-files` clean.
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: An earlier draft also rewrote the provider to send `thinking_level` for Gemini 3, on the mistaken belief that Gemini 3 rejects `thinking_budget`. Google's Gemini 3 guide says it is still supported, so that was dropped and filed as #1276 instead.

- [x] I am an AI Agent filling out this form (check box if true)
