### PR TITLE
fix(ollama): send tool history in Ollama's native format

### DIFF
--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -267,9 +267,12 @@ class OllamaProvider(AnyLLM):
         cleaned_messages = []
         for input_message in params.messages:
             if input_message["role"] == "tool":
+                # OpenAI also allows a tool result as a list of content parts, while Ollama
+                # takes a plain string, so flatten it to its text the same way user turns are.
+                tool_content, _ = self._extract_images_from_message(input_message)
                 cleaned_message: dict[str, Any] = {
                     "role": "tool",
-                    "content": input_message.get("content") or "",
+                    "content": tool_content or "",
                 }
                 # OpenAI identifies a tool result by call id, Ollama by tool name.
                 tool_name = input_message.get("name") or tool_names_by_call_id.get(

--- a/src/any_llm/providers/ollama/ollama.py
+++ b/src/any_llm/providers/ollama/ollama.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import override
@@ -15,6 +14,7 @@ try:
 
     from .utils import (
         _convert_models_list,
+        _convert_tool_calls,
         _create_chat_completion_from_ollama_response,
         _create_openai_chunk_from_ollama_chunk,
         _create_openai_embedding_response_from_ollama,
@@ -259,19 +259,33 @@ class OllamaProvider(AnyLLM):
 
         output_format = self._convert_response_format(params.response_format)
 
-        # (https://www.reddit.com/r/ollama/comments/1ked8x2/feeding_tool_output_back_to_llm/)
+        # Ollama accepts `tool` role messages and assistant `tool_calls` natively, so both are
+        # forwarded as-is. Flattening them into assistant text shows the model a transcript of
+        # itself answering with raw JSON, which smaller models copy instead of emitting a real
+        # tool call. (https://docs.ollama.com/capabilities/tool-calling)
+        tool_names_by_call_id: dict[str, str] = {}
         cleaned_messages = []
         for input_message in params.messages:
             if input_message["role"] == "tool":
                 cleaned_message: dict[str, Any] = {
-                    "role": "user",
-                    "content": json.dumps(input_message["content"]),
+                    "role": "tool",
+                    "content": input_message.get("content") or "",
                 }
-            elif input_message["role"] == "assistant" and "tool_calls" in input_message:
-                content = input_message["content"] + "\n" + json.dumps(input_message["tool_calls"])
+                # OpenAI identifies a tool result by call id, Ollama by tool name.
+                tool_name = input_message.get("name") or tool_names_by_call_id.get(
+                    input_message.get("tool_call_id", "")
+                )
+                if tool_name:
+                    cleaned_message["tool_name"] = tool_name
+            elif input_message["role"] == "assistant" and input_message.get("tool_calls"):
+                tool_calls: list[dict[str, Any]] = input_message["tool_calls"]
+                for tool_call in tool_calls:
+                    if tool_call.get("id"):
+                        tool_names_by_call_id[tool_call["id"]] = tool_call["function"]["name"]
                 cleaned_message = {
                     "role": "assistant",
-                    "content": content,
+                    "content": input_message.get("content") or "",
+                    "tool_calls": _convert_tool_calls(tool_calls),
                 }
             else:
                 cleaned_message = input_message.copy()

--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -41,6 +41,21 @@ if TYPE_CHECKING:
     )
 
 
+def _convert_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI tool calls to the shape Ollama expects.
+
+    Ollama takes `arguments` as a mapping, while OpenAI serializes it to a JSON string.
+    """
+    converted = []
+    for tool_call in tool_calls:
+        function = tool_call["function"]
+        arguments = function.get("arguments") or {}
+        if isinstance(arguments, str):
+            arguments = json.loads(arguments) if arguments.strip() else {}
+        converted.append({"function": {"name": function["name"], "arguments": arguments}})
+    return converted
+
+
 def _create_openai_embedding_response_from_ollama(
     ollama_response: EmbedResponse,
 ) -> CreateEmbeddingResponse:

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -717,6 +717,25 @@ async def test_tool_message_without_a_resolvable_name_omits_tool_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_message_content_parts_are_flattened_to_text() -> None:
+    """OpenAI allows a tool result as content parts, which Ollama rejects as a non-string content."""
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "What time is it?"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "text", "text": "12:30"}],
+                "name": "get_time",
+            },
+        ],
+        stream=False,
+    )
+
+    assert sent[1] == {"role": "tool", "content": "12:30", "tool_name": "get_time"}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("assistant_message", [{"role": "assistant"}, {"role": "assistant", "content": None}])
 async def test_missing_or_null_content_is_normalized(assistant_message: dict[str, Any]) -> None:
     """`model_dump(exclude_none=True)` drops `content`, which used to raise on the tool-call path."""

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -611,3 +611,153 @@ async def test_streaming_completion_passes_think_level_top_level() -> None:
 def test_per_request_timeout_is_declared_unsupported() -> None:
     """Ollama only accepts a timeout at client construction, so the base class rejects a per-request one."""
     assert OllamaProvider.TIMEOUT_SUPPORT == "unsupported"
+
+
+async def _sent_messages(messages: list[dict[str, Any]], stream: bool) -> list[dict[str, Any]]:
+    """Run a completion against a mocked client and return the messages it received."""
+
+    async def empty_async_iter() -> AsyncIterator[None]:
+        return
+        yield
+
+    params = CompletionParams(model_id="qwen3:0.6b", messages=messages, stream=stream)
+
+    with patch.object(OllamaProvider, "_init_client"):
+        provider = OllamaProvider(api_key=None)
+        provider.client = Mock()
+        provider.client.chat = AsyncMock(return_value=empty_async_iter() if stream else Mock())
+
+        if stream:
+            result = await provider._acompletion(params)
+            async for _ in result:  # type: ignore[union-attr]
+                pass
+        else:
+            with patch.object(OllamaProvider, "_convert_completion_response", return_value=Mock()):
+                await provider._acompletion(params)
+
+    sent: list[dict[str, Any]] = provider.client.chat.call_args.kwargs["messages"]
+    return sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_tool_history_is_forwarded_in_native_ollama_format(stream: bool) -> None:
+    """Ollama takes tool results and assistant tool calls natively.
+
+    Flattening them into assistant text shows the model a transcript of itself answering with
+    raw JSON, which smaller models copy instead of emitting a real tool call.
+    """
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "What's the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Paris"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "15C and sunny", "tool_call_id": "call_abc"},
+        ],
+        stream,
+    )
+
+    assert sent[1] == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"function": {"name": "get_weather", "arguments": {"location": "Paris"}}}],
+    }
+    assert sent[2] == {"role": "tool", "content": "15C and sunny", "tool_name": "get_weather"}
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_without_tool_calls_is_left_untouched() -> None:
+    """An empty tool_calls list must not leak into the assistant's content."""
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!", "tool_calls": []},
+            {"role": "user", "content": "How are you?"},
+        ],
+        stream=False,
+    )
+
+    assert sent[1]["content"] == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_tool_message_name_falls_back_to_explicit_name_field() -> None:
+    """Clients that label the tool result directly should not need the matching assistant turn."""
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "What time is it?"},
+            {"role": "tool", "content": "12:30", "tool_call_id": "call_missing", "name": "get_time"},
+        ],
+        stream=False,
+    )
+
+    assert sent[1] == {"role": "tool", "content": "12:30", "tool_name": "get_time"}
+
+
+@pytest.mark.asyncio
+async def test_tool_message_without_a_resolvable_name_omits_tool_name() -> None:
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "What time is it?"},
+            {"role": "tool", "content": "12:30", "tool_call_id": "call_unknown"},
+        ],
+        stream=False,
+    )
+
+    assert sent[1] == {"role": "tool", "content": "12:30"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("assistant_message", [{"role": "assistant"}, {"role": "assistant", "content": None}])
+async def test_missing_or_null_content_is_normalized(assistant_message: dict[str, Any]) -> None:
+    """`model_dump(exclude_none=True)` drops `content`, which used to raise on the tool-call path."""
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "What time is it?"},
+            {
+                **assistant_message,
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_time", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1"},
+        ],
+        stream=False,
+    )
+
+    assert sent[1]["content"] == ""
+    assert sent[2] == {"role": "tool", "content": "", "tool_name": "get_time"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        ('{"location": "Paris"}', {"location": "Paris"}),
+        ({"location": "Paris"}, {"location": "Paris"}),
+        ("", {}),
+        ("  ", {}),
+        (None, {}),
+    ],
+)
+async def test_tool_call_arguments_are_converted_to_a_mapping(arguments: Any, expected: dict[str, Any]) -> None:
+    """Ollama takes arguments as a mapping, while OpenAI serializes them to a JSON string."""
+    sent = await _sent_messages(
+        [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_weather", "arguments": arguments}}],
+            },
+        ],
+        stream=False,
+    )
+
+    assert sent[1]["tool_calls"] == [{"function": {"name": "get_weather", "arguments": expected}}]


### PR DESCRIPTION
## Description

`OllamaProvider._acompletion` rewrites tool history before sending it: tool results become `user` messages, and assistant tool calls are flattened into the assistant's text as raw OpenAI JSON. Ollama accepts both natively, so nothing needs flattening (https://docs.ollama.com/capabilities/tool-calling).

I hit this in [ollmcp](https://github.com/jonigl/mcp-client-for-ollama), where the model would sometimes print a tool call as raw JSON instead of calling the tool, but only once a tool had already run in the conversation. It was not just small local models — gemma4:31b-cloud through Ollama Cloud did it too. With this branch I can no longer reproduce it.

Four things go wrong on the released path:

- the tool result is attributed to the **user**
- `json.dumps` wraps it in quotes and escapes its newlines into literal `\n`, so a multi-line page snapshot arrives as one line of escape sequences
- the assistant's tool call is shown as **text**, which is a few-shot demonstration of the wrong output format. Smaller models copy it and emit the next tool call as prose instead of a structured call, so the caller gets a JSON blob as the answer.
- the trailing `\n[]`, because the branch tests `"tool_calls" in message` rather than its truth, so every assistant turn carrying an empty list gets a bare `[]` glued to its text

The fix keeps `role: "tool"` and sets `tool_name`, resolved from the matching assistant tool call (OpenAI addresses a tool result by `tool_call_id`, Ollama by name; templates such as gpt-oss render it). Assistant tool calls are forwarded in their own field, with `arguments` converted from OpenAI's JSON string to the mapping `ollama._types.Message.ToolCall` requires. The conversion runs before the streaming fork, so both paths are covered.

It also fixes a crash on the same path: `model_dump(exclude_none=True)` drops `content` when it is `None`, and the old code indexed `input_message["content"]` directly, raising `KeyError: 'content'`.

One judgment call worth your opinion: `json.loads` on `arguments` now raises on malformed JSON, where the old code passed it through silently. I went with failing loudly, since a tool call with unparseable arguments cannot be executed either way. Happy to downgrade it to a warning.

### Here a simple way to check what is going on

No Ollama server or model needed; the messages are captured before the request goes out.

```bash
# released
uv run --no-project --with 'any-llm-sdk[ollama]' python context_dump.py

# this PR
uv run --no-project --with ollama \
  --with "any-llm-sdk @ git+https://github.com/jonigl/any-llm@fix/ollama-native-tool-messages" \
  python context_dump.py
```

<details>
<summary><code>context_dump.py</code></summary>

```python
import asyncio

from any_llm import AnyLLM

HISTORY = [
    {"role": "user", "content": "Open the news page and summarize it"},
    {"role": "assistant", "content": "", "tool_calls": [
        {"id": "c1", "type": "function", "function": {
            "name": "browser_navigate", "arguments": '{"url": "https://news.google.com/"}'}}]},
    {"role": "tool", "tool_call_id": "c1",
     "content": "### Page state\n- generic [ref=e1]: Before you continue\n- button [ref=e2]: Accept all"},
    {"role": "assistant", "content": "I opened the page.", "tool_calls": []},
]


async def spy(*args, **kwargs):
    for message in kwargs.get("messages") or args[1]:
        print(message)
    raise SystemExit


llm = AnyLLM.create("ollama", api_base="http://localhost:11434")
llm.client.chat = spy
asyncio.run(llm.acompletion(model="x", messages=HISTORY, stream=False))
```

</details>

### Verification

<img width="990" height="288" alt="image" src="https://github.com/user-attachments/assets/f3061c25-df6c-4362-9501-e42f645455eb" />


## PR Type

- 🐛 Bug Fix

## Relevant issues

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Opus 5
- AI Developer Tool used: Claude Code + vscode
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama tool-call handling for streaming and non-streaming responses.
  * Preserved tool messages, names and assistant tool calls when forwarding conversation history.
  * Normalised missing or empty tool-call arguments and content for more reliable requests.

* **Tests**
  * Added coverage for tool calls, tool results, missing names, and empty content scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->