### PR TITLE
fix: limit sync runner cleanup to loops it owns

### DIFF
--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -83,7 +83,9 @@ def run_async_in_sync(coro: Coroutine[Any, Any, T], allow_running_loop: bool = T
         if loop.is_closed():
             return asyncio.run(run_with_cleanup())
 
-        return loop.run_until_complete(run_with_cleanup())
+        # A reused loop belongs to the caller and stays open, so tasks on it are not ours to cancel
+        # or wait on, and there is no loop closure for background tasks to race with.
+        return loop.run_until_complete(coro)
 
 
 def _async_source_to_sync_iter(

--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -37,6 +37,30 @@ def run_async_in_sync(coro: Coroutine[Any, Any, T], allow_running_loop: bool = T
     except RuntimeError:
         running_loop = False
 
+    async def run_with_cleanup() -> T:
+        try:
+            result = await coro
+        except Exception:
+            pending_tasks = [
+                task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()
+            ]
+
+            for task in pending_tasks:
+                task.cancel()
+
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+            raise
+
+        # Async HTTP clients can schedule response cleanup after the main coroutine returns. Finish
+        # those tasks before the event loop is closed so their transports can still schedule callbacks.
+        pending_tasks = [task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()]
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        return result
+
     if running_loop:
         if not allow_running_loop:
             msg = "Cannot use the `sync` API in an `async` context. Use the `async` API instead."
@@ -45,43 +69,21 @@ def run_async_in_sync(coro: Coroutine[Any, Any, T], allow_running_loop: bool = T
         # If we get here, there's a loop running, so we can't use run_until_complete()
         # or asyncio.run() - must use threading approach
         def run_in_thread() -> T:
-            async def run_with_cleanup() -> T:
-                try:
-                    result = await coro
-
-                    # Wait for any pending background tasks to complete to prevent "Event loop is closed" errors
-                    pending_tasks = [
-                        task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()
-                    ]
-
-                    if pending_tasks:
-                        await asyncio.gather(*pending_tasks, return_exceptions=True)
-                except Exception:
-                    pending_tasks = [
-                        task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()
-                    ]
-
-                    for task in pending_tasks:
-                        task.cancel()
-
-                    if pending_tasks:
-                        await asyncio.gather(*pending_tasks, return_exceptions=True)
-
-                    raise
-                return result
-
             return asyncio.run(run_with_cleanup())
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
             return executor.submit(run_in_thread).result()
     else:
-        # No running event loop - try to get available loop
+        # No running event loop: reuse an available loop, or create one when the thread has no loop.
         try:
             loop = asyncio.get_event_loop()
-            return loop.run_until_complete(coro)
         except RuntimeError:
-            # No event loop at all - create one
-            return asyncio.run(coro)
+            return asyncio.run(run_with_cleanup())
+
+        if loop.is_closed():
+            return asyncio.run(run_with_cleanup())
+
+        return loop.run_until_complete(run_with_cleanup())
 
 
 def _async_source_to_sync_iter(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import threading
 import time
 from collections.abc import AsyncIterator, Generator
 from typing import Any, cast
@@ -32,6 +33,35 @@ def test_run_async_in_sync_fails_with_background_task_state() -> None:
         assert task_completed["value"] is True
 
     asyncio.run(test_in_streamlit_context())
+
+
+def test_run_async_in_sync_cleans_up_background_tasks_without_running_loop() -> None:
+    task_completed = {"value": False}
+    result: list[str] = []
+    errors: list[BaseException] = []
+
+    async def operation_with_background_task() -> str:
+        async def background_work() -> None:
+            await asyncio.sleep(0)
+            task_completed["value"] = True
+
+        task = asyncio.create_task(background_work())
+        assert task is not None
+        return "operation_started"
+
+    def run_in_thread() -> None:
+        try:
+            result.append(run_async_in_sync(operation_with_background_task()))
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_in_thread)
+    thread.start()
+    thread.join()
+
+    assert errors == []
+    assert result == ["operation_started"]
+    assert task_completed["value"] is True
 
 
 def test_async_iter_to_sync_iter_preserves_contextvars() -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -38,7 +38,7 @@ def test_run_async_in_sync_fails_with_background_task_state() -> None:
 def test_run_async_in_sync_cleans_up_background_tasks_without_running_loop() -> None:
     task_completed = {"value": False}
     result: list[str] = []
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     async def operation_with_background_task() -> str:
         async def background_work() -> None:
@@ -52,16 +52,156 @@ def test_run_async_in_sync_cleans_up_background_tasks_without_running_loop() -> 
     def run_in_thread() -> None:
         try:
             result.append(run_async_in_sync(operation_with_background_task()))
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
 
-    thread = threading.Thread(target=run_in_thread)
+    thread = threading.Thread(target=run_in_thread, daemon=True)
     thread.start()
-    thread.join()
+    thread.join(timeout=5)
 
+    assert not thread.is_alive()
     assert errors == []
     assert result == ["operation_started"]
     assert task_completed["value"] is True
+
+
+def test_run_async_in_sync_cancels_its_background_tasks_when_the_operation_fails() -> None:
+    background_cancelled = threading.Event()
+    errors: list[Exception] = []
+
+    async def failing_operation() -> str:
+        started = asyncio.Event()
+
+        async def background_work() -> None:
+            started.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                background_cancelled.set()
+                raise
+
+        task = asyncio.create_task(background_work())
+        assert task is not None
+        await started.wait()
+
+        msg = "provider failed"
+        raise ValueError(msg)
+
+    def run_in_thread() -> None:
+        try:
+            run_async_in_sync(failing_operation())
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert [str(error) for error in errors] == ["provider failed"]
+    # This loop is about to close, so its leftover task is cancelled while it can still clean up.
+    assert background_cancelled.is_set()
+
+
+def test_run_async_in_sync_disallows_running_loop_when_requested() -> None:
+    async def operation() -> str:
+        return "unreachable"
+
+    async def call_from_async_context() -> None:
+        coro = operation()
+        with pytest.raises(RuntimeError, match="Cannot use the `sync` API in an `async` context"):
+            run_async_in_sync(coro, allow_running_loop=False)
+        coro.close()
+
+    asyncio.run(call_from_async_context())
+
+
+def test_run_async_in_sync_leaves_caller_owned_tasks_on_a_reused_loop() -> None:
+    state: dict[str, Any] = {}
+
+    def run_in_thread() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        async def caller_background_work() -> None:
+            await asyncio.sleep(30)
+
+        caller_task = loop.create_task(caller_background_work())
+
+        async def operation() -> str:
+            await asyncio.sleep(0)
+            return "operation_finished"
+
+        async def failing_operation() -> str:
+            await asyncio.sleep(0)
+            msg = "provider failed"
+            raise ValueError(msg)
+
+        # A loop handed back by `asyncio.get_event_loop()` is the caller's, and its tasks may never
+        # finish, so waiting on them would hang and cancelling them would discard the caller's work.
+        state["result"] = run_async_in_sync(operation())
+        with pytest.raises(ValueError, match="provider failed"):
+            run_async_in_sync(failing_operation())
+        state["caller_task_cancelled"] = caller_task.cancelled()
+
+        caller_task.cancel()
+        loop.run_until_complete(asyncio.gather(caller_task, return_exceptions=True))
+        loop.close()
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive(), "sync call blocked on a task it does not own"
+    assert state["result"] == "operation_finished"
+    assert state["caller_task_cancelled"] is False
+
+
+def test_run_async_in_sync_ignores_a_closed_current_loop() -> None:
+    results: list[str] = []
+
+    def run_in_thread() -> None:
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        asyncio.set_event_loop(closed_loop)
+
+        async def operation() -> str:
+            return "ran on a fresh loop"
+
+        results.append(run_async_in_sync(operation()))
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert results == ["ran on a fresh loop"]
+
+
+def test_run_async_in_sync_propagates_runtime_error_from_coroutine() -> None:
+    errors: list[Exception] = []
+
+    def run_in_thread() -> None:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+        async def failing_operation() -> str:
+            await asyncio.sleep(0)
+            msg = "provider raised RuntimeError"
+            raise RuntimeError(msg)
+
+        # Looking the loop up separately from running the coroutine keeps a RuntimeError raised by
+        # the coroutine from being mistaken for a missing loop and retried on a spent coroutine.
+        try:
+            run_async_in_sync(failing_operation())
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert [str(error) for error in errors] == ["provider raised RuntimeError"]
 
 
 def test_async_iter_to_sync_iter_preserves_contextvars() -> None:


### PR DESCRIPTION
## Description

Narrows the sync runner cleanup to loops the call owns.

`run_with_cleanup` waits for every unfinished task on the loop, and cancels them when the coroutine fails. That is right for the `asyncio.run` paths, where the loop is created for the call and then closed. On a loop returned by `asyncio.get_event_loop()`, which belongs to the caller and stays open, waiting hangs the call whenever the caller has a long-lived task of its own, and cancelling on failure discards the caller's background work. Nothing on that loop is racing a closure either, so the coroutine now runs directly on it.

Keeping the loop lookup separate from `run_until_complete` is kept from the original commit: it stops a `RuntimeError` raised by the coroutine from being mistaken for a missing loop and retried on a spent coroutine.

This does not close #1268. That failure comes from provider clients caching transports on a loop that is then closed, so it needs the loop to outlive the call. See #1282.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure

## Relevant issues

Refs #1268

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [ ] AI Usage: No AI was used.
- [ ] AI Usage: AI was used for drafting/refactoring.
- [x] AI Usage: This is fully AI-generated.

## Test results

- `pytest tests/unit tests/docs`: green on 3.11 and 3.14
- `pre-commit run --all-files`: clean, including mypy
- Patch coverage on `src/any_llm/utils/aio.py`: 91%

## AI Usage Information

- AI Model used: GPT-5 via Codex (first commit); Claude Opus 5 via Claude Code (follow-up commit, driven by @njbrake)
- AI Developer Tool used: Codex; Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronous execution of asynchronous operations by reliably completing background tasks after success.
  * Background tasks are now cancelled and cleaned up when an operation fails.
  * Existing caller-owned event loops and tasks are preserved where appropriate.
  * Closed event loops are handled safely, and coroutine errors continue to propagate correctly.

* **Tests**
  * Added coverage for task cleanup, cancellation, loop reuse, closed loops, async-context restrictions, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
