### PR TITLE
feat(azure): support list_models via get_model_info()

### DIFF
--- a/src/any_llm/providers/azure/azure.py
+++ b/src/any_llm/providers/azure/azure.py
@@ -14,6 +14,7 @@ try:
     from azure.core.credentials import AzureKeyCredential
 
     from .utils import (
+        _convert_model_info_to_list,
         _convert_response,
         _convert_response_format,
         _create_openai_chunk_from_azure_chunk,
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterable, AsyncIterator, Sequence
 
     from azure.ai.inference import aio  # noqa: TC004
-    from azure.ai.inference.models import ChatCompletions, EmbeddingsResult, StreamingChatCompletionsUpdate
+    from azure.ai.inference.models import ChatCompletions, EmbeddingsResult, ModelInfo, StreamingChatCompletionsUpdate
     from azure.core.credentials_async import AsyncTokenCredential
 
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
@@ -59,7 +60,7 @@ class AzureProvider(AnyLLM):
     SUPPORTS_COMPLETION_REASONING = False
     SUPPORTS_COMPLETION = True
     SUPPORTS_RESPONSES = False
-    SUPPORTS_LIST_MODELS = False
+    SUPPORTS_LIST_MODELS = True
     SUPPORTS_BATCH = False
     SUPPORTS_RERANK = False
 
@@ -158,6 +159,18 @@ class AzureProvider(AnyLLM):
         return self._convert_completion_response(response)
 
     @override
+    async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
+        """List models via Azure AI Inference's ``/info`` route.
+
+        Azure AI Inference has no catalog-listing endpoint; each endpoint is bound to a single
+        deployed model, and ``get_model_info()`` describes that one model. This only works for
+        Serverless API and Managed Compute endpoints - Azure raises ``HttpResponseError`` for
+        GitHub Models and Azure OpenAI endpoints, which this lets propagate as-is.
+        """
+        response: ModelInfo = await self.chat_client.get_model_info(**kwargs)
+        return self._convert_list_models_response(response)
+
+    @override
     async def _aembedding(
         self,
         model: str,
@@ -229,6 +242,5 @@ class AzureProvider(AnyLLM):
     @staticmethod
     @override
     def _convert_list_models_response(response: Any) -> Sequence[Model]:
-        """Convert Azure list models response to OpenAI format. Not supported by Azure."""
-        msg = "Azure provider does not support listing models"
-        raise NotImplementedError(msg)
+        """Convert Azure's single ModelInfo (from get_model_info) to an OpenAI Model list."""
+        return _convert_model_info_to_list(response)

--- a/src/any_llm/providers/azure/utils.py
+++ b/src/any_llm/providers/azure/utils.py
@@ -5,6 +5,7 @@ from azure.ai.inference.models import (
     ChatCompletions,
     EmbeddingsResult,
     JsonSchemaFormat,
+    ModelInfo,
     StreamingChatCompletionsUpdate,
 )
 
@@ -25,6 +26,7 @@ from any_llm.types.completion import (
     Function,
     Usage,
 )
+from any_llm.types.model import Model
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 if TYPE_CHECKING:
@@ -250,3 +252,21 @@ def _create_openai_embedding_response_from_azure(
         object="list",
         usage=usage,
     )
+
+
+def _convert_model_info_to_list(model_info: ModelInfo) -> list[Model]:
+    """Convert Azure's single-model /info response to a one-item OpenAI Model list.
+
+    The Azure AI Inference SDK has no catalog-listing endpoint: ``get_model_info()`` only
+    describes the single model deployed behind the caller's endpoint. Azure has no ``created``
+    timestamp for a model, so it is reported as 0, matching the convention other providers
+    without one (bedrock, cohere, gemini) already use.
+    """
+    return [
+        Model(
+            id=model_info.model_name,
+            object="model",
+            created=0,
+            owned_by=model_info.model_provider_name,
+        )
+    ]

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -294,7 +294,7 @@ async def test_alist_models_propagates_http_response_error_for_unsupported_endpo
     """get_model_info() raises HttpResponseError for GitHub Models and Azure OpenAI endpoints
     (it only works for Serverless API / Managed Compute). _alist_models must let that error
     propagate unchanged rather than swallowing it into an empty list."""
-    custom_endpoint = "https://test.eu.models.ai.azure.com"
+    custom_endpoint = "https://test.openai.azure.com"
 
     with mock_azure_provider() as (mock_client_instance, _, _):
         mock_client_instance.get_model_info = AsyncMock(

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from azure.ai.inference.models import JsonSchemaFormat, ModelInfo
+from azure.core.exceptions import HttpResponseError
 
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.providers.azure.azure import AzureProvider
@@ -286,3 +287,21 @@ async def test_alist_models_calls_get_model_info_on_the_chat_client() -> None:
         assert result == [
             Model(id="Phi-4", object="model", created=0, owned_by="Microsoft Research"),
         ]
+
+
+@pytest.mark.asyncio
+async def test_alist_models_propagates_http_response_error_for_unsupported_endpoints() -> None:
+    """get_model_info() raises HttpResponseError for GitHub Models and Azure OpenAI endpoints
+    (it only works for Serverless API / Managed Compute). _alist_models must let that error
+    propagate unchanged rather than swallowing it into an empty list."""
+    custom_endpoint = "https://test.eu.models.ai.azure.com"
+
+    with mock_azure_provider() as (mock_client_instance, _, _):
+        mock_client_instance.get_model_info = AsyncMock(
+            side_effect=HttpResponseError(message="This method is not supported for the provided endpoint.")
+        )
+
+        provider = AzureProvider(api_key="test-key", api_base=custom_endpoint)
+
+        with pytest.raises(HttpResponseError):
+            await provider._alist_models()

--- a/tests/unit/providers/test_azure_provider.py
+++ b/tests/unit/providers/test_azure_provider.py
@@ -3,12 +3,13 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from azure.ai.inference.models import JsonSchemaFormat
+from azure.ai.inference.models import JsonSchemaFormat, ModelInfo
 
 from any_llm.exceptions import MissingApiKeyError
 from any_llm.providers.azure.azure import AzureProvider
-from any_llm.providers.azure.utils import _convert_response_format
+from any_llm.providers.azure.utils import _convert_model_info_to_list, _convert_response_format
 from any_llm.types.completion import CompletionParams
+from any_llm.types.model import Model
 
 
 @contextmanager
@@ -241,3 +242,47 @@ def test_convert_completion_params_drops_stream_options() -> None:
     )
     result = AzureProvider._convert_completion_params(params)
     assert "stream_options" not in result
+
+
+def test_supports_list_models_flag() -> None:
+    """Azure exposes list_models via get_model_info(), so the capability flag is True."""
+    assert AzureProvider.SUPPORTS_LIST_MODELS is True
+
+
+def test_convert_model_info_to_list() -> None:
+    """Azure's /info route describes the single model behind the endpoint, so the OpenAI-shaped
+    list_models() result is always exactly one item, built from that model's name and provider."""
+    model_info = ModelInfo(
+        model_name="Phi-4",
+        model_type="chat_completion",
+        model_provider_name="Microsoft Research",
+    )
+
+    result = _convert_model_info_to_list(model_info)
+
+    assert result == [
+        Model(id="Phi-4", object="model", created=0, owned_by="Microsoft Research"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_alist_models_calls_get_model_info_on_the_chat_client() -> None:
+    """_alist_models must go through get_model_info(), the only model-info route the Azure AI
+    Inference SDK exposes (there is no catalog-listing endpoint)."""
+    custom_endpoint = "https://test.eu.models.ai.azure.com"
+
+    with mock_azure_provider() as (mock_client_instance, _, _):
+        model_info = ModelInfo(
+            model_name="Phi-4",
+            model_type="chat_completion",
+            model_provider_name="Microsoft Research",
+        )
+        mock_client_instance.get_model_info = AsyncMock(return_value=model_info)
+
+        provider = AzureProvider(api_key="test-key", api_base=custom_endpoint)
+        result = await provider._alist_models()
+
+        mock_client_instance.get_model_info.assert_called_once()
+        assert result == [
+            Model(id="Phi-4", object="model", created=0, owned_by="Microsoft Research"),
+        ]


### PR DESCRIPTION
## Description
The Azure AI Inference SDK has no catalog-listing endpoint. `ChatCompletionsClient` (and `EmbeddingsClient`) are bound to a single deployed model via the endpoint URL, and `get_model_info()` (the `/info` route) is the only model-info call the SDK exposes:

> Returns information about the AI model. The method makes a REST API call to the `/info` route on the given endpoint. This method will only work when using Serverless API or Managed Compute endpoint. It will not work for GitHub Models endpoint or Azure OpenAI endpoint.

This matches the docstring @njbrake quoted on the issue. `@AnshManwani` asked the same question on the thread (return the single deployed model as a one-item `list_models()` result, or something else?) and didn't get a confirmation, so I want to flag that explicitly here rather than assume it's settled: **this PR takes the interpretation that a one-item list from `get_model_info()` is the intended shape**, since it's the only model-info route the SDK has and it's what the existing docstring in the codebase already pointed at. Happy to adjust if the intended scope was something else (e.g. an Azure OpenAI-specific `/models` listing via a different client).

- `AzureProvider._alist_models()` calls `self.chat_client.get_model_info()` and converts the result via `_convert_list_models_response`.
- `_convert_model_info_to_list()` in `utils.py` builds a one-item `Model` list from `ModelInfo.model_name` / `model_provider_name`. Azure has no `created` timestamp for a model, so it's reported as `0`, matching the existing convention for providers without one (bedrock, cohere, gemini).
- `SUPPORTS_LIST_MODELS` flipped to `True`.
- For GitHub Models / Azure OpenAI endpoints (where `get_model_info()` isn't supported), the SDK's `HttpResponseError` is left to propagate as-is rather than being swallowed, so callers get Azure's real error instead of a silent empty list.

## PR Type

- 🆕 New Feature

## Relevant issues
Fixes #299

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: I picked this issue from the `good first issue` label, read through the existing thread (including the unanswered question from @AnshManwani) before deciding on an interpretation, then had Claude Code implement it, write tests, and run ruff/mypy locally. I reviewed the diff before opening this PR. Flagging the interpretation question above since it wasn't confirmed by a maintainer before I built against it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for listing Azure model information.
  * Azure model details are now presented in a standard, OpenAI-compatible format.
  * Listings include the model identifier and standard metadata.

* **Bug Fixes**
  * Azure model discovery is no longer reported as unsupported.
  * Errors from unsupported Azure model-listing endpoints are now surfaced correctly.

* **Tests**
  * Added coverage for model listing, conversion, retrieval, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->