### PR TITLE
fix(otari): forward beta params and request IDs

### DIFF
--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -346,10 +346,6 @@ class OtariProvider(BaseOpenAIProvider):
         config). otari's gateway serves /messages natively, so delegate to the otari
         SDK's ``message()`` to preserve them.
         """
-        if params.context_management is not None or params.betas:
-            msg = "context_management and betas require a provider with a native Anthropic Messages API"
-            raise NotImplementedError(msg)
-
         if params.output_format is not None:
             # Structured output is handled by the base Messages<->Completions bridge, which
             # routes output_format through otari's completion path. A follow-up could adopt

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -141,7 +141,7 @@ _MESSAGE_STREAM_EVENT_TYPES: dict[str, type[BaseModel]] = {
 }
 
 
-def _message_stream_event_from_dict(event: dict[str, Any]) -> MessageStreamEvent | None:
+def _message_stream_event_from_dict(event: dict[str, Any], request_id: str | None = None) -> MessageStreamEvent | None:
     """Validate a raw otari message SSE event dict into a typed MessageStreamEvent.
 
     Returns ``None`` for event types any-llm does not surface (e.g. ``ping``).
@@ -150,6 +150,10 @@ def _message_stream_event_from_dict(event: dict[str, Any]) -> MessageStreamEvent
     model = _MESSAGE_STREAM_EVENT_TYPES.get(event_type) if isinstance(event_type, str) else None
     if model is None:
         return None
+    if event_type == "message_start" and request_id is not None:
+        message = event.get("message")
+        if isinstance(message, dict):
+            event = {**event, "message": {**message, "request_id": request_id}}
     return cast("MessageStreamEvent", model.model_validate(event))
 
 
@@ -359,14 +363,22 @@ class OtariProvider(BaseOpenAIProvider):
         if params.stream:
             return self._stream_messages_async(**api_kwargs)
 
-        response = await self.otari_client.message(**api_kwargs)
-        return MessageResponse.model_validate(_as_plain_dict(response))
+        response = await self.otari_client.with_response_metadata.message(**api_kwargs)
+        payload = _as_plain_dict(response.data)
+        if response.request_id is not None and isinstance(payload, dict):
+            payload = {**payload, "request_id": response.request_id}
+        return MessageResponse.model_validate(payload)
 
     async def _stream_messages_async(self, **api_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
         """Stream otari's /messages endpoint, yielding typed any-llm event models."""
-        stream = await self.otari_client.message(stream=True, **api_kwargs)
+        stream = await self.otari_client.with_response_metadata.message(stream=True, **api_kwargs)
+        request_id: str | None = None
+        request_id_read = False
         async for event in stream:
-            converted = _message_stream_event_from_dict(_as_plain_dict(event))
+            if not request_id_read:
+                request_id = stream.request_id
+                request_id_read = True
+            converted = _message_stream_event_from_dict(_as_plain_dict(event), request_id)
             if converted is not None:
                 yield converted
 

--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -354,6 +354,14 @@ class OtariProvider(BaseOpenAIProvider):
             # Structured output is handled by the base Messages<->Completions bridge, which
             # routes output_format through otari's completion path. A follow-up could adopt
             # otari's native /messages structured-output support directly.
+            if params.context_management is not None or params.betas:
+                msg = (
+                    "output_format cannot be combined with context_management or betas on otari: "
+                    "structured output routes through the Completions bridge, which drops both. "
+                    "Send them in separate requests until otari's native /messages structured "
+                    "output is adopted."
+                )
+                raise NotImplementedError(msg)
             return await super()._amessages(params, **kwargs)
 
         api_kwargs = params.model_dump(exclude_none=True)

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -111,6 +111,9 @@ ContentBlock = MessageContentBlock
 
 
 class MessageResponse(AnthropicMessage):
+    request_id: str | None = None
+    """Provider request identifier, when exposed by the transport."""
+
     container: BetaContainer | None = None  # type: ignore[assignment]
     content: list[MessageContentBlock]  # type: ignore[assignment]
     stop_reason: StopReason | None = None  # type: ignore[assignment]

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -811,27 +811,64 @@ async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "unsupported_params",
-    [
-        {"context_management": {"edits": [{"type": "compact_20260112"}]}},
-        {"betas": ["compact-2026-01-12"]},
-    ],
-)
-async def test_otari_amessages_rejects_anthropic_beta_params(unsupported_params: dict[str, Any]) -> None:
+async def test_otari_amessages_forwards_anthropic_beta_params() -> None:
     client = _mock_otari_client()
+    client.message.return_value = _message_response_payload()
     provider = _build_provider(client)
+    context_management = {
+        "edits": [
+            {
+                "type": "compact_20260112",
+                "trigger": {"type": "input_tokens", "value": 50_000},
+            }
+        ]
+    }
+    betas = ["compact-2026-01-12"]
     params = MessagesParams(
         model="claude-sonnet-4-5",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=100,
-        **unsupported_params,
+        context_management=context_management,
+        betas=betas,
     )
 
-    with pytest.raises(NotImplementedError, match="native Anthropic Messages"):
-        await provider._amessages(params)
+    result = await provider._amessages(params)
 
-    client.message.assert_not_called()
+    assert isinstance(result, MessageResponse)
+    call_kwargs = client.message.call_args.kwargs
+    assert call_kwargs["context_management"] == context_management
+    assert call_kwargs["betas"] == betas
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_streaming_forwards_anthropic_beta_params() -> None:
+    async def _aiter() -> Any:
+        yield {"type": "message_stop"}
+
+    client = _mock_otari_client()
+    client.message.return_value = _aiter()
+    provider = _build_provider(client)
+    context_management = {"edits": [{"type": "compact_20260112"}]}
+    betas = ["compact-2026-01-12"]
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+        context_management=context_management,
+        betas=betas,
+    )
+
+    result = await provider._amessages(params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage, ParsedBetaMessage))
+    collected = [event async for event in result]
+
+    assert len(collected) == 1
+    assert isinstance(collected[0], MessageStopEvent)
+    call_kwargs = client.message.call_args.kwargs
+    assert call_kwargs["stream"] is True
+    assert call_kwargs["context_management"] == context_management
+    assert call_kwargs["betas"] == betas
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -990,6 +990,40 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "beta_params",
+    [
+        {"context_management": {"edits": [{"type": "compact_20260112"}]}},
+        {"betas": ["compact-2026-01-12"]},
+    ],
+)
+async def test_otari_amessages_output_format_with_beta_params_raises(beta_params: dict[str, Any]) -> None:
+    """output_format routes through the bridge, which cannot carry context_management or betas."""
+    from pydantic import BaseModel
+
+    class City(BaseModel):
+        city: str
+
+    client = _mock_otari_client()
+    provider = _build_provider(client)
+    provider._acompletion = AsyncMock()  # type: ignore[method-assign]
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=100,
+        output_format=City,
+        **beta_params,
+    )
+
+    with pytest.raises(NotImplementedError, match="output_format cannot be combined"):
+        await provider._amessages(params)
+
+    provider._acompletion.assert_not_called()
+    client.message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_otari_amessages_excludes_none_valued_optional_params() -> None:
     client = _mock_otari_client()
     client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -46,11 +46,27 @@ def test_otari_passes_prompt_cache_key_to_the_resolved_provider() -> None:
     assert OtariProvider.PROMPT_CACHE_KEY_SUPPORT == "passthrough"
 
 
+class _MockMetadataStream:
+    def __init__(self, events: list[dict[str, Any]], request_id: str | None = None) -> None:
+        self.request_id = request_id
+        self._events = iter(events)
+
+    def __aiter__(self) -> _MockMetadataStream:
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        try:
+            return next(self._events)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
 def _mock_otari_client() -> MagicMock:
     client = MagicMock()
     client.platform_mode = False
     client.completion = AsyncMock()
     client.message = AsyncMock()
+    client.with_response_metadata = SimpleNamespace(message=client.message)
     client.embedding = AsyncMock()
     client.moderation = AsyncMock()
     client.image_generation = AsyncMock()
@@ -778,7 +794,7 @@ def _message_response_payload() -> dict[str, Any]:
 @pytest.mark.asyncio
 async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic_fields() -> None:
     client = _mock_otari_client()
-    client.message.return_value = _message_response_payload()
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
     provider = _build_provider(client)
 
     params = MessagesParams(
@@ -811,9 +827,76 @@ async def test_otari_amessages_delegates_to_native_endpoint_preserving_anthropic
 
 
 @pytest.mark.asyncio
+async def test_otari_amessages_preserves_request_id() -> None:
+    client = _mock_otari_client()
+    client.with_response_metadata.message = AsyncMock(
+        return_value=SimpleNamespace(
+            data=_message_response_payload(),
+            request_id="req-message-123",
+        )
+    )
+    provider = _build_provider(client)
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    result = await provider._amessages(params)
+
+    assert isinstance(result, MessageResponse)
+    assert result.request_id == "req-message-123"
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_streaming_preserves_request_id_on_message_start() -> None:
+    class _RequestIdStream:
+        def __init__(self) -> None:
+            self._request_id: str | None = None
+            self.request_id_reads = 0
+            self._events = iter([{"type": "message_start", "message": _message_response_payload()}])
+
+        @property
+        def request_id(self) -> str | None:
+            self.request_id_reads += 1
+            return self._request_id
+
+        def __aiter__(self) -> _RequestIdStream:
+            return self
+
+        async def __anext__(self) -> dict[str, Any]:
+            try:
+                event = next(self._events)
+            except StopIteration:
+                raise StopAsyncIteration from None
+            self._request_id = "req-stream-123"
+            return event
+
+    stream = _RequestIdStream()
+    client = _mock_otari_client()
+    client.with_response_metadata.message = AsyncMock(return_value=stream)
+    provider = _build_provider(client)
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stream=True,
+    )
+
+    result = await provider._amessages(params)
+    assert not isinstance(result, (MessageResponse, ParsedMessage, ParsedBetaMessage))
+    collected = [event async for event in result]
+
+    assert len(collected) == 1
+    assert isinstance(collected[0], MessageStartEvent)
+    assert collected[0].message.request_id == "req-stream-123"
+    assert stream.request_id_reads == 1
+
+
+@pytest.mark.asyncio
 async def test_otari_amessages_forwards_anthropic_beta_params() -> None:
     client = _mock_otari_client()
-    client.message.return_value = _message_response_payload()
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
     provider = _build_provider(client)
     context_management = {
         "edits": [
@@ -842,11 +925,8 @@ async def test_otari_amessages_forwards_anthropic_beta_params() -> None:
 
 @pytest.mark.asyncio
 async def test_otari_amessages_streaming_forwards_anthropic_beta_params() -> None:
-    async def _aiter() -> Any:
-        yield {"type": "message_stop"}
-
     client = _mock_otari_client()
-    client.message.return_value = _aiter()
+    client.with_response_metadata.message.return_value = _MockMetadataStream([{"type": "message_stop"}])
     provider = _build_provider(client)
     context_management = {"edits": [{"type": "compact_20260112"}]}
     betas = ["compact-2026-01-12"]
@@ -912,7 +992,7 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
 @pytest.mark.asyncio
 async def test_otari_amessages_excludes_none_valued_optional_params() -> None:
     client = _mock_otari_client()
-    client.message.return_value = _message_response_payload()
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
     provider = _build_provider(client)
 
     params = MessagesParams(
@@ -932,7 +1012,7 @@ async def test_otari_amessages_excludes_none_valued_optional_params() -> None:
 
 @pytest.mark.asyncio
 async def test_otari_amessages_streaming_yields_typed_events_and_skips_unknown() -> None:
-    raw_events = [
+    raw_events: list[dict[str, Any]] = [
         {"type": "message_start", "message": _message_response_payload()},
         {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
         {"type": "ping"},
@@ -946,12 +1026,8 @@ async def test_otari_amessages_streaming_yields_typed_events_and_skips_unknown()
         {"type": "message_stop"},
     ]
 
-    async def _aiter() -> Any:
-        for event in raw_events:
-            yield event
-
     client = _mock_otari_client()
-    client.message.return_value = _aiter()
+    client.with_response_metadata.message.return_value = _MockMetadataStream(raw_events)
     provider = _build_provider(client)
 
     params = MessagesParams(

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from any_llm.exceptions import BatchNotCompleteError
 from any_llm.types.audio import AudioSpeechParams, AudioTranscriptionParams
@@ -82,8 +83,6 @@ def _mock_otari_client() -> MagicMock:
 
 
 def test_as_plain_dict_normalizes_models_and_passes_through() -> None:
-    from pydantic import BaseModel
-
     class _Model(BaseModel):
         value: int
 
@@ -96,7 +95,6 @@ def test_as_plain_dict_prefers_to_dict_over_model_dump() -> None:
     """otari's generated models leak oneOf/anyOf union wrappers via model_dump (breaking
     tool_calls and Messages content); their to_dict unwraps to the actual instance, so
     _as_plain_dict must prefer to_dict."""
-    from pydantic import BaseModel
 
     class _OtariLike(BaseModel):
         value: int
@@ -243,7 +241,6 @@ def test_otari_remaps_max_completion_tokens_to_max_tokens() -> None:
 
 def test_otari_converts_pydantic_response_format_to_json_schema() -> None:
     """otari has no parse() helper, so a Pydantic response_format must be sent as a json_schema dict."""
-    from pydantic import BaseModel
 
     class Schema(BaseModel):
         city: str
@@ -263,8 +260,6 @@ def test_otari_converts_pydantic_response_format_to_json_schema() -> None:
 
 
 def test_otari_to_parsed_completion_parses_json_content() -> None:
-    from pydantic import BaseModel
-
     from any_llm.types.completion import ParsedChatCompletion
 
     class Schema(BaseModel):
@@ -295,8 +290,6 @@ def test_otari_to_parsed_completion_parses_json_content() -> None:
 
 @pytest.mark.asyncio
 async def test_otari_acompletion_returns_parsed_completion_for_structured_output() -> None:
-    from pydantic import BaseModel
-
     from any_llm.types.completion import ParsedChatCompletion
 
     class Schema(BaseModel):
@@ -333,8 +326,6 @@ async def test_otari_acompletion_returns_parsed_completion_for_structured_output
 
 @pytest.mark.asyncio
 async def test_otari_acompletion_streams_with_response_format() -> None:
-    from pydantic import BaseModel
-
     class Schema(BaseModel):
         city: str
 
@@ -690,8 +681,6 @@ def _make_openai_response(text: str):  # type: ignore[no-untyped-def]
 
 @pytest.mark.asyncio
 async def test_otari_aresponses_basemodel_requests_schema_and_is_parsed() -> None:
-    from pydantic import BaseModel
-
     from any_llm.types.responses import ParsedResponse
 
     class City(BaseModel):
@@ -966,8 +955,6 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
         }
     )
 
-    from pydantic import BaseModel
-
     class City(BaseModel):
         city: str
 
@@ -999,7 +986,6 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
 )
 async def test_otari_amessages_output_format_with_beta_params_raises(beta_params: dict[str, Any]) -> None:
     """output_format routes through the bridge, which cannot carry context_management or betas."""
-    from pydantic import BaseModel
 
     class City(BaseModel):
         city: str


### PR DESCRIPTION
## Why

AnyLLM still blocks Otari context management parameters after SDK support shipped, and native Messages calls discard the Otari request ID needed for observability.

## What changed

Remove the temporary beta parameter guard, forward `context_management` and `betas`, and use the SDK response metadata API. Non-streaming responses expose `request_id`, while streaming responses attach it to the provider-neutral message-start event.

## Notes

- Stacked on #1286. Retarget this PR to `main` after the dependency PR merges.
- Verified with `otari 0.3.0` and `46` Otari provider unit tests.

Fixes #1225.

## PR Type

- Bug Fix
- New Feature

## Relevant issues

Fixes #1225.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6
- AI Developer Tool used: Pi
- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include the provider request ID when available, including streamed responses.
  * Anthropic beta parameters are forwarded for supported requests.
  * Structured output remains available through the existing completion experience.

* **Bug Fixes**
  * Improved handling of metadata-wrapped responses and streaming events.
  * Context management and beta parameters are now rejected only when incompatible with structured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->