### PR TITLE
fix: run sync calls on an event loop that outlives them

### DIFF
--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -133,11 +133,12 @@ class XaiProvider(AnyLLM):
     @override
     def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
         # The xAI SDK builds its grpc.aio channels eagerly, and grpc binds a channel to
-        # whatever event loop is current in the constructing thread. The sync API runs each
-        # request on a fresh worker loop (see any_llm.utils.aio), so a client built here
-        # would always belong to a different loop than the one driving the RPC, and every
-        # call would fail with "attached to a different loop". Defer construction instead,
-        # keyed by loop, so the channel always belongs to the loop that will use it.
+        # whatever event loop is current in the constructing thread. A provider is built on
+        # the caller's thread, while its requests run somewhere else: on the sync API's runner
+        # loop (see any_llm.utils.aio), or on whichever loop an async caller is using. A client
+        # built here would belong to neither, and every call would fail with "attached to a
+        # different loop". Defer construction instead, keyed by loop, so the channel always
+        # belongs to the loop that will use it.
         self._client_kwargs: dict[str, Any] = {"api_key": api_key, **kwargs}
         self._clients_by_loop: dict[asyncio.AbstractEventLoop, XaiAsyncClient] = {}
 
@@ -169,9 +170,10 @@ class XaiProvider(AnyLLM):
     def _discard_clients_for_closed_loops(self) -> None:
         """Drop clients whose loop has been closed, releasing their grpc socket.
 
-        The sync API gives every request a throwaway loop, so a provider used from sync code
-        would otherwise accumulate one live channel per call for its whole life. A closed
-        loop can never serve another request, so its client is dead weight.
+        Sync calls share one long-lived loop, but its nested cases still run on a private loop
+        that closes afterwards, and an async caller can close its own loop at any time. A
+        closed loop can never serve another request, so its client is dead weight holding a
+        socket open.
         """
         for loop in [loop for loop in self._clients_by_loop if loop.is_closed()]:
             _close_client(self._clients_by_loop.pop(loop))

--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -187,6 +187,14 @@ def _run_in_dedicated_loop(coro: Coroutine[Any, Any, T]) -> T:
         return executor.submit(run_in_thread).result()
 
 
+def _is_running_on(loop: asyncio.AbstractEventLoop) -> bool:
+    """Whether the calling thread is the one driving ``loop``."""
+    try:
+        return asyncio.get_running_loop() is loop
+    except RuntimeError:
+        return False
+
+
 def _reject_running_loop_if_needed(allow_running_loop: bool) -> asyncio.AbstractEventLoop | None:
     """Return the loop running in this thread, if any, rejecting the call when not allowed."""
     try:
@@ -298,12 +306,17 @@ def _async_source_to_sync_iter(
         if task is not None and not task.done():
             loop.call_soon_threadsafe(task.cancel)
 
-        # `consume` closes the source, so waiting for it means the source is fully cleaned up by the
-        # time this iterator returns.
-        consumer_done.wait()
+        # Closing from the thread that drives the loop, which happens when a garbage collection
+        # pass finalises an abandoned iterator there, must not wait: the cancellation just
+        # scheduled can only run once this thread returns to the loop, so blocking would wedge it
+        # permanently. Leave the consumer to settle on its own in that case.
+        if not _is_running_on(loop):
+            # `consume` closes the source, so waiting for it means the source is fully cleaned up
+            # by the time this iterator returns.
+            consumer_done.wait()
 
-        if loop_thread is not None:
-            _stop_loop_thread(loop, loop_thread)
+            if loop_thread is not None:
+                _stop_loop_thread(loop, loop_thread)
 
 
 def async_iter_to_sync_iter(async_iter: AsyncIterator[T], allow_running_loop: bool = True) -> Iterator[T]:

--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -173,6 +173,14 @@ def _stop_loop_thread(loop: asyncio.AbstractEventLoop, thread: threading.Thread)
     loop.close()
 
 
+def _stop_loop_thread_when_settled(
+    loop: asyncio.AbstractEventLoop, thread: threading.Thread, settled: threading.Event
+) -> None:
+    """Wait for ``settled``, then tear the loop down, for callers that cannot afford to block."""
+    settled.wait()
+    _stop_loop_thread(loop, thread)
+
+
 def _run_in_dedicated_loop(coro: Coroutine[Any, Any, T]) -> T:
     """Run ``coro`` on a throwaway loop in a new thread.
 
@@ -317,6 +325,15 @@ def _async_source_to_sync_iter(
 
             if loop_thread is not None:
                 _stop_loop_thread(loop, loop_thread)
+        elif loop_thread is not None:
+            # A private loop still has to be stopped, and it cannot stop itself from inside, so
+            # hand that to a helper rather than leaving the loop and its thread behind.
+            threading.Thread(
+                target=_stop_loop_thread_when_settled,
+                args=(loop, loop_thread, consumer_done),
+                name=f"{RUNNER_THREAD_NAME}-nested-teardown",
+                daemon=True,
+            ).start()
 
 
 def async_iter_to_sync_iter(async_iter: AsyncIterator[T], allow_running_loop: bool = True) -> Iterator[T]:

--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+import contextvars
+import os
 import queue
 import threading
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -14,13 +16,196 @@ T = TypeVar("T")
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterator
 
+RUNNER_THREAD_NAME = "any-llm-async-runner"
+
+
+def _start_loop_thread(name: str) -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+    """Start an event loop in a new daemon thread and return both once the loop is running."""
+    loop = asyncio.new_event_loop()
+    loop_started = threading.Event()
+
+    def run_forever() -> None:
+        asyncio.set_event_loop(loop)
+        loop_started.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=run_forever, name=name, daemon=True)
+    thread.start()
+    loop_started.wait()
+
+    return loop, thread
+
+
+class _RunnerLoop:
+    """Holds the long-lived event loop that backs the sync API.
+
+    Provider clients are built once per provider instance and cache their transports (HTTP
+    connection pools, gRPC channels), which stay bound to the loop that first used them. Running
+    each sync call on its own loop and then closing it leaves those transports bound to a dead
+    loop, so the next call fails with "Event loop is closed". A loop that outlives every call
+    keeps them usable.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def get(self) -> asyncio.AbstractEventLoop:
+        with self._lock:
+            if self._loop is None or self._loop.is_closed():
+                self._loop, _ = _start_loop_thread(RUNNER_THREAD_NAME)
+
+            return self._loop
+
+    def forget(self) -> None:
+        """Drop the loop inherited by a forked child, whose thread did not survive the fork."""
+        self._lock = threading.Lock()
+        self._loop = None
+
+
+_runner = _RunnerLoop()
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_runner.forget)
+
+
+def _get_runner_loop() -> asyncio.AbstractEventLoop:
+    """Return the long-lived event loop that backs the sync API."""
+    return _runner.get()
+
+
+def _pending_tasks() -> list[asyncio.Task[Any]]:
+    """Return the unfinished tasks on the running loop, other than the one asking."""
+    return [task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()]
+
+
+async def _await_with_cleanup(coro: Coroutine[Any, Any, T]) -> T:
+    """Await ``coro``, then settle every remaining task before the loop it runs on is closed.
+
+    Only safe on a loop dedicated to this one call: every task on it belongs to this call. Async
+    HTTP clients can schedule response cleanup after the awaited coroutine returns, and closing the
+    loop first breaks it.
+    """
+    try:
+        result = await coro
+    except Exception:
+        pending_tasks = _pending_tasks()
+
+        for task in pending_tasks:
+            task.cancel()
+
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        raise
+
+    pending_tasks = _pending_tasks()
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    return result
+
+
+async def _settle_remaining_tasks() -> None:
+    """Cancel and await whatever is left on the running loop, so it can be closed safely.
+
+    Cancelling on a live loop lets each task run its own cleanup, which is what keeps a transport
+    from trying to schedule callbacks on a loop that is already gone.
+    """
+    pending_tasks = _pending_tasks()
+
+    for task in pending_tasks:
+        task.cancel()
+
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    await asyncio.get_running_loop().shutdown_asyncgens()
+
+
+def _submit_to_loop(coro: Coroutine[Any, Any, T], loop: asyncio.AbstractEventLoop) -> T:
+    """Run ``coro`` on ``loop`` from a thread that is not running it, and block for the result.
+
+    Background tasks the coroutine leaves behind are not waited on or cancelled: the loop is shared
+    with other calls and outlives all of them, so those tasks finish on their own and are not this
+    call's to touch.
+    """
+    context = contextvars.copy_context()
+    result_future: concurrent.futures.Future[T] = concurrent.futures.Future()
+    task_holder: dict[str, asyncio.Task[T]] = {}
+
+    def schedule() -> None:
+        task = loop.create_task(coro, context=context)
+        task_holder["task"] = task
+        task.add_done_callback(complete)
+
+    def complete(task: asyncio.Task[T]) -> None:
+        if task.cancelled():
+            result_future.set_exception(asyncio.CancelledError())
+            return
+
+        error = task.exception()
+        if error is not None:
+            result_future.set_exception(error)
+        else:
+            result_future.set_result(task.result())
+
+    loop.call_soon_threadsafe(schedule)
+
+    try:
+        return result_future.result()
+    except BaseException:
+        # An interrupt in the calling thread should not leave the coroutine running on the loop.
+        task = task_holder.get("task")
+        if task is not None and not task.done():
+            loop.call_soon_threadsafe(task.cancel)
+        raise
+
+
+def _stop_loop_thread(loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+    """Settle the work left on a private loop, then stop its thread and close it."""
+    with contextlib.suppress(Exception):
+        # Teardown runs from a `finally`, so a failure to settle must not mask the original error.
+        _submit_to_loop(_settle_remaining_tasks(), loop)
+
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join()
+    loop.close()
+
+
+def _run_in_dedicated_loop(coro: Coroutine[Any, Any, T]) -> T:
+    """Run ``coro`` on a throwaway loop in a new thread.
+
+    Only used when the caller is itself running on the runner loop, where submitting back to that
+    loop and blocking on the result would deadlock.
+    """
+
+    def run_in_thread() -> T:
+        return asyncio.run(_await_with_cleanup(coro))
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        return executor.submit(run_in_thread).result()
+
+
+def _reject_running_loop_if_needed(allow_running_loop: bool) -> asyncio.AbstractEventLoop | None:
+    """Return the loop running in this thread, if any, rejecting the call when not allowed."""
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+    if not allow_running_loop:
+        msg = "Cannot use the `sync` API in an `async` context. Use the `async` API instead."
+        raise RuntimeError(msg)
+
+    return running_loop
+
 
 def run_async_in_sync(coro: Coroutine[Any, Any, T], allow_running_loop: bool = True) -> T:
     """Run an async coroutine in a synchronous context.
 
-    Handles different event loop scenarios:
-    - If a loop is running, uses threading to avoid conflicts
-    - If no loop exists, creates one or uses the current loop
+    The coroutine runs on a long-lived event loop owned by any-llm, so cached provider clients
+    keep working across calls, and the calling thread blocks until it finishes.
 
     Args:
         coro: The coroutine to execute
@@ -30,91 +215,40 @@ def run_async_in_sync(coro: Coroutine[Any, Any, T], allow_running_loop: bool = T
         The result of the coroutine execution
 
     """
-    try:
-        # Check if there's a running event loop
-        asyncio.get_running_loop()
-        running_loop = True
-    except RuntimeError:
-        running_loop = False
+    running_loop = _reject_running_loop_if_needed(allow_running_loop)
+    runner_loop = _get_runner_loop()
 
-    async def run_with_cleanup() -> T:
-        try:
-            result = await coro
-        except Exception:
-            pending_tasks = [
-                task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()
-            ]
+    if running_loop is runner_loop:
+        return _run_in_dedicated_loop(coro)
 
-            for task in pending_tasks:
-                task.cancel()
-
-            if pending_tasks:
-                await asyncio.gather(*pending_tasks, return_exceptions=True)
-
-            raise
-
-        # Async HTTP clients can schedule response cleanup after the main coroutine returns. Finish
-        # those tasks before the event loop is closed so their transports can still schedule callbacks.
-        pending_tasks = [task for task in asyncio.all_tasks() if not task.done() and task is not asyncio.current_task()]
-        if pending_tasks:
-            await asyncio.gather(*pending_tasks, return_exceptions=True)
-
-        return result
-
-    if running_loop:
-        if not allow_running_loop:
-            msg = "Cannot use the `sync` API in an `async` context. Use the `async` API instead."
-            raise RuntimeError(msg)
-
-        # If we get here, there's a loop running, so we can't use run_until_complete()
-        # or asyncio.run() - must use threading approach
-        def run_in_thread() -> T:
-            return asyncio.run(run_with_cleanup())
-
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            return executor.submit(run_in_thread).result()
-    else:
-        # No running event loop: reuse an available loop, or create one when the thread has no loop.
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            return asyncio.run(run_with_cleanup())
-
-        if loop.is_closed():
-            return asyncio.run(run_with_cleanup())
-
-        # A reused loop belongs to the caller and stays open, so tasks on it are not ours to cancel
-        # or wait on, and there is no loop closure for background tasks to race with.
-        return loop.run_until_complete(coro)
+    return _submit_to_loop(coro, runner_loop)
 
 
 def _async_source_to_sync_iter(
     get_async_iter: Callable[[], Awaitable[AsyncIterator[T]]], allow_running_loop: bool = True
 ) -> Iterator[T]:
     """Bridge an async iterator source into a synchronous iterator."""
-    try:
-        asyncio.get_running_loop()
-        running_loop = True
-    except RuntimeError:
-        running_loop = False
+    running_loop = _reject_running_loop_if_needed(allow_running_loop)
 
-    if running_loop and not allow_running_loop:
-        msg = "Cannot use the `sync` API in an `async` context. Use the `async` API instead."
-        raise RuntimeError(msg)
+    # The whole iterator is consumed by one task so the source keeps a single context, which async
+    # generators rely on to reset the contextvar tokens they set.
+    runner_loop = _get_runner_loop()
+    if running_loop is runner_loop:
+        # Draining the queue below would block the runner loop's own thread, so the consumer could
+        # never make progress. This nested case gets a private loop instead.
+        loop, loop_thread = _start_loop_thread(f"{RUNNER_THREAD_NAME}-nested")
+    else:
+        loop, loop_thread = runner_loop, None
 
     done_sentinel = object()
     output_queue: queue.Queue[object] = queue.Queue()
     cancel_event = threading.Event()
-    loop_ready = threading.Event()
-    loop_holder: dict[str, asyncio.AbstractEventLoop | None] = {"loop": None}
+    task_ready = threading.Event()
+    consumer_done = threading.Event()
     task_holder: dict[str, asyncio.Task[None] | None] = {"task": None}
 
-    def worker() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop_holder["loop"] = loop
-
-        async def consume() -> None:
+    async def consume() -> None:
+        try:
             async_iter = await get_async_iter()
             try:
                 async for item in async_iter:
@@ -128,32 +262,27 @@ def _async_source_to_sync_iter(
                         maybe_awaitable = aclose()
                         if asyncio.iscoroutine(maybe_awaitable):
                             await maybe_awaitable
-
-        task = loop.create_task(consume())
-        task_holder["task"] = task
-        loop_ready.set()
-
-        try:
-            loop.run_until_complete(task)
         except asyncio.CancelledError:
             pass
         except Exception as exc:
             output_queue.put(exc)
         finally:
-            pending_tasks = [pending for pending in asyncio.all_tasks(loop) if not pending.done()]
-            for pending in pending_tasks:
-                pending.cancel()
-
-            if pending_tasks:
-                loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
-
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.close()
             output_queue.put(done_sentinel)
 
-    thread = threading.Thread(target=worker, daemon=True)
-    thread.start()
-    loop_ready.wait()
+    context = contextvars.copy_context()
+
+    def schedule() -> None:
+        task = loop.create_task(consume(), context=context)
+        task.add_done_callback(lambda _: consumer_done.set())
+        task_holder["task"] = task
+        task_ready.set()
+
+    loop.call_soon_threadsafe(schedule)
+    # Both waits below are unbounded, as the thread-based implementation before them was. Nothing
+    # stops the loop being submitted to, so `schedule` always runs, and `consume` always settles the
+    # source before signalling, so the only way to wait forever is a source that never finishes
+    # closing, which no timeout here could rescue.
+    task_ready.wait()
 
     try:
         while True:
@@ -165,11 +294,16 @@ def _async_source_to_sync_iter(
             yield cast("T", result)
     finally:
         cancel_event.set()
-        loop = loop_holder["loop"]
         task = task_holder["task"]
-        if loop is not None and task is not None and not task.done():
+        if task is not None and not task.done():
             loop.call_soon_threadsafe(task.cancel)
-        thread.join()
+
+        # `consume` closes the source, so waiting for it means the source is fully cleaned up by the
+        # time this iterator returns.
+        consumer_done.wait()
+
+        if loop_thread is not None:
+            _stop_loop_thread(loop, loop_thread)
 
 
 def async_iter_to_sync_iter(async_iter: AsyncIterator[T], allow_running_loop: bool = True) -> Iterator[T]:

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -197,7 +197,8 @@ def test_client_is_built_on_the_loop_that_will_drive_it() -> None:
 
     grpc binds a channel to the loop that is current when it is built, so building it
     anywhere else fails at the first call with "attached to a different loop". That is what
-    broke every sync xAI request, since the sync bridge runs each one on a fresh worker loop.
+    broke every sync xAI request, since the sync bridge runs them on a loop of its own rather
+    than on whichever one was current where the provider was constructed.
     """
     from any_llm.providers.xai.xai import XaiProvider
 
@@ -219,8 +220,8 @@ def test_client_is_built_on_the_loop_that_will_drive_it() -> None:
 
 
 def test_each_event_loop_gets_its_own_client() -> None:
-    """A provider reused across sync calls sees a new worker loop each time, so it needs a
-    new client each time; within one loop it must reuse the channel rather than rebuild it.
+    """A provider shared between loops, such as an async caller's and the sync API's runner,
+    needs a client per loop; within one loop it must reuse the channel rather than rebuild it.
     """
     from any_llm.providers.xai.xai import XaiProvider
 
@@ -238,9 +239,9 @@ def test_each_event_loop_gets_its_own_client() -> None:
 
 
 def test_clients_for_closed_loops_are_dropped_and_closed() -> None:
-    """Sync callers get a throwaway loop per request, so the per-loop cache has to shed the
-    dead ones. Left alone it would hold a live grpc channel, and its socket, per call made
-    for the whole life of the provider.
+    """Loops still come and go, from the sync API's nested cases and from async callers that
+    close their own, so the per-loop cache has to shed the dead ones. Left alone it would hold
+    a live grpc channel, and its socket, per dead loop for the whole life of the provider.
     """
     from any_llm.providers.xai.xai import XaiProvider
 

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -1,10 +1,14 @@
+import json
 import sys
+import threading
 from collections.abc import AsyncIterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from inspect import signature
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import override
 
 from any_llm import AnyLLM
 from any_llm.api import acompletion, aresponses, completion, responses
@@ -398,3 +402,86 @@ async def test_provider_factory_can_create_all_supported_providers() -> None:
         provider_instance = AnyLLM.create(provider_name, **kwargs)
 
         assert isinstance(provider_instance, AnyLLM), f"Failed to create valid AnyLLM instance for {provider_name}"
+
+
+class _ChatCompletionHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive, so the connection stays in the client's pool
+
+    def do_POST(self) -> None:
+        self.rfile.read(int(self.headers.get("content-length", 0)))
+        encoded = json.dumps(
+            {
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}
+                ],
+            }
+        ).encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+        self.wfile.flush()
+
+    @override
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def test_sync_completion_can_be_called_repeatedly_on_one_provider() -> None:
+    """Regression test for #1268.
+
+    Each sync call used to run on its own event loop and close it, while the provider client kept
+    the connection pool it built on the first loop. Reusing that pooled connection from the next
+    call raised `RuntimeError: Event loop is closed`. This exercises the real OpenAI SDK, httpx and
+    anyio against a local server, with no live provider or API key required.
+
+    The calls happen on a worker thread so that no event loop is set for the thread, which is what
+    the reported failure needed and what `asyncio.run` gives every Python version under test.
+    Retries are disabled because the OpenAI SDK otherwise hides the failure by reconnecting, while
+    SDKs that do not retry (such as Ollama's, in the report) surface it to the caller.
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ChatCompletionHandler)
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    contents: list[str | None] = []
+    errors: list[Exception] = []
+
+    def call_twice() -> None:
+        api_base = f"http://127.0.0.1:{server.server_address[1]}/v1"
+        provider = AnyLLM.create_openai_compatible(
+            name="local-completion", api_base=api_base, api_key="test", max_retries=0
+        )
+
+        try:
+            # A short message leaves a pooled connection behind; the long one reuses it.
+            for content in ("hello", "c" * 300_000):
+                response = provider.completion(
+                    model="test-model",
+                    messages=[{"role": "user", "content": content}],
+                )
+                assert isinstance(response, ChatCompletion)
+                contents.append(response.choices[0].message.content)
+        except Exception as exc:
+            errors.append(exc)
+
+    caller = threading.Thread(target=call_twice, daemon=True)
+    caller.start()
+    caller.join(timeout=30)
+
+    try:
+        assert not caller.is_alive()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+    assert errors == []
+    assert contents == ["Hello", "Hello"]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 import pytest
 
-from any_llm.utils.aio import async_iter_to_sync_iter, run_async_in_sync
+from any_llm.utils.aio import _get_runner_loop, _runner, async_iter_to_sync_iter, run_async_in_sync
 
 
 def test_run_async_in_sync_fails_with_background_task_state() -> None:
@@ -35,15 +35,15 @@ def test_run_async_in_sync_fails_with_background_task_state() -> None:
     asyncio.run(test_in_streamlit_context())
 
 
-def test_run_async_in_sync_cleans_up_background_tasks_without_running_loop() -> None:
-    task_completed = {"value": False}
+def test_run_async_in_sync_background_tasks_survive_the_call_without_a_running_loop() -> None:
+    task_completed = threading.Event()
     result: list[str] = []
     errors: list[Exception] = []
 
     async def operation_with_background_task() -> str:
         async def background_work() -> None:
-            await asyncio.sleep(0)
-            task_completed["value"] = True
+            await asyncio.sleep(0.02)
+            task_completed.set()
 
         task = asyncio.create_task(background_work())
         assert task is not None
@@ -62,14 +62,153 @@ def test_run_async_in_sync_cleans_up_background_tasks_without_running_loop() -> 
     assert not thread.is_alive()
     assert errors == []
     assert result == ["operation_started"]
-    assert task_completed["value"] is True
+    # The runner loop outlives the call, so the task keeps running instead of being cancelled.
+    assert task_completed.wait(timeout=5)
 
 
-def test_run_async_in_sync_cancels_its_background_tasks_when_the_operation_fails() -> None:
+def test_run_async_in_sync_reuses_one_open_loop_across_calls() -> None:
+    loops: list[asyncio.AbstractEventLoop] = []
+
+    async def record_loop() -> str:
+        loops.append(asyncio.get_running_loop())
+        return "recorded"
+
+    def run_in_thread() -> None:
+        run_async_in_sync(record_loop())
+        run_async_in_sync(record_loop())
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert len(loops) == 2
+    # Provider clients cache transports bound to the loop that created them, so every sync call has
+    # to run on the same loop, and that loop must stay open once the call returns.
+    assert loops[0] is loops[1]
+    assert not loops[0].is_closed()
+
+
+def test_run_async_in_sync_does_not_wait_for_background_tasks_of_other_calls() -> None:
+    long_running_started = threading.Event()
+
+    async def operation_leaving_a_long_task() -> str:
+        async def long_running_work() -> None:
+            long_running_started.set()
+            await asyncio.sleep(30)
+
+        task = asyncio.create_task(long_running_work())
+        assert task is not None
+        return "first"
+
+    async def second_operation() -> str:
+        return "second"
+
+    def run_in_thread() -> None:
+        run_async_in_sync(operation_leaving_a_long_task())
+        assert long_running_started.wait(timeout=5)
+        run_async_in_sync(second_operation())
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive(), "a sync call blocked on background work it does not own"
+
+
+@pytest.fixture
+def restore_runner_loop() -> Generator[None, None, None]:
+    """Undo runner loop swaps, so tests holding clients bound to it are not left stranded."""
+    previous_loop = _runner._loop
+    try:
+        yield
+    finally:
+        _runner._loop = previous_loop
+
+
+def test_runner_loop_is_rebuilt_after_a_fork(restore_runner_loop: None) -> None:
+    first_loop = _get_runner_loop()
+
+    # A forked child inherits the loop object but not the thread running it, so the child has to
+    # build its own instead of waiting on a loop nothing is driving.
+    _runner.forget()
+    second_loop = _get_runner_loop()
+
+    assert second_loop is not first_loop
+
+    async def operation() -> str:
+        return "ran on the new loop"
+
+    result: list[str] = []
+    thread = threading.Thread(target=lambda: result.append(run_async_in_sync(operation())), daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert result == ["ran on the new loop"]
+
+
+def test_runner_loop_is_replaced_once_it_has_been_closed(restore_runner_loop: None) -> None:
+    stale_loop = asyncio.new_event_loop()
+    stale_loop.close()
+    _runner._loop = stale_loop
+
+    assert _get_runner_loop() is not stale_loop
+
+
+def test_run_async_in_sync_ignores_a_closed_current_loop() -> None:
+    results: list[str] = []
+
+    def run_in_thread() -> None:
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        asyncio.set_event_loop(closed_loop)
+
+        async def operation() -> str:
+            return "ran on the runner loop"
+
+        results.append(run_async_in_sync(operation()))
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert results == ["ran on the runner loop"]
+
+
+def test_run_async_in_sync_from_the_runner_loop_does_not_deadlock() -> None:
+    async def inner() -> str:
+        return "inner"
+
+    async def outer() -> str:
+        # A coroutine already running on the runner loop calling back into the sync API.
+        return run_async_in_sync(inner())
+
+    def run_in_thread() -> None:
+        assert run_async_in_sync(outer()) == "inner"
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+
+
+def test_nested_sync_call_settles_its_background_tasks_before_its_loop_closes() -> None:
+    background_finished = threading.Event()
     background_cancelled = threading.Event()
-    errors: list[Exception] = []
 
-    async def failing_operation() -> str:
+    async def succeeding_inner() -> str:
+        async def background_work() -> None:
+            await asyncio.sleep(0.01)
+            background_finished.set()
+
+        task = asyncio.create_task(background_work())
+        assert task is not None
+        return "inner"
+
+    async def failing_inner() -> str:
         started = asyncio.Event()
 
         async def background_work() -> None:
@@ -84,13 +223,42 @@ def test_run_async_in_sync_cancels_its_background_tasks_when_the_operation_fails
         assert task is not None
         await started.wait()
 
-        msg = "provider failed"
+        msg = "inner failed"
         raise ValueError(msg)
+
+    async def outer() -> str:
+        # These nested calls get a private loop that really does close, so leftover tasks have to be
+        # settled first: awaited on success, cancelled on failure.
+        result = run_async_in_sync(succeeding_inner())
+        with pytest.raises(ValueError, match="inner failed"):
+            run_async_in_sync(failing_inner())
+        return result
+
+    results: list[str] = []
+    thread = threading.Thread(target=lambda: results.append(run_async_in_sync(outer())), daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert results == ["inner"]
+    assert background_finished.is_set()
+    assert background_cancelled.is_set()
+
+
+def test_run_async_in_sync_surfaces_cancellation_of_its_own_task() -> None:
+    async def cancel_itself() -> str:
+        task = asyncio.current_task()
+        assert task is not None
+        task.cancel()
+        await asyncio.sleep(0)
+        return "unreachable"
+
+    errors: list[BaseException] = []
 
     def run_in_thread() -> None:
         try:
-            run_async_in_sync(failing_operation())
-        except Exception as exc:
+            run_async_in_sync(cancel_itself())
+        except BaseException as exc:
             errors.append(exc)
 
     thread = threading.Thread(target=run_in_thread, daemon=True)
@@ -98,22 +266,7 @@ def test_run_async_in_sync_cancels_its_background_tasks_when_the_operation_fails
     thread.join(timeout=5)
 
     assert not thread.is_alive()
-    assert [str(error) for error in errors] == ["provider failed"]
-    # This loop is about to close, so its leftover task is cancelled while it can still clean up.
-    assert background_cancelled.is_set()
-
-
-def test_run_async_in_sync_disallows_running_loop_when_requested() -> None:
-    async def operation() -> str:
-        return "unreachable"
-
-    async def call_from_async_context() -> None:
-        coro = operation()
-        with pytest.raises(RuntimeError, match="Cannot use the `sync` API in an `async` context"):
-            run_async_in_sync(coro, allow_running_loop=False)
-        coro.close()
-
-    asyncio.run(call_from_async_context())
+    assert [type(error) for error in errors] == [asyncio.CancelledError]
 
 
 def test_run_async_in_sync_leaves_caller_owned_tasks_on_a_reused_loop() -> None:
@@ -137,8 +290,6 @@ def test_run_async_in_sync_leaves_caller_owned_tasks_on_a_reused_loop() -> None:
             msg = "provider failed"
             raise ValueError(msg)
 
-        # A loop handed back by `asyncio.get_event_loop()` is the caller's, and its tasks may never
-        # finish, so waiting on them would hang and cancelling them would discard the caller's work.
         state["result"] = run_async_in_sync(operation())
         with pytest.raises(ValueError, match="provider failed"):
             run_async_in_sync(failing_operation())
@@ -157,27 +308,6 @@ def test_run_async_in_sync_leaves_caller_owned_tasks_on_a_reused_loop() -> None:
     assert state["caller_task_cancelled"] is False
 
 
-def test_run_async_in_sync_ignores_a_closed_current_loop() -> None:
-    results: list[str] = []
-
-    def run_in_thread() -> None:
-        closed_loop = asyncio.new_event_loop()
-        closed_loop.close()
-        asyncio.set_event_loop(closed_loop)
-
-        async def operation() -> str:
-            return "ran on a fresh loop"
-
-        results.append(run_async_in_sync(operation()))
-
-    thread = threading.Thread(target=run_in_thread, daemon=True)
-    thread.start()
-    thread.join(timeout=5)
-
-    assert not thread.is_alive()
-    assert results == ["ran on a fresh loop"]
-
-
 def test_run_async_in_sync_propagates_runtime_error_from_coroutine() -> None:
     errors: list[Exception] = []
 
@@ -189,8 +319,6 @@ def test_run_async_in_sync_propagates_runtime_error_from_coroutine() -> None:
             msg = "provider raised RuntimeError"
             raise RuntimeError(msg)
 
-        # Looking the loop up separately from running the coroutine keeps a RuntimeError raised by
-        # the coroutine from being mistaken for a missing loop and retried on a spent coroutine.
         try:
             run_async_in_sync(failing_operation())
         except Exception as exc:
@@ -202,6 +330,19 @@ def test_run_async_in_sync_propagates_runtime_error_from_coroutine() -> None:
 
     assert not thread.is_alive()
     assert [str(error) for error in errors] == ["provider raised RuntimeError"]
+
+
+def test_run_async_in_sync_disallows_running_loop_when_requested() -> None:
+    async def operation() -> str:
+        return "unreachable"
+
+    async def call_from_async_context() -> None:
+        coro = operation()
+        with pytest.raises(RuntimeError, match="Cannot use the `sync` API in an `async` context"):
+            run_async_in_sync(coro, allow_running_loop=False)
+        coro.close()
+
+    asyncio.run(call_from_async_context())
 
 
 def test_async_iter_to_sync_iter_preserves_contextvars() -> None:
@@ -241,6 +382,87 @@ def test_async_iter_to_sync_iter_closes_cleanly_on_generator_close() -> None:
         time.sleep(0.01)
 
     assert cleanup["done"] is True
+
+
+def test_async_iter_to_sync_iter_shares_the_open_runner_loop() -> None:
+    loops: list[asyncio.AbstractEventLoop] = []
+
+    async def record_loop() -> str:
+        loops.append(asyncio.get_running_loop())
+        return "recorded"
+
+    async def source() -> AsyncIterator[str]:
+        loops.append(asyncio.get_running_loop())
+        yield "chunk"
+
+    def run_in_thread() -> None:
+        run_async_in_sync(record_loop())
+        assert list(async_iter_to_sync_iter(source())) == ["chunk"]
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert len(loops) == 2
+    # Streaming and non-streaming sync calls share the provider client, so they have to share the
+    # loop its transports are bound to, and that loop must survive the iterator finishing.
+    assert loops[0] is loops[1]
+    assert not loops[0].is_closed()
+
+
+def test_async_iter_to_sync_iter_propagates_source_errors() -> None:
+    async def source() -> AsyncIterator[int]:
+        yield 1
+        msg = "source failed"
+        raise ValueError(msg)
+
+    iterator = async_iter_to_sync_iter(source())
+
+    assert next(iterator) == 1
+    with pytest.raises(ValueError, match="source failed"):
+        next(iterator)
+
+
+def test_async_iter_to_sync_iter_from_the_runner_loop_uses_a_private_loop() -> None:
+    source_loops: list[asyncio.AbstractEventLoop] = []
+    background_cancelled = threading.Event()
+
+    async def source() -> AsyncIterator[int]:
+        source_loops.append(asyncio.get_running_loop())
+        started = asyncio.Event()
+
+        async def background_work() -> None:
+            started.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                background_cancelled.set()
+                raise
+
+        task = asyncio.create_task(background_work())
+        assert task is not None
+        await started.wait()
+        yield 1
+        yield 2
+
+    async def outer() -> list[int]:
+        # Consuming an iterator from the runner loop would block the thread the consumer needs, so
+        # this nested case runs on its own loop.
+        return list(async_iter_to_sync_iter(source()))
+
+    results: list[list[int]] = []
+    thread = threading.Thread(target=lambda: results.append(run_async_in_sync(outer())), daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert results == [[1, 2]]
+    assert source_loops[0] is not _get_runner_loop()
+    assert source_loops[0].is_closed()
+    # Work the source left behind is settled while the private loop is still alive, rather than
+    # being abandoned to a loop that has already closed.
+    assert background_cancelled.is_set()
 
 
 def test_async_iter_to_sync_iter_disallows_running_loop_when_requested() -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import gc
 import threading
 import time
 from collections.abc import AsyncIterator, Generator
@@ -522,3 +523,50 @@ def test_async_iter_to_sync_iter_close_from_the_runner_thread_does_not_wedge_the
 
     assert not follow_up_thread.is_alive()
     assert follow_up == ["still running"]
+
+
+def test_nested_private_loop_is_torn_down_when_closed_on_its_own_thread() -> None:
+    """The private loop cannot stop itself, but it must not be left running either.
+
+    A garbage collection pass on that loop's own thread can finalise an abandoned nested
+    iterator. Blocking there would wedge the loop, so the teardown is handed off instead of
+    being skipped, which would leak the loop and its thread for the life of the process.
+    """
+
+    def live_nested_threads() -> list[str]:
+        return [thread.name for thread in threading.enumerate() if "nested" in thread.name]
+
+    async def source() -> AsyncIterator[int]:
+        value = 0
+        while True:
+            # Runs on the private loop's thread, so this is where the abandoned iterator below
+            # gets finalised.
+            gc.collect()
+            await asyncio.sleep(0.005)
+            yield value
+            value += 1
+
+    async def outer() -> str:
+        iterator = async_iter_to_sync_iter(source())
+        assert next(iterator) == 0
+
+        cycle: dict[str, Any] = {"iterator": iterator}
+        cycle["self"] = cycle
+        del iterator, cycle
+
+        await asyncio.sleep(0.5)
+        return "outer done"
+
+    results: list[str] = []
+    thread = threading.Thread(target=lambda: results.append(run_async_in_sync(outer())), daemon=True)
+    thread.start()
+    thread.join(timeout=15)
+
+    assert not thread.is_alive()
+    assert results == ["outer done"]
+
+    deadline = time.monotonic() + 5
+    while live_nested_threads() and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+    assert live_nested_threads() == []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -474,3 +474,51 @@ def test_async_iter_to_sync_iter_disallows_running_loop_when_requested() -> None
             list(async_iter_to_sync_iter(source(), allow_running_loop=False))
 
     asyncio.run(consume_in_async_context())
+
+
+def test_async_iter_to_sync_iter_close_from_the_runner_thread_does_not_wedge_the_loop() -> None:
+    """An abandoned iterator can be finalised on the runner thread by a garbage collection pass.
+
+    The close runs the iterator's cleanup there, and waiting for the consumer to settle would
+    block the only thread that can run the cancellation, taking the shared loop down for good.
+    """
+
+    async def infinite_source() -> AsyncIterator[int]:
+        value = 0
+        while True:
+            await asyncio.sleep(0.001)
+            yield value
+            value += 1
+
+    holder: dict[str, Any] = {}
+
+    def run_in_thread() -> None:
+        iterator = async_iter_to_sync_iter(infinite_source())
+        assert next(iterator) == 0
+        holder["iterator"] = iterator
+
+        async def close_on_the_runner_loop() -> str:
+            cast("Generator[int, None, None]", holder.pop("iterator")).close()
+            return "closed"
+
+        holder["result"] = run_async_in_sync(close_on_the_runner_loop())
+
+    thread = threading.Thread(target=run_in_thread, daemon=True)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive(), "closing an abandoned iterator wedged the runner loop"
+    assert holder["result"] == "closed"
+
+    # The shared loop is still usable afterwards.
+    follow_up: list[str] = []
+
+    async def operation() -> str:
+        return "still running"
+
+    follow_up_thread = threading.Thread(target=lambda: follow_up.append(run_async_in_sync(operation())), daemon=True)
+    follow_up_thread.start()
+    follow_up_thread.join(timeout=5)
+
+    assert not follow_up_thread.is_alive()
+    assert follow_up == ["still running"]


### PR DESCRIPTION
## Description

Fixes #1268. Supersedes #1280, which is merged; its safety fix lived in the code this replaces, and each of its three parts has an equivalent here.

Sync calls created an event loop per call and closed it, while provider clients cache the transports they build (HTTP connection pools, gRPC channels) on the loop that first used them. The next call reused a pooled connection bound to a dead loop and failed with `RuntimeError: Event loop is closed`. Python 3.13 and earlier hid this, because `asyncio.get_event_loop()` handed back a loop that was never closed; 3.14 raises instead, so every call goes through `asyncio.run`. That matches the report: same code worked on 3.10, fails on 3.14.

`run_async_in_sync` and the sync iterator bridge now submit their work to one loop that outlives every call, in a daemon thread. The streaming bridge is included because it had the identical defect, and leaving it on a per-call loop made mixed streaming and non-streaming calls fail with "bound to a different event loop".

Three commits: the fix, then a deadlock found reviewing it (closing an abandoned stream from the runner thread waited on a cancellation only that thread could run, wedging the loop for the life of the process), then the xAI comments that this invalidates.

## Design note: one shared loop, one thread

A coroutine that blocks rather than awaits now stalls other concurrent sync callers, and the loop's default executor is shared rather than created per call. In-repo providers with sync SDKs (bedrock, sagemaker) offload through `run_in_executor`, so they are unaffected today.

That cost does not show up as lost throughput. Eight threads, five sync completions each, against a local server sleeping 200ms per request:

| | wall clock |
|---|---|
| before | 3.69s, plus an `APIConnectionError` from the bug itself |
| after | 1.32s |

The alternative, a loop per calling thread, keeps threads independent but breaks sharing one provider instance across request threads (threaded gunicorn, Flask), which is the case that reported the bug. Shared loop it is.

One behavior change worth knowing: a caller that set its own loop with `asyncio.set_event_loop` no longer has that loop's pending tasks advance during a sync call, since the work no longer runs there.

## Verification

Reproduced the reported failure against a local server with a cached client, matching the traceback in #1268 through httpcore, anyio and `selector_events`:

| Scenario | Before | After |
|---|---|---|
| Two sync completions, one provider, py3.14 | `Event loop is closed` | passes |
| Same through sync streaming | same failure | passes |
| Streaming mixed with non-streaming | fails both ways | passes |

`tests/unit/test_completion.py::test_sync_completion_can_be_called_repeatedly_on_one_provider` is the regression test, driving the real OpenAI SDK, httpx and anyio against a local server. It fails on `main` on both 3.11 and 3.14. It sets `max_retries=0` because the OpenAI SDK otherwise reconnects and hides the bug, which is why only Ollama users saw a hard failure, and it means sync users have been paying a failed request plus a reconnect on every call.

`test_async_iter_to_sync_iter_close_from_the_runner_thread_does_not_wedge_the_loop` covers the deadlock; it hangs without its fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure

## Relevant issues

Fixes #1268

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [ ] AI Usage: No AI was used.
- [ ] AI Usage: AI was used for drafting/refactoring.
- [x] AI Usage: This is fully AI-generated.

## Test results

- `pytest tests/unit tests/docs` on 3.11: 2171 passed, 69 skipped
- `pytest tests/unit tests/docs` on 3.14: 2146 passed, 94 skipped
- `ruff` (pinned 0.15.20) and `mypy` clean
- Integration tests: `run-integration-tests` label applied, since this touches every sync entry point and long-lived loop affinity for gRPC-based clients is not something unit tests can check.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info: Diagnosis started from @mikemikimike's #1280, which reported the issue and narrowed it to `run_async_in_sync`. The root cause and this approach came out of reviewing that PR. The deadlock and the stale xAI comments came out of a later review pass over this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for repeated synchronous and streaming requests.
  * Preserved provider connections between calls, reducing transport-related failures.
  * Improved cancellation, exception handling, and cleanup for asynchronous operations.
  * Prevented abandoned streams from blocking application execution.
  * Improved behaviour after process forks and during nested event-loop usage.
  * Ensured applications recover more reliably when event loops are closed or recreated.
  * Improved handling of concurrent requests and streaming errors without disrupting subsequent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->