### PR TITLE
fix(anthropic): default tool_choice to auto when only parallel_tool_calls is set

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -430,7 +430,7 @@ def _convert_tool_choice(params: CompletionParams) -> dict[str, Any]:
     parallel_tool_calls = params.parallel_tool_calls
     if parallel_tool_calls is None:
         parallel_tool_calls = True
-    tool_choice = params.tool_choice or "any"
+    tool_choice = params.tool_choice or "auto"
     if tool_choice == "required":
         tool_choice = "any"
     elif isinstance(tool_choice, dict):
@@ -480,7 +480,7 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
     if params.tools:
         params.tools = _convert_tool_spec(params.tools)
 
-    if params.tool_choice or params.parallel_tool_calls:
+    if params.tool_choice is not None or params.parallel_tool_calls is not None:
         params.tool_choice = _convert_tool_choice(params)
 
     if params.reasoning_effort is None or params.reasoning_effort == "none":

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -309,6 +309,30 @@ async def test_completion_with_tool_choice_and_parallel_tool_calls(parallel_tool
         )
 
 
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+@pytest.mark.asyncio
+async def test_completion_with_parallel_tool_calls_only(parallel_tool_calls: bool) -> None:
+    """Test that parallel_tool_calls without tool_choice maps to "auto" instead of forcing tool use."""
+    api_key = "test-api-key"
+    model = "model-id"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_anthropic_provider() as mock_anthropic:
+        provider = AnthropicProvider(api_key=api_key)
+        await provider._acompletion(
+            CompletionParams(model_id=model, messages=messages, parallel_tool_calls=parallel_tool_calls),
+        )
+
+        expected_kwargs = {"tool_choice": {"type": "auto", "disable_parallel_tool_use": not parallel_tool_calls}}
+
+        mock_anthropic.return_value.messages.create.assert_called_once_with(
+            model=model,
+            messages=[{"role": "user", "content": "Hello"}],
+            **expected_kwargs,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+
+
 @pytest.mark.asyncio
 async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, Any]]) -> None:
     api_key = "test-api-key"


### PR DESCRIPTION
## Description

Anthropic and OpenAI set tool calling differently:

| | OpenAI (chat completions) | Anthropic (messages) |
|---|---|---|
| may/must the model call a tool? | `tool_choice`: `"auto"` (default), `"required"`, `"none"`, or a dict naming one function | `tool_choice` object: `{"type": "auto"}`, `{"type": "any"}` (= `"required"`), `{"type": "tool", "name": ...}`, `{"type": "none"}` |
| may it return several calls at once? | `parallel_tool_calls`, a separate top-level boolean | no separate field; `disable_parallel_tool_use` lives inside the `tool_choice` object |

So `_convert_tool_choice` has two jobs: 
- map the values,
- carry `parallel_tool_calls` into `disable_parallel_tool_use` inside whatever `tool_choice` object it sends.

The corner case is a caller who passes **only** `parallel_tool_calls`. Anthropic has no standalone field for it, so the converter must synthesize a `tool_choice` object just to carry the flag. 

The neutral carrier is `{"type": "auto"}`: identical model behavior to not mentioning tool choice at all. What happens today instead:
- the converter defaults the missing `tool_choice` to `"any"`: Anthropic's "must call a tool" mode. So a caller who only asked about parallelism gets forced tool use;
- the call site gates on truthiness (`if params.tool_choice or params.parallel_tool_calls`), so `parallel_tool_calls=False` never reaches the converter at all (the restriction is silently dropped).

The fix is two lines: default the synthesized `tool_choice` to `"auto"` and gate on `is not None`. 
With the fix, `parallel_tool_calls=False` alone sends `{"type": "auto", "disable_parallel_tool_use": true}`. Explicit `tool_choice` values (`"auto"`/`"required"`/dict form) are unchanged.

### Example

```python
llm = AnyLLM.create("anthropic")
resp = await llm.acompletion(
    model="claude-haiku-4-5",
    messages=[{"role": "user", "content": "Just say the word 'hello'. Do not use any tools."}],
    tools=[get_weather_tool],
    parallel_tool_calls=True,
)
```

Before (live, `main`): the model is not allowed to reply in text, so it fabricates a tool call:

```
content:    ""
tool_calls: [get_weather(arguments='{"city": "hello"}')]
```

After (live, this branch):

```
content:    "Hello."
tool_calls: None
```

## PR Type

- 🐛 Bug Fix

## Relevant issues

Related: mozilla-ai/any-llm#646 (fixed the dict-form translation; this fixes the unset-default path)

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Anthropic tool-use configuration when parallel tool calls are enabled without an explicit tool choice.
  - Tool selection now defaults to automatic mode, allowing the provider to choose whether tools should be used.
  - Explicit tool-choice settings, including disabled or otherwise falsy values, are now handled correctly.

- **Tests**
  - Added coverage for parallel tool calls with both enabled and disabled settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->