### PR TITLE
fix(gemini): accumulate non-streaming reasoning parts

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -384,8 +384,8 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                     tool_call_dict["extra_content"] = extra_content
 
                 tool_calls_list.append(tool_call_dict)
-            elif getattr(part, "text", None):
-                text_content = part.text
+            elif part_text := getattr(part, "text", None):
+                text_content = (text_content or "") + part_text
 
         # Truncated or filtered responses produce a choice even without content or tool
         # calls, e.g. a thinking model that spent the whole max_output_tokens budget on

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -363,7 +363,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
 
         for part in parts or []:
             if getattr(part, "thought", None):
-                reasoning = part.text
+                reasoning = (reasoning or "") + (part.text or "")
             elif function_call := getattr(part, "function_call", None):
                 args_dict = {}
                 if args := getattr(function_call, "args", None):

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -396,7 +396,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                     "message": {
                         "role": "assistant",
                         "content": None if tool_calls_list else text_content,
-                        "reasoning": reasoning,
+                        "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
                     },
                     "finish_reason": _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list)) or "stop",

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -848,6 +848,19 @@ def test_convert_response_keeps_reasoning_none_for_textless_thought_part() -> No
     assert message["content"] == "The answer."
 
 
+def test_convert_response_accumulates_multiple_text_parts() -> None:
+    response = _make_gemini_response(
+        [types.Part(text="Hello "), types.Part(text="world.")],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    message = response_dict["choices"][0]["message"]
+    assert message["content"] == "Hello world."
+    assert message["reasoning"] is None
+
+
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
     response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -861,6 +861,24 @@ def test_convert_response_accumulates_multiple_text_parts() -> None:
     assert message["reasoning"] is None
 
 
+def test_convert_response_skips_parts_without_text_or_function_call() -> None:
+    """A candidate can mix in parts that carry neither text nor a tool call, e.g. inline image
+    data; those must not disturb the accumulated text."""
+    response = _make_gemini_response(
+        [
+            types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG")),
+            types.Part(text="Described."),
+        ],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    message = response_dict["choices"][0]["message"]
+    assert message["content"] == "Described."
+    assert message["tool_calls"] is None
+
+
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
     response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -813,6 +813,23 @@ def test_convert_response_emits_choice_for_reasoning_only_truncation() -> None:
     assert choice["message"]["reasoning"] == "internal reasoning"
 
 
+def test_convert_response_accumulates_multiple_reasoning_parts() -> None:
+    response = _make_gemini_response(
+        [
+            types.Part(text="First thought. ", thought=True),
+            types.Part(text="Second thought.", thought=True),
+            types.Part(text="The answer."),
+        ],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    message = response_dict["choices"][0]["message"]
+    assert message["reasoning"] == "First thought. Second thought."
+    assert message["content"] == "The answer."
+
+
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
     response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -830,6 +830,24 @@ def test_convert_response_accumulates_multiple_reasoning_parts() -> None:
     assert message["content"] == "The answer."
 
 
+def test_convert_response_keeps_reasoning_none_for_textless_thought_part() -> None:
+    """A thought part can carry only a thought_signature; that must not turn reasoning into an
+    empty Reasoning object, matching the streaming converter."""
+    response = _make_gemini_response(
+        [
+            types.Part(thought=True, thought_signature=b"sig"),
+            types.Part(text="The answer."),
+        ],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    message = response_dict["choices"][0]["message"]
+    assert message["reasoning"] is None
+    assert message["content"] == "The answer."
+
+
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
     response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
 


### PR DESCRIPTION
## Description
Fix Gemini non-streaming response conversion so reasoning text from multiple thought parts is accumulated instead of overwritten. This keeps non-streaming reasoning consistent with the existing streaming converter and preserves `None` when no thought parts are present.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #1277

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the contribution guidelines
- [x] This is fully AI-generated.

## Validation

- `uv run --frozen pytest -q tests/unit/providers/test_gemini_provider.py` - 130 passed
- `uv run --frozen pytest -q tests/unit` - 2108 passed, 69 skipped
- Targeted pre-commit hooks for changed files passed: ruff, ruff-format, mypy, codespell, line-ending checks

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info: Implemented in an isolated worktree from `upstream/main`; no provider API key was used.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini response handling so reasoning and answer text from multiple parts are accumulated correctly.
  * Preserved the separation between reasoning and regular answer content.
  * Normalised responses without reasoning so they are handled consistently.
  * Ignored unsupported response parts without affecting valid content.

* **Tests**
  * Added regression coverage for combined reasoning, text-only responses, and multi-part answer text.
  * Added coverage for responses containing parts without text or function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->