### PR TITLE
fix(gemini): use thinking level for Gemini 3.5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ mistral = [
 anthropic = []
 
 gemini = [
-  "google-genai",
+  "google-genai>=1.51.0",
   "google-cloud-storage",
 ]
 
 vertexai = [
-  "google-genai",
+  "google-genai>=1.51.0",
   "google-cloud-storage",
 ]
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from typing_extensions import override
@@ -77,6 +78,17 @@ REASONING_EFFORT_TO_THINKING_LEVELS = {
     "max": "HIGH",
 }
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
+_THINKING_LEVEL_MIN_GEMINI_VERSION = (3, 5)
+_GEMINI_VERSION_PATTERN = re.compile(r"gemini-(\d+)(?:\.(\d+))?")
+
+
+def _uses_thinking_level(model_id: str) -> bool:
+    """Gemini 3.5 and newer reject `thinking_budget` and expect `thinking_level` instead."""
+    match = _GEMINI_VERSION_PATTERN.search(model_id.lower())
+    if match is None:
+        return False
+    major, minor = int(match.group(1)), int(match.group(2) or 0)
+    return (major, minor) >= _THINKING_LEVEL_MIN_GEMINI_VERSION
 
 
 class GoogleProvider(AnyLLM):
@@ -147,17 +159,15 @@ class GoogleProvider(AnyLLM):
         if params.reasoning_effort != "auto":
             if params.reasoning_effort is None or params.reasoning_effort == "none":
                 kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
+            elif _uses_thinking_level(params.model_id) and "thinking_level" in types.ThinkingConfig.model_fields:
+                kwargs["thinking_config"] = types.ThinkingConfig(
+                    include_thoughts=True,
+                    thinking_level=types.ThinkingLevel(REASONING_EFFORT_TO_THINKING_LEVELS[params.reasoning_effort]),
+                )
             else:
-                reasoning_effort = params.reasoning_effort
-                model_fields = getattr(types.ThinkingConfig, "model_fields", {})
-                supports_thinking_level = "thinking_level" in model_fields
-                is_new_gemini_model = params.model_id.lower().startswith(("gemini-3.5", "gemini-4"))
-                thinking_kwargs: dict[str, Any] = {"include_thoughts": True}
-                if is_new_gemini_model and supports_thinking_level:
-                    thinking_kwargs["thinking_level"] = REASONING_EFFORT_TO_THINKING_LEVELS[reasoning_effort]
-                else:
-                    thinking_kwargs["thinking_budget"] = REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
-                kwargs["thinking_config"] = types.ThinkingConfig(**thinking_kwargs)
+                kwargs["thinking_config"] = types.ThinkingConfig(
+                    include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort]
+                )
         if params.seed is not None:
             kwargs["seed"] = params.seed
         if params.service_tier is not None:

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -78,6 +78,17 @@ REASONING_EFFORT_TO_THINKING_LEVELS = {
     "max": types.ThinkingLevel.HIGH,
 }
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
+_THINKING_LEVEL_MIN_GEMINI_VERSION = (3, 5)
+_GEMINI_VERSION_PATTERN = re.compile(r"(?:^|/)gemini-(\d+)(?:\.(\d+))?")
+
+
+def _uses_thinking_level(model_id: str) -> bool:
+    """Gemini 3.5 and newer reject `thinking_budget` and expect `thinking_level` instead."""
+    match = _GEMINI_VERSION_PATTERN.search(model_id.lower())
+    if match is None:
+        return False
+    major, minor = int(match.group(1)), int(match.group(2) or 0)
+    return (major, minor) >= _THINKING_LEVEL_MIN_GEMINI_VERSION
 
 
 class GoogleProvider(AnyLLM):
@@ -148,26 +159,14 @@ class GoogleProvider(AnyLLM):
         if params.reasoning_effort != "auto":
             if params.reasoning_effort is None or params.reasoning_effort == "none":
                 kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
-            else:
-                reasoning_effort = params.reasoning_effort
-                model_fields = getattr(types.ThinkingConfig, "model_fields", {})
-                supports_thinking_level = "thinking_level" in model_fields
-                model_match = re.search(r"(?:^|/)gemini-(\d+)(?:\.(\d+))?", params.model_id.lower())
-                model_version = (
-                    (
-                        int(model_match.group(1)),
-                        int(model_match.group(2) or 0),
-                    )
-                    if model_match
-                    else (0, 0)
+            elif _uses_thinking_level(params.model_id):
+                kwargs["thinking_config"] = types.ThinkingConfig(
+                    include_thoughts=True, thinking_level=REASONING_EFFORT_TO_THINKING_LEVELS[params.reasoning_effort]
                 )
-                is_new_gemini_model = model_version >= (3, 5)
-                thinking_kwargs: dict[str, Any] = {"include_thoughts": True}
-                if is_new_gemini_model and supports_thinking_level:
-                    thinking_kwargs["thinking_level"] = REASONING_EFFORT_TO_THINKING_LEVELS[reasoning_effort]
-                else:
-                    thinking_kwargs["thinking_budget"] = REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
-                kwargs["thinking_config"] = types.ThinkingConfig(**thinking_kwargs)
+            else:
+                kwargs["thinking_config"] = types.ThinkingConfig(
+                    include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort]
+                )
         if params.seed is not None:
             kwargs["seed"] = params.seed
         if params.service_tier is not None:

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -70,12 +70,12 @@ REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "max": 32768,
 }
 REASONING_EFFORT_TO_THINKING_LEVELS = {
-    "minimal": "MINIMAL",
-    "low": "LOW",
-    "medium": "MEDIUM",
-    "high": "HIGH",
-    "xhigh": "HIGH",
-    "max": "HIGH",
+    "minimal": types.ThinkingLevel.MINIMAL,
+    "low": types.ThinkingLevel.LOW,
+    "medium": types.ThinkingLevel.MEDIUM,
+    "high": types.ThinkingLevel.HIGH,
+    "xhigh": types.ThinkingLevel.HIGH,
+    "max": types.ThinkingLevel.HIGH,
 }
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
 
@@ -152,7 +152,7 @@ class GoogleProvider(AnyLLM):
                 reasoning_effort = params.reasoning_effort
                 model_fields = getattr(types.ThinkingConfig, "model_fields", {})
                 supports_thinking_level = "thinking_level" in model_fields
-                model_match = re.match(r"^gemini-(\d+)(?:\.(\d+))?", params.model_id.lower())
+                model_match = re.search(r"(?:^|/)gemini-(\d+)(?:\.(\d+))?", params.model_id.lower())
                 model_version = (
                     (
                         int(model_match.group(1)),

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -68,6 +68,14 @@ REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "xhigh": 32768,
     "max": 32768,
 }
+REASONING_EFFORT_TO_THINKING_LEVELS = {
+    "minimal": "MINIMAL",
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH",
+    "xhigh": "HIGH",
+    "max": "HIGH",
+}
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
 
 
@@ -140,9 +148,16 @@ class GoogleProvider(AnyLLM):
             if params.reasoning_effort is None or params.reasoning_effort == "none":
                 kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
             else:
-                kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort]
-                )
+                reasoning_effort = params.reasoning_effort
+                model_fields = getattr(types.ThinkingConfig, "model_fields", {})
+                supports_thinking_level = "thinking_level" in model_fields
+                is_new_gemini_model = params.model_id.lower().startswith(("gemini-3.5", "gemini-4"))
+                thinking_kwargs: dict[str, Any] = {"include_thoughts": True}
+                if is_new_gemini_model and supports_thinking_level:
+                    thinking_kwargs["thinking_level"] = REASONING_EFFORT_TO_THINKING_LEVELS[reasoning_effort]
+                else:
+                    thinking_kwargs["thinking_budget"] = REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
+                kwargs["thinking_config"] = types.ThinkingConfig(**thinking_kwargs)
         if params.seed is not None:
             kwargs["seed"] = params.seed
         if params.service_tier is not None:

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -78,17 +78,6 @@ REASONING_EFFORT_TO_THINKING_LEVELS = {
     "max": "HIGH",
 }
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
-_THINKING_LEVEL_MIN_GEMINI_VERSION = (3, 5)
-_GEMINI_VERSION_PATTERN = re.compile(r"gemini-(\d+)(?:\.(\d+))?")
-
-
-def _uses_thinking_level(model_id: str) -> bool:
-    """Gemini 3.5 and newer reject `thinking_budget` and expect `thinking_level` instead."""
-    match = _GEMINI_VERSION_PATTERN.search(model_id.lower())
-    if match is None:
-        return False
-    major, minor = int(match.group(1)), int(match.group(2) or 0)
-    return (major, minor) >= _THINKING_LEVEL_MIN_GEMINI_VERSION
 
 
 class GoogleProvider(AnyLLM):
@@ -159,15 +148,26 @@ class GoogleProvider(AnyLLM):
         if params.reasoning_effort != "auto":
             if params.reasoning_effort is None or params.reasoning_effort == "none":
                 kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
-            elif _uses_thinking_level(params.model_id) and "thinking_level" in types.ThinkingConfig.model_fields:
-                kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True,
-                    thinking_level=types.ThinkingLevel(REASONING_EFFORT_TO_THINKING_LEVELS[params.reasoning_effort]),
-                )
             else:
-                kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort]
+                reasoning_effort = params.reasoning_effort
+                model_fields = getattr(types.ThinkingConfig, "model_fields", {})
+                supports_thinking_level = "thinking_level" in model_fields
+                model_match = re.match(r"^gemini-(\d+)(?:\.(\d+))?", params.model_id.lower())
+                model_version = (
+                    (
+                        int(model_match.group(1)),
+                        int(model_match.group(2) or 0),
+                    )
+                    if model_match
+                    else (0, 0)
                 )
+                is_new_gemini_model = model_version >= (3, 5)
+                thinking_kwargs: dict[str, Any] = {"include_thoughts": True}
+                if is_new_gemini_model and supports_thinking_level:
+                    thinking_kwargs["thinking_level"] = REASONING_EFFORT_TO_THINKING_LEVELS[reasoning_effort]
+                else:
+                    thinking_kwargs["thinking_budget"] = REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
+                kwargs["thinking_config"] = types.ThinkingConfig(**thinking_kwargs)
         if params.seed is not None:
             kwargs["seed"] = params.seed
         if params.service_tier is not None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,7 +1,7 @@
 import base64
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
-from typing import Any, ClassVar, get_args
+from typing import Any, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -598,30 +598,57 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
             )
 
 
-def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest.MonkeyPatch) -> None:
-    class ThinkingConfig:
-        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object(), "thinking_level": object()}
-
-        def __init__(self, **kwargs: object) -> None:
-            self.kwargs = kwargs
-
-    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
-
+@pytest.mark.parametrize(
+    ("model_id", "reasoning_effort", "expected_level"),
+    [
+        ("gemini-3.5-flash", "xhigh", "HIGH"),
+        ("gemini-3.5-flash", "max", "HIGH"),
+        ("gemini-3.5-pro", "low", "LOW"),
+        ("models/gemini-3.5-flash", "medium", "MEDIUM"),
+        ("gemini-4-pro", "minimal", "MINIMAL"),
+        ("gemini-10.1-flash", "high", "HIGH"),
+    ],
+)
+def test_new_gemini_models_use_thinking_level(
+    model_id: str, reasoning_effort: ReasoningEffort, expected_level: str
+) -> None:
     result = GoogleProvider._convert_completion_params(
-        CompletionParams(model_id="gemini-3.5-flash", messages=[], reasoning_effort="xhigh"),
+        CompletionParams(
+            model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort=reasoning_effort
+        ),
         provider_name="gemini",
     )
 
-    assert result["thinking_config"].kwargs == {"include_thoughts": True, "thinking_level": "HIGH"}
+    assert result["config"].thinking_config == types.ThinkingConfig(
+        include_thoughts=True, thinking_level=types.ThinkingLevel(expected_level)
+    )
 
 
-def test_older_gemini_models_keep_thinking_budget() -> None:
+@pytest.mark.parametrize("model_id", ["gemini-3.0-flash", "gemini-3-pro-preview", "gemini-2.5-flash", "gemini-pro"])
+def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
     result = GoogleProvider._convert_completion_params(
-        CompletionParams(model_id="gemini-3.0-flash", messages=[], reasoning_effort="high"),
+        CompletionParams(model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"),
         provider_name="gemini",
     )
 
-    assert result["thinking_config"] == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
+    assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
+
+
+def test_new_gemini_models_fall_back_to_thinking_budget_on_older_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An SDK without `thinking_level` keeps the pre-existing `thinking_budget` behaviour."""
+    model_fields = {
+        name: field for name, field in types.ThinkingConfig.model_fields.items() if name != "thinking_level"
+    }
+    monkeypatch.setattr(types.ThinkingConfig, "model_fields", model_fields)
+
+    result = GoogleProvider._convert_completion_params(
+        CompletionParams(
+            model_id="gemini-3.5-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="xhigh"
+        ),
+        provider_name="gemini",
+    )
+
+    assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=32768)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -628,6 +628,7 @@ def test_new_gemini_models_use_thinking_level(
     "model_id",
     [
         "gemini-3.0-flash",
+        "gemini-3.4-flash",
         "gemini-3-pro-preview",
         "gemini-2.5-flash",
         "gemini-pro",

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -606,6 +606,10 @@ def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest
             self.kwargs = kwargs
 
     monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
+    monkeypatch.setattr(
+        "any_llm.providers.gemini.base.types.GenerateContentConfig",
+        lambda **kwargs: Mock(thinking_config=kwargs["thinking_config"]),
+    )
 
     result = GoogleProvider._convert_completion_params(
         CompletionParams(
@@ -614,9 +618,10 @@ def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest
         provider_name="gemini",
     )
 
-    thinking_config = result["config"].thinking_config
-    assert thinking_config.include_thoughts is True
-    assert thinking_config.thinking_level == types.ThinkingLevel.HIGH
+    assert result["config"].thinking_config.kwargs == {
+        "include_thoughts": True,
+        "thinking_level": types.ThinkingLevel.HIGH,
+    }
 
 
 def test_new_gemini_models_use_thinking_budget_when_sdk_lacks_thinking_level(
@@ -629,6 +634,10 @@ def test_new_gemini_models_use_thinking_budget_when_sdk_lacks_thinking_level(
             self.kwargs = kwargs
 
     monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
+    monkeypatch.setattr(
+        "any_llm.providers.gemini.base.types.GenerateContentConfig",
+        lambda **kwargs: Mock(thinking_config=kwargs["thinking_config"]),
+    )
 
     result = GoogleProvider._convert_completion_params(
         CompletionParams(
@@ -637,9 +646,7 @@ def test_new_gemini_models_use_thinking_budget_when_sdk_lacks_thinking_level(
         provider_name="gemini",
     )
 
-    thinking_config = result["config"].thinking_config
-    assert thinking_config.include_thoughts is True
-    assert thinking_config.thinking_budget == 24576
+    assert result["config"].thinking_config.kwargs == {"include_thoughts": True, "thinking_budget": 24576}
 
 
 def test_older_gemini_models_keep_thinking_budget() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,7 +1,7 @@
 import base64
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
-from typing import Any, get_args
+from typing import Any, ClassVar, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -598,57 +598,59 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
             )
 
 
-@pytest.mark.parametrize(
-    ("model_id", "reasoning_effort", "expected_level"),
-    [
-        ("gemini-3.5-flash", "xhigh", "HIGH"),
-        ("gemini-3.5-flash", "max", "HIGH"),
-        ("gemini-3.5-pro", "low", "LOW"),
-        ("models/gemini-3.5-flash", "medium", "MEDIUM"),
-        ("gemini-4-pro", "minimal", "MINIMAL"),
-        ("gemini-10.1-flash", "high", "HIGH"),
-    ],
-)
-def test_new_gemini_models_use_thinking_level(
-    model_id: str, reasoning_effort: ReasoningEffort, expected_level: str
-) -> None:
+def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ThinkingConfig:
+        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object(), "thinking_level": object()}
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
+
     result = GoogleProvider._convert_completion_params(
         CompletionParams(
-            model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort=reasoning_effort
+            model_id="gemini-3.10-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="max"
         ),
         provider_name="gemini",
     )
 
-    assert result["config"].thinking_config == types.ThinkingConfig(
-        include_thoughts=True, thinking_level=types.ThinkingLevel(expected_level)
+    thinking_config = result["config"].thinking_config
+    assert thinking_config.include_thoughts is True
+    assert thinking_config.thinking_level == types.ThinkingLevel.HIGH
+
+
+def test_new_gemini_models_use_thinking_budget_when_sdk_lacks_thinking_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ThinkingConfig:
+        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object()}
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
+
+    result = GoogleProvider._convert_completion_params(
+        CompletionParams(
+            model_id="gemini-3.5-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"
+        ),
+        provider_name="gemini",
     )
 
+    thinking_config = result["config"].thinking_config
+    assert thinking_config.include_thoughts is True
+    assert thinking_config.thinking_budget == 24576
 
-@pytest.mark.parametrize("model_id", ["gemini-3.0-flash", "gemini-3-pro-preview", "gemini-2.5-flash", "gemini-pro"])
-def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
+
+def test_older_gemini_models_keep_thinking_budget() -> None:
     result = GoogleProvider._convert_completion_params(
-        CompletionParams(model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"),
+        CompletionParams(
+            model_id="gemini-3.0-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"
+        ),
         provider_name="gemini",
     )
 
     assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
-
-
-def test_new_gemini_models_fall_back_to_thinking_budget_on_older_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An SDK without `thinking_level` keeps the pre-existing `thinking_budget` behaviour."""
-    model_fields = {
-        name: field for name, field in types.ThinkingConfig.model_fields.items() if name != "thinking_level"
-    }
-    monkeypatch.setattr(types.ThinkingConfig, "model_fields", model_fields)
-
-    result = GoogleProvider._convert_completion_params(
-        CompletionParams(
-            model_id="gemini-3.5-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="xhigh"
-        ),
-        provider_name="gemini",
-    )
-
-    assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=32768)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,7 +1,7 @@
 import base64
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
-from typing import Any, ClassVar, get_args
+from typing import Any, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -598,62 +598,45 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
             )
 
 
-def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest.MonkeyPatch) -> None:
-    class ThinkingConfig:
-        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object(), "thinking_level": object()}
-
-        def __init__(self, **kwargs: object) -> None:
-            self.kwargs = kwargs
-
-    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
-    monkeypatch.setattr(
-        "any_llm.providers.gemini.base.types.GenerateContentConfig",
-        lambda **kwargs: Mock(thinking_config=kwargs["thinking_config"]),
-    )
-
-    result = GoogleProvider._convert_completion_params(
-        CompletionParams(
-            model_id="gemini-3.10-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="max"
-        ),
-        provider_name="gemini",
-    )
-
-    assert result["config"].thinking_config.kwargs == {
-        "include_thoughts": True,
-        "thinking_level": types.ThinkingLevel.HIGH,
-    }
-
-
-def test_new_gemini_models_use_thinking_budget_when_sdk_lacks_thinking_level(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    ("model_id", "reasoning_effort", "expected_level"),
+    [
+        ("gemini-3.5-flash", "xhigh", types.ThinkingLevel.HIGH),
+        ("gemini-3.5-flash", "max", types.ThinkingLevel.HIGH),
+        ("gemini-3.5-pro", "low", types.ThinkingLevel.LOW),
+        ("models/gemini-3.5-flash", "medium", types.ThinkingLevel.MEDIUM),
+        ("gemini-3.10-flash", "minimal", types.ThinkingLevel.MINIMAL),
+        ("gemini-4-pro", "high", types.ThinkingLevel.HIGH),
+    ],
+)
+def test_new_gemini_models_use_thinking_level(
+    model_id: str, reasoning_effort: ReasoningEffort, expected_level: types.ThinkingLevel
 ) -> None:
-    class ThinkingConfig:
-        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object()}
-
-        def __init__(self, **kwargs: object) -> None:
-            self.kwargs = kwargs
-
-    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
-    monkeypatch.setattr(
-        "any_llm.providers.gemini.base.types.GenerateContentConfig",
-        lambda **kwargs: Mock(thinking_config=kwargs["thinking_config"]),
-    )
-
     result = GoogleProvider._convert_completion_params(
         CompletionParams(
-            model_id="gemini-3.5-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"
+            model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort=reasoning_effort
         ),
         provider_name="gemini",
     )
 
-    assert result["config"].thinking_config.kwargs == {"include_thoughts": True, "thinking_budget": 24576}
+    assert result["config"].thinking_config == types.ThinkingConfig(
+        include_thoughts=True, thinking_level=expected_level
+    )
 
 
-def test_older_gemini_models_keep_thinking_budget() -> None:
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-3.0-flash",
+        "gemini-3-pro-preview",
+        "gemini-2.5-flash",
+        "gemini-pro",
+        "projects/p/locations/l/publishers/google/models/gemini-3-pro",
+    ],
+)
+def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
     result = GoogleProvider._convert_completion_params(
-        CompletionParams(
-            model_id="gemini-3.0-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"
-        ),
+        CompletionParams(model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"),
         provider_name="gemini",
     )
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1,7 +1,7 @@
 import base64
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
-from typing import Any, get_args
+from typing import Any, ClassVar, get_args
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -596,6 +596,32 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
             assert thinking_config == types.ThinkingConfig(
                 include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
             )
+
+
+def test_new_gemini_models_use_thinking_level_when_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ThinkingConfig:
+        model_fields: ClassVar[dict[str, object]] = {"include_thoughts": object(), "thinking_level": object()}
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("any_llm.providers.gemini.base.types.ThinkingConfig", ThinkingConfig)
+
+    result = GoogleProvider._convert_completion_params(
+        CompletionParams(model_id="gemini-3.5-flash", messages=[], reasoning_effort="xhigh"),
+        provider_name="gemini",
+    )
+
+    assert result["thinking_config"].kwargs == {"include_thoughts": True, "thinking_level": "HIGH"}
+
+
+def test_older_gemini_models_keep_thinking_budget() -> None:
+    result = GoogleProvider._convert_completion_params(
+        CompletionParams(model_id="gemini-3.0-flash", messages=[], reasoning_effort="high"),
+        provider_name="gemini",
+    )
+
+    assert result["thinking_config"] == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Use Gemini thinking levels for Gemini 3.5+ models while preserving thinking-budget fallback for older models and SDKs without thinking-level support. The model-version parser also handles future minor and major versions.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure

## Relevant issues

Fixes #1276

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] AI Usage: AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: Used to inspect review feedback and draft focused regression coverage.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable reasoning levels on newer Gemini models, including high-effort reasoning.
  * Reasoning settings are now automatically selected based on the Gemini model version.

* **Bug Fixes**
  * Preserved existing thinking-budget behaviour for older Gemini models.
  * Improved compatibility across supported Gemini model generations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->