### PR TITLE
fix(gemini): include thoughts_token_count in completion_tokens

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -270,6 +270,7 @@ class GoogleProvider(AnyLLM):
             completion_tokens=usage_dict.get("completion_tokens", 0),
             total_tokens=usage_dict.get("total_tokens", 0),
             prompt_tokens_details=usage_dict.get("prompt_tokens_details"),
+            completion_tokens_details=usage_dict.get("completion_tokens_details"),
         )
 
         return ChatCompletion(

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -17,6 +17,7 @@ from any_llm.types.completion import (
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
     ChunkChoice,
+    CompletionTokensDetails,
     CompletionUsage,
     CreateEmbeddingResponse,
     Embedding,
@@ -275,7 +276,9 @@ def _extract_usage_dict(response: types.GenerateContentResponse) -> dict[str, An
     """Extract usage from a Gemini response as a dict.
 
     Gemini's ``prompt_token_count`` already includes cached tokens
-    (``cached_content_token_count`` is a subset).
+    (``cached_content_token_count`` is a subset). ``thoughts_token_count`` is
+    billed output and included in ``total_token_count``, so it is folded into
+    ``completion_tokens`` to keep ``prompt + completion == total``.
 
     Reference: https://ai.google.dev/gemini-api/docs/caching
     """
@@ -284,9 +287,11 @@ def _extract_usage_dict(response: types.GenerateContentResponse) -> dict[str, An
         return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     usage: dict[str, Any] = {
         "prompt_tokens": metadata.prompt_token_count or 0,
-        "completion_tokens": metadata.candidates_token_count or 0,
+        "completion_tokens": (metadata.candidates_token_count or 0) + (metadata.thoughts_token_count or 0),
         "total_tokens": metadata.total_token_count or 0,
     }
+    if metadata.thoughts_token_count:
+        usage["completion_tokens_details"] = CompletionTokensDetails(reasoning_tokens=metadata.thoughts_token_count)
     if metadata.cached_content_token_count:
         usage["prompt_tokens_details"] = PromptTokensDetails(cached_tokens=metadata.cached_content_token_count)
     return usage
@@ -513,11 +518,15 @@ def _create_openai_chunk_from_google_chunk(
     usage = None
     if response.usage_metadata:
         cached_tokens = response.usage_metadata.cached_content_token_count
+        thought_tokens = response.usage_metadata.thoughts_token_count
         usage = CompletionUsage(
             prompt_tokens=response.usage_metadata.prompt_token_count or 0,
-            completion_tokens=response.usage_metadata.candidates_token_count or 0,
+            completion_tokens=(response.usage_metadata.candidates_token_count or 0) + (thought_tokens or 0),
             total_tokens=response.usage_metadata.total_token_count or 0,
             prompt_tokens_details=PromptTokensDetails(cached_tokens=cached_tokens) if cached_tokens else None,
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=thought_tokens)
+            if thought_tokens
+            else None,
         )
 
     return ChatCompletionChunk(

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -276,9 +276,7 @@ def _extract_usage_dict(response: types.GenerateContentResponse) -> dict[str, An
     """Extract usage from a Gemini response as a dict.
 
     Gemini's ``prompt_token_count`` already includes cached tokens
-    (``cached_content_token_count`` is a subset). ``thoughts_token_count`` is
-    billed output and included in ``total_token_count``, so it is folded into
-    ``completion_tokens`` to keep ``prompt + completion == total``.
+    (``cached_content_token_count`` is a subset).
 
     Reference: https://ai.google.dev/gemini-api/docs/caching
     """
@@ -287,6 +285,7 @@ def _extract_usage_dict(response: types.GenerateContentResponse) -> dict[str, An
         return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     usage: dict[str, Any] = {
         "prompt_tokens": metadata.prompt_token_count or 0,
+        # thoughts_token_count is billed output and already counted in total_token_count
         "completion_tokens": (metadata.candidates_token_count or 0) + (metadata.thoughts_token_count or 0),
         "total_tokens": metadata.total_token_count or 0,
     }

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -18,6 +18,7 @@ from openai.types.chat.chat_completion_message_function_tool_call import (
     ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
 )
 from openai.types.chat.chat_completion_message_function_tool_call import Function as OpenAIFunction
+from openai.types.completion_usage import CompletionTokensDetails as OpenAICompletionTokensDetails
 from openai.types.completion_usage import CompletionUsage as OpenAICompletionUsage
 from openai.types.completion_usage import PromptTokensDetails as OpenAIPromptTokensDetails
 from openai.types.create_embedding_response import Usage as OpenAIUsage
@@ -141,6 +142,7 @@ class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionT
 ChatCompletionMessageToolCall = ChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
 Function = OpenAIFunction
 CompletionUsage = OpenAICompletionUsage
+CompletionTokensDetails = OpenAICompletionTokensDetails
 PromptTokensDetails = OpenAIPromptTokensDetails
 CreateEmbeddingResponse = OpenAICreateEmbeddingResponse
 Embedding = OpenAIEmbedding

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -2045,6 +2045,59 @@ def test_streaming_chunk_includes_thought_tokens() -> None:
     assert chunk.usage.prompt_tokens + chunk.usage.completion_tokens == chunk.usage.total_tokens
 
 
+def test_convert_response_without_thought_tokens() -> None:
+    """Test that completion_tokens_details stays absent when the model produced no thoughts."""
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_part = Mock()
+    mock_part.thought = None
+    mock_part.function_call = None
+    mock_part.text = "Hello!"
+    mock_response.candidates[0].content.parts = [mock_part]
+
+    mock_response.usage_metadata = Mock()
+    mock_response.usage_metadata.prompt_token_count = 100
+    mock_response.usage_metadata.candidates_token_count = 50
+    mock_response.usage_metadata.thoughts_token_count = None
+    mock_response.usage_metadata.total_token_count = 150
+    mock_response.usage_metadata.cached_content_token_count = None
+
+    response_dict = _convert_response_to_response_dict(mock_response)
+
+    assert response_dict["usage"]["completion_tokens"] == 50
+    assert "completion_tokens_details" not in response_dict["usage"]
+
+
+def test_streaming_chunk_without_thought_tokens() -> None:
+    """Test that streaming usage has no completion_tokens_details when the model produced no thoughts."""
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_part = Mock()
+    mock_part.thought = None
+    mock_part.function_call = None
+    mock_part.text = "Hello!"
+    mock_response.candidates[0].content.parts = [mock_part]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.model_version = "gemini-2.5-flash"
+
+    mock_response.usage_metadata = Mock()
+    mock_response.usage_metadata.prompt_token_count = 100
+    mock_response.usage_metadata.candidates_token_count = 50
+    mock_response.usage_metadata.thoughts_token_count = None
+    mock_response.usage_metadata.total_token_count = 150
+    mock_response.usage_metadata.cached_content_token_count = None
+
+    chunk = _create_openai_chunk_from_google_chunk(mock_response)
+
+    assert chunk.usage is not None
+    assert chunk.usage.completion_tokens == 50
+    assert chunk.usage.completion_tokens_details is None
+
+
 def test_convert_completion_response_preserves_prompt_tokens_details() -> None:
     """Test that _convert_completion_response passes prompt_tokens_details through to ChatCompletion."""
     response_dict = {

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -24,7 +24,13 @@ from any_llm.providers.gemini.utils import (
     _has_additional_properties,
     _map_finish_reason,
 )
-from any_llm.types.completion import ChatCompletion, CompletionParams, PromptTokensDetails, ReasoningEffort
+from any_llm.types.completion import (
+    ChatCompletion,
+    CompletionParams,
+    CompletionTokensDetails,
+    PromptTokensDetails,
+    ReasoningEffort,
+)
 
 TEST_IMAGE_BYTES = b"test-image-bytes"
 TEST_PDF_BYTES = b"%PDF-1.4\ntest"
@@ -2125,6 +2131,35 @@ def test_convert_completion_response_preserves_prompt_tokens_details() -> None:
     assert result.usage.prompt_tokens == 100
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 80
+
+
+def test_convert_completion_response_preserves_completion_tokens_details() -> None:
+    """Test that _convert_completion_response passes completion_tokens_details through to ChatCompletion."""
+    response_dict = {
+        "id": "google_genai_response",
+        "model": "google/genai",
+        "created": 0,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!", "tool_calls": None},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 603,
+            "total_tokens": 623,
+            "completion_tokens_details": CompletionTokensDetails(reasoning_tokens=405),
+        },
+    }
+
+    result = GoogleProvider._convert_completion_response((response_dict, "test-model"))
+
+    assert result.usage is not None
+    assert result.usage.completion_tokens == 603
+    assert result.usage.completion_tokens_details is not None
+    assert result.usage.completion_tokens_details.reasoning_tokens == 405
 
 
 def test_merge_timeout_creates_http_options_when_absent() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -682,6 +682,7 @@ def test_convert_response_single_tool_call() -> None:
     mock_response.usage_metadata.candidates_token_count = 15
     mock_response.usage_metadata.total_token_count = 25
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -744,6 +745,7 @@ def test_convert_response_multiple_parallel_tool_calls() -> None:
     mock_response.usage_metadata.candidates_token_count = 30
     mock_response.usage_metadata.total_token_count = 50
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -1144,6 +1146,7 @@ async def test_streaming_completion_includes_usage_data() -> None:
     mock_response.usage_metadata.candidates_token_count = 5
     mock_response.usage_metadata.total_token_count = 15
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     chunk = _create_openai_chunk_from_google_chunk(mock_response)
 
@@ -1472,6 +1475,7 @@ def test_convert_response_preserves_thought_signature() -> None:
     mock_response.usage_metadata.candidates_token_count = 15
     mock_response.usage_metadata.total_token_count = 25
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -1504,6 +1508,7 @@ def test_convert_response_no_thought_signature() -> None:
     mock_response.usage_metadata.candidates_token_count = 15
     mock_response.usage_metadata.total_token_count = 25
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -1890,6 +1895,7 @@ def test_convert_response_extracts_cached_tokens() -> None:
     mock_response.usage_metadata.candidates_token_count = 50
     mock_response.usage_metadata.total_token_count = 150
     mock_response.usage_metadata.cached_content_token_count = 80
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -1916,6 +1922,7 @@ def test_convert_response_without_cached_tokens() -> None:
     mock_response.usage_metadata.candidates_token_count = 50
     mock_response.usage_metadata.total_token_count = 150
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     response_dict = _convert_response_to_response_dict(mock_response)
 
@@ -1942,6 +1949,7 @@ def test_streaming_chunk_extracts_cached_tokens() -> None:
     mock_response.usage_metadata.candidates_token_count = 50
     mock_response.usage_metadata.total_token_count = 150
     mock_response.usage_metadata.cached_content_token_count = 80
+    mock_response.usage_metadata.thoughts_token_count = None
 
     chunk = _create_openai_chunk_from_google_chunk(mock_response)
 
@@ -1971,12 +1979,70 @@ def test_streaming_chunk_without_cached_tokens() -> None:
     mock_response.usage_metadata.candidates_token_count = 50
     mock_response.usage_metadata.total_token_count = 150
     mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.thoughts_token_count = None
 
     chunk = _create_openai_chunk_from_google_chunk(mock_response)
 
     assert chunk.usage is not None
     assert chunk.usage.prompt_tokens == 100
     assert chunk.usage.prompt_tokens_details is None
+
+
+def test_convert_response_includes_thought_tokens() -> None:
+    """Test that thought tokens are folded into completion_tokens and surfaced as reasoning_tokens."""
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_part = Mock()
+    mock_part.thought = None
+    mock_part.function_call = None
+    mock_part.text = "36"
+    mock_response.candidates[0].content.parts = [mock_part]
+
+    mock_response.usage_metadata = Mock()
+    mock_response.usage_metadata.prompt_token_count = 20
+    mock_response.usage_metadata.candidates_token_count = 198
+    mock_response.usage_metadata.thoughts_token_count = 405
+    mock_response.usage_metadata.total_token_count = 623
+    mock_response.usage_metadata.cached_content_token_count = None
+
+    response_dict = _convert_response_to_response_dict(mock_response)
+
+    usage = response_dict["usage"]
+    assert usage["completion_tokens"] == 603
+    assert usage["completion_tokens_details"].reasoning_tokens == 405
+    assert usage["prompt_tokens"] + usage["completion_tokens"] == usage["total_tokens"]
+
+
+def test_streaming_chunk_includes_thought_tokens() -> None:
+    """Test that streaming usage folds thought tokens into completion_tokens with reasoning_tokens detail."""
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+
+    mock_part = Mock()
+    mock_part.thought = None
+    mock_part.function_call = None
+    mock_part.text = "36"
+    mock_response.candidates[0].content.parts = [mock_part]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.model_version = "gemini-2.5-flash"
+
+    mock_response.usage_metadata = Mock()
+    mock_response.usage_metadata.prompt_token_count = 20
+    mock_response.usage_metadata.candidates_token_count = 198
+    mock_response.usage_metadata.thoughts_token_count = 405
+    mock_response.usage_metadata.total_token_count = 623
+    mock_response.usage_metadata.cached_content_token_count = None
+
+    chunk = _create_openai_chunk_from_google_chunk(mock_response)
+
+    assert chunk.usage is not None
+    assert chunk.usage.completion_tokens == 603
+    assert chunk.usage.completion_tokens_details is not None
+    assert chunk.usage.completion_tokens_details.reasoning_tokens == 405
+    assert chunk.usage.prompt_tokens + chunk.usage.completion_tokens == chunk.usage.total_tokens
 
 
 def test_convert_completion_response_preserves_prompt_tokens_details() -> None:


### PR DESCRIPTION
## Description

Gemini bills thought tokens as output and includes them in `total_token_count`, but both usage conversion sites map `completion_tokens` straight from `candidates_token_count`. The returned usage is internally inconsistent: `prompt_tokens + completion_tokens ≠ total_tokens` whenever the model thinks.

This folds `thoughts_token_count` into `completion_tokens` at both sites (non-streaming `_extract_usage_dict` and the streaming chunk converter) and surfaces it as `completion_tokens_details.reasoning_tokens`, matching OpenAI reasoning-token semantics.

Verified live against `gemini-2.5-flash`:

```
before: prompt=20 completion=151 total=553   (382 thought tokens missing)
after:  prompt=20 completion=533 total=553   reasoning_tokens=382
```

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1290

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Gemini responses now include reasoning/thought token usage in completion and total token counts.
  * Reasoning-token details are available for both standard and streaming responses.
  * Usage information provides a clearer breakdown of completion tokens, including reasoning activity where available.
* **Bug Fixes**
  * Corrected Gemini usage reporting to account for thought tokens consistently across response types.
  * Preserved detailed completion usage information when converting Gemini responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->