### PR TITLE
ci: stabilize local-provider integration tests

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Retry a command with exponential backoff.
+#
+# Usage: retry.sh <attempts> <initial-backoff-seconds> -- <command> [args...]
+#
+# Every local-provider model download in the integration workflow is a single-shot network call
+# against huggingface.co or lmstudio.ai. A stalled download used to fail the whole job: on
+# 2026-08-13 `lms get` aborted with "Download failed: Timed-out" at 0.02% of 1.14 GB and took
+# the ollama and LM Studio tests down with it, none of which were broken.
+set -uo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <attempts> <initial-backoff-seconds> -- <command> [args...]" >&2
+  exit 2
+fi
+
+attempts=$1
+shift
+backoff=$1
+shift
+[ "${1:-}" = "--" ] && shift
+
+for attempt in $(seq 1 "$attempts"); do
+  # Capture the status directly off the command. Reading $? after an `if "$@"; then ... fi`
+  # yields the status of the `if` compound (0 when the branch is not taken), not of the
+  # command, which silently turned an exhausted retry into a passing step.
+  "$@"
+  status=$?
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "::error::'$*' failed after ${attempts} attempts (last exit code ${status})"
+    exit "$status"
+  fi
+
+  echo "Attempt ${attempt}/${attempts} of '$*' failed (exit ${status}); retrying in ${backoff}s..."
+  sleep "$backoff"
+  backoff=$((backoff * 2))
+done

--- a/.github/scripts/wait-for-http.sh
+++ b/.github/scripts/wait-for-http.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Poll an HTTP endpoint until it returns a success status, or give up.
+#
+# Usage: wait-for-http.sh <url> <timeout-seconds> [description]
+#
+# Two things this does that the previous inline form
+# (`timeout 60 bash -c 'until curl -s URL >/dev/null; do sleep 1; done'`) did not:
+#
+#   1. Requires a 2xx. Plain `curl -s` exits 0 for any HTTP response, including llama.cpp's
+#      /health returning 503 "loading model" and LM Studio's /v1/models answering before any
+#      model is loaded. Either one counted as ready and let tests start against a server that
+#      could not serve them. `curl -fsS` treats >= 400 as failure.
+#   2. Explains itself on timeout. The old form died as a bare "Process completed with exit
+#      code 124" with no indication of which server never came up, or why.
+set -uo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <url> <timeout-seconds> [description]" >&2
+  exit 2
+fi
+
+url=$1
+timeout=$2
+description=${3:-$url}
+
+start=$SECONDS
+last_output=""
+
+while [ $((SECONDS - start)) -lt "$timeout" ]; do
+  if last_output=$(curl -fsS --max-time 10 "$url" 2>&1); then
+    echo "${description} ready after $((SECONDS - start))s"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "::error::${description} did not become ready at ${url} within ${timeout}s"
+echo "Last curl output: ${last_output:-<none>}"
+exit 1

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -188,6 +188,19 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
 
+    # Model identifiers live here so the download URL and the cache key cannot drift apart. The
+    # cache keys below are derived from these values rather than from hashFiles('tests/conftest.py'),
+    # which had nothing to do with which model file gets downloaded.
+    env:
+      # This is the file `-hf ggml-org/Qwen3-1.7B-GGUF` already resolved to: that repo's `latest`
+      # and `Q4_K_M` manifests point at the same 1.28 GB layer. Naming it explicitly lets us
+      # download it once to a cached host directory and mount it, instead of re-fetching it
+      # inside the container on every run.
+      LLAMACPP_MODEL_FILE: Qwen3-1.7B-Q4_K_M.gguf
+      LLAMACPP_MODEL_REPO: ggml-org/Qwen3-1.7B-GGUF
+      LLAMAFILE_NAME: Qwen_Qwen3-0.6B-Q4_K_M.llamafile
+      LMSTUDIO_MODEL: qwen/qwen3-1.7b
+
     steps:
       # Runs fork code with our secrets on a labeled fork PR; gated on the
       # run-integration-tests label. See the note at the top of this file before changing.
@@ -212,22 +225,34 @@ jobs:
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
         with:
           path: ~/.ollama
-          key: ${{ runner.os }}-ollama-models-${{ hashFiles('tests/conftest.py') }}
+          key: ${{ runner.os }}-ollama-models-llama3.2-1b-qwen3-0.6b-llava-phi3
           restore-keys: |
             ${{ runner.os }}-ollama-models-
 
       - uses: actions/cache@v6
         with:
           path: ~/.llamafile
-          key: ${{ runner.os }}-llamafile-${{ hashFiles('tests/conftest.py') }}
+          key: ${{ runner.os }}-llamafile-${{ env.LLAMAFILE_NAME }}
           restore-keys: |
             ${{ runner.os }}-llamafile-
+
+      # The llama.cpp model used to be fetched by `-hf` from inside the container on every run,
+      # so a 1.28 GB HuggingFace download sat inside a 60s readiness window. That combination was
+      # the single largest source of flakes in this job. Caching it on the host takes the
+      # download off the critical path entirely.
+      - uses: actions/cache@v6
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
+        with:
+          path: ~/.cache/llama.cpp
+          key: ${{ runner.os }}-llamacpp-${{ env.LLAMACPP_MODEL_FILE }}
+          restore-keys: |
+            ${{ runner.os }}-llamacpp-
 
       - uses: actions/cache@v6
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
         with:
           path: ~/.lmstudio
-          key: ${{ runner.os }}-lmstudio-models-${{ hashFiles('tests/conftest.py') }}
+          key: ${{ runner.os }}-lmstudio-models-${{ env.LMSTUDIO_MODEL }}
           restore-keys: |
             ${{ runner.os }}-lmstudio-models-
 
@@ -239,34 +264,73 @@ jobs:
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamafile')
         run: |
           mkdir -p ~/.llamafile
-          LLAMAFILE_PATH="$HOME/.llamafile/Qwen_Qwen3-0.6B-Q4_K_M.llamafile"
+          LLAMAFILE_PATH="$HOME/.llamafile/$LLAMAFILE_NAME"
 
-          if [ ! -f "$LLAMAFILE_PATH" ]; then
-            echo "Downloading llamafile (not found in cache)..."
-            wget -O "$LLAMAFILE_PATH" https://huggingface.co/Mozilla/Qwen3-0.6B-llamafile/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.llamafile
-            chmod +x "$LLAMAFILE_PATH"
-          else
+          if [ -s "$LLAMAFILE_PATH" ]; then
             echo "Using cached llamafile"
+          else
+            echo "Downloading llamafile (not found in cache)..."
+            # Download to a scratch path and move into place only once curl reports success.
+            # Writing straight to the final path meant an interrupted download left a truncated
+            # file that the `-f` check accepted and the cache then preserved under the same key,
+            # so one bad download could wedge every later run.
+            rm -f "$LLAMAFILE_PATH.partial"
+            .github/scripts/retry.sh 3 10 -- \
+              curl -fL --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+                   -o "$LLAMAFILE_PATH.partial" \
+                   "https://huggingface.co/Mozilla/Qwen3-0.6B-llamafile/resolve/main/$LLAMAFILE_NAME"
+            mv "$LLAMAFILE_PATH.partial" "$LLAMAFILE_PATH"
           fi
 
-          "$LLAMAFILE_PATH" --server --v2 &
+          chmod +x "$LLAMAFILE_PATH"
+          "$LLAMAFILE_PATH" --server --v2 > llamafile.log 2>&1 &
           echo $! > llamafile.pid
 
       - name: Wait for LlamaFile to be ready
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamafile')
         run: |
-          timeout 60 bash -c 'until curl -s http://localhost:8080/v1/models >/dev/null; do sleep 1; done'
+          .github/scripts/wait-for-http.sh http://localhost:8080/v1/models 120 "llamafile server" \
+            || { echo "--- llamafile.log ---"; cat llamafile.log || true; exit 1; }
 
-      - name : Download and Run LlamaCpp
+      - name: Download LlamaCpp model
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
         run: |
-          cid=$(docker run -d -p 8090:8090 ghcr.io/ggml-org/llama.cpp:server -hf ggml-org/Qwen3-1.7B-GGUF --jinja --port 8090)
+          mkdir -p ~/.cache/llama.cpp
+          MODEL_PATH="$HOME/.cache/llama.cpp/$LLAMACPP_MODEL_FILE"
+
+          if [ -s "$MODEL_PATH" ]; then
+            echo "Using cached $LLAMACPP_MODEL_FILE"
+          else
+            echo "Downloading $LLAMACPP_MODEL_FILE (not found in cache)..."
+            # --speed-limit/--speed-time abort a download that has stalled below 1 KB/s for a
+            # minute, so a wedged connection fails fast into a retry instead of crawling until
+            # some outer timeout kills the step. Clear any .partial left by a cancelled run so it
+            # cannot sit in the cache indefinitely.
+            rm -f "$MODEL_PATH.partial"
+            .github/scripts/retry.sh 3 10 -- \
+              curl -fL --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+                   -o "$MODEL_PATH.partial" \
+                   "https://huggingface.co/$LLAMACPP_MODEL_REPO/resolve/main/$LLAMACPP_MODEL_FILE"
+            mv "$MODEL_PATH.partial" "$MODEL_PATH"
+          fi
+          ls -lh "$MODEL_PATH"
+
+      - name: Run LlamaCpp
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
+        run: |
+          # Mount the cached model read-only and load it with -m. The previous `-hf` form made the
+          # container re-download it from HuggingFace on every run, inside the readiness window.
+          cid=$(docker run -d -p 8090:8090 \
+            -v "$HOME/.cache/llama.cpp:/models:ro" \
+            ghcr.io/ggml-org/llama.cpp:server \
+            -m "/models/$LLAMACPP_MODEL_FILE" --jinja --host 0.0.0.0 --port 8090)
           echo "$cid" > llamacpp.cid
 
       - name: Wait for LlamaCpp to be ready
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamacpp')
         run: |
-          timeout 60 bash -c 'until curl -s http://localhost:8090/health >/dev/null; do sleep 1; done'
+          .github/scripts/wait-for-http.sh http://localhost:8090/health 180 "llama.cpp server" \
+            || { echo "--- docker logs ---"; docker logs "$(cat llamacpp.cid)" || true; exit 1; }
 
       - name: Run LlamaFile and LlamaCpp integration tests
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'llamafile') || contains(github.event.inputs.filter, 'llamacpp')
@@ -299,34 +363,61 @@ jobs:
       - name: Run ollama
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
         run: |
-          ollama serve &
-          ollama pull llama3.2:1b
-          ollama pull qwen3:0.6b
-          ollama pull llava-phi3
+          # Redirect to a file rather than inheriting the step's stdout: a backgrounded process
+          # holding that pipe open can keep the step from completing.
+          ollama serve > ollama.log 2>&1 &
 
+      # The pulls used to run immediately after `ollama serve &`, racing the server's startup, and
+      # had no retry. Wait for the API first, then pull with retries.
       - name: Wait for Ollama to be ready
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
         run: |
-          timeout 60 bash -c 'until curl -s http://localhost:11434/api/tags >/dev/null; do sleep 1; done'
+          .github/scripts/wait-for-http.sh http://localhost:11434/api/tags 60 "ollama server" \
+            || { echo "--- ollama.log ---"; cat ollama.log || true; exit 1; }
+
+      - name: Pull ollama models
+        if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'ollama')
+        run: |
+          for model in llama3.2:1b qwen3:0.6b llava-phi3; do
+            .github/scripts/retry.sh 3 10 -- ollama pull "$model"
+          done
 
       - name: Install LM Studio CLI
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
-        run: curl -fsSL https://lmstudio.ai/install.sh | bash
+        run: .github/scripts/retry.sh 3 10 -- bash -c 'curl -fsSL https://lmstudio.ai/install.sh | bash'
 
       - name: Download LM Studio model
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
-        run: lms get qwen/qwen3-1.7b --yes
+        # `lms get` gives up on a stalled HuggingFace download ("Download failed: Timed-out"),
+        # which failed this job on main. It resumes from what it already fetched, so retrying is
+        # both cheap and usually sufficient.
+        run: .github/scripts/retry.sh 3 15 -- lms get "$LMSTUDIO_MODEL" --yes
 
       - name: Load model and start LM Studio server
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
         run: |
-          lms load qwen/qwen3-1.7b --yes &
+          lms load "$LMSTUDIO_MODEL" --yes > lms-load.log 2>&1 &
           lms server start
 
       - name: Wait for LM Studio to be ready
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio')
         run: |
-          timeout 120 bash -c 'until curl -s http://localhost:1234/v1/models >/dev/null; do sleep 1; done'
+          .github/scripts/wait-for-http.sh http://localhost:1234/v1/models 120 "LM Studio server" \
+            || { echo "--- lms-load.log ---"; cat lms-load.log || true; exit 1; }
+
+          # /v1/models answers 200 as soon as the server is up, whether or not a model finished
+          # loading, and the load above runs in the background. Without this the suite could start
+          # against a server with nothing loaded and fail for reasons unrelated to the change
+          # under test.
+          MODEL_SLUG="${LMSTUDIO_MODEL#*/}"
+          if ! timeout 180 bash -c "until curl -fsS http://localhost:1234/v1/models | grep -q '$MODEL_SLUG'; do sleep 2; done"; then
+            echo "::error::LM Studio never reported $LMSTUDIO_MODEL as loaded"
+            echo "--- lms-load.log ---"; cat lms-load.log || true
+            echo "--- /v1/models ---"; curl -fsS http://localhost:1234/v1/models || true
+            echo "--- lms ps ---"; lms ps || true
+            exit 1
+          fi
+          echo "LM Studio reports $LMSTUDIO_MODEL loaded"
 
       - name: Run LMStudio and Ollama integration tests
         if: github.event.inputs.filter == '' || contains(github.event.inputs.filter, 'lmstudio') || contains(github.event.inputs.filter, 'ollama')


### PR DESCRIPTION
## Description

Every recent `run-local-integration-tests` failure on main died in a setup step, not in a test. Two causes covered all six failures whose logs are still retained:

1. **The llama.cpp readiness gate (5 of 6, exit 124).** `-hf` made the container download a 1.28 GB GGUF from HuggingFace on every run, uncached, inside a 60s window. Successful runs spent 13 to 31s there, so any dip in HuggingFace throughput failed the whole job, taking the ollama and LM Studio tests down with it.
2. **`lms get` giving up on a stalled download** ("Download failed: Timed-out" at 0.02% of 1.14 GB), with no retry.

The model is now downloaded once into a cached host directory and mounted read-only with `-m`, so the readiness window covers only model load. The pinned file is what `-hf ggml-org/Qwen3-1.7B-GGUF` already resolved to; that repo's `latest` and `Q4_K_M` manifests point at the same layer digest. Network-facing setup commands retry with backoff, and stalled downloads abort early instead of crawling into a timeout.

Three latent bugs in the same job, also fixed:

- Downloads wrote straight to their final path, so an interrupted transfer left a truncated file that the existence check accepted and the cache then preserved under the same key, wedging later runs.
- Readiness probes used `curl -s`, which exits 0 for any HTTP response, so llama.cpp `/health` returning 503 "loading model" counted as ready.
- LM Studio loads its model in the background while `/v1/models` already answers 200, so the suite could run against a model-less server. Similarly, `ollama pull` ran before `ollama serve` was listening.

Readiness timeouts now name the failing server and dump its logs instead of a bare exit 124.

**Worth watching:** this adds a fourth large cache entry (~1.3 GB) alongside llamafile, lmstudio, and ollama (~7 GB total) against GitHub's 10 GB limit. With retries in place, an eviction now means a slower run rather than a failed one.

**Verification:** I hand-tested both helper scripts, which caught a real bug (reading `$?` after `if cmd; then` made exhausted retries exit 0, silently turning a failed download into a passing step). The download step was run under `bash -e`, matching how Actions invokes it, across cold, warm, and failing paths, and the readiness probes against fake servers that 503 then 200 and that report an empty model list. `actionlint` and `shellcheck` are clean on the new code, `pre-commit` passes, and the unit suite is green. My sandbox has no Docker, so the `docker run` line is the one piece not executed end to end; the first run on this PR is what confirms it.

## PR Type

- 🚦 Infrastructure

## Relevant issues

No open issue tracks this flake. Related: #1236, the earlier OOM fix in this same job.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works (CI-only change; the helper scripts were verified by hand as described above)
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The diagnosis came from reading the retained failure logs for this job across roughly three weeks of runs, then timing the llama.cpp readiness step on passing runs to size the gate against real data.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration-test reliability with retries, backoff, readiness checks, and clearer timeout diagnostics.
  * Added verification that required models and services are fully available before tests run.

* **Chores**
  * Improved model caching and downloads to reduce repeated work and prevent incomplete installations.
  * Added reusable checks for waiting on HTTP services and retrying failed commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->