### PR TITLE
chore(deps): require otari 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ deepseek = []
 fireworks = []
 gmi = []
 otari = [
-  "otari>=0.2.0",
+  "otari>=0.3.0",
 ]
 github = []
 inception = []


### PR DESCRIPTION
## Why

The follow-up Otari provider changes rely on the response metadata API released in Otari 0.3.0.

## What changed

Raise the minimum Otari SDK version from 0.2.0 to 0.3.0.

## Notes

Verified that the published `otari 0.3.0` package installs successfully. The provider changes are in a stacked follow-up PR.

## PR Type

- Infrastructure

## Relevant issues

Supports #1225.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6
- AI Developer Tool used: Pi
- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional Otari requirement to version 0.3.0 or later for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->