### PR TITLE
fix(gemini): reasoning_effort="none" disables thinking instead of hiding it

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,6 +159,8 @@ print(response.choices[0].message.content)
 
 Reasoning also works with streaming — each chunk may include `chunk.choices[0].delta.reasoning`.
 
+`reasoning_effort="none"` (or `None`) turns thinking off. A model that only runs with thinking on, such as `gemini-2.5-pro`, rejects it with an `InvalidRequestError`, so use `"auto"` or a graded level there.
+
 ## Embeddings
 
 `embedding` and `aembedding` allow you to create vector embeddings from text using the same unified interface across providers.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,7 +159,7 @@ print(response.choices[0].message.content)
 
 Reasoning also works with streaming — each chunk may include `chunk.choices[0].delta.reasoning`.
 
-`reasoning_effort="none"` (or `None`) turns thinking off. A model that only runs with thinking on, such as `gemini-2.5-pro`, rejects it with an `InvalidRequestError`, so use `"auto"` or a graded level there.
+`reasoning_effort="none"` (or `None`) turns thinking off where the model has an off setting. Gemini 3.5 and newer have no off tier and run at their lowest level instead, and a model that only runs with thinking on, such as `gemini-2.5-pro`, rejects it with an `InvalidRequestError`, so use `"auto"` or a graded level there.
 
 ## Embeddings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ mistral = [
 anthropic = []
 
 gemini = [
-  "google-genai>=1.51.0",
+  "google-genai>=1.56.0",
   "google-cloud-storage",
 ]
 
 vertexai = [
-  "google-genai>=1.51.0",
+  "google-genai>=1.56.0",
   "google-cloud-storage",
 ]
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -8,6 +8,7 @@ from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
 from any_llm.exceptions import BatchNotCompleteError, InvalidRequestError, UnsupportedParameterError
+from any_llm.logging import logger
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -148,7 +149,17 @@ class GoogleProvider(AnyLLM):
             kwargs["presence_penalty"] = params.presence_penalty
         if params.reasoning_effort != "auto":
             if params.reasoning_effort is None or params.reasoning_effort == "none":
-                kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
+                if _uses_thinking_level(params.model_id):
+                    # thinking_level has no off tier; MINIMAL is the nearest expressible value
+                    logger.warning(
+                        "%s cannot disable thinking; clamping reasoning_effort='none' to thinking_level=MINIMAL",
+                        params.model_id,
+                    )
+                    kwargs["thinking_config"] = types.ThinkingConfig(
+                        include_thoughts=False, thinking_level=types.ThinkingLevel.MINIMAL
+                    )
+                else:
+                    kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False, thinking_budget=0)
             elif _uses_thinking_level(params.model_id):
                 kwargs["thinking_config"] = types.ThinkingConfig(
                     include_thoughts=True, thinking_level=REASONING_EFFORT_TO_THINKING_LEVELS[params.reasoning_effort]

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -71,6 +71,7 @@ REASONING_EFFORT_TO_THINKING_LEVELS = {
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
 _THINKING_LEVEL_MIN_GEMINI_VERSION = (3, 5)
 _GEMINI_VERSION_PATTERN = re.compile(r"(?:^|/)gemini-(\d+)(?:\.(\d+))?")
+_MINIMAL_CLAMP_WARNED: set[str] = set()
 
 
 def _uses_thinking_level(model_id: str) -> bool:
@@ -150,11 +151,12 @@ class GoogleProvider(AnyLLM):
         if params.reasoning_effort != "auto":
             if params.reasoning_effort is None or params.reasoning_effort == "none":
                 if _uses_thinking_level(params.model_id):
-                    # thinking_level has no off tier; MINIMAL is the nearest expressible value
-                    logger.warning(
-                        "%s cannot disable thinking; clamping reasoning_effort='none' to thinking_level=MINIMAL",
-                        params.model_id,
-                    )
+                    if params.model_id not in _MINIMAL_CLAMP_WARNED:
+                        _MINIMAL_CLAMP_WARNED.add(params.model_id)
+                        logger.warning(
+                            "%s has no thinking off tier; clamping reasoning_effort='none' to thinking_level=MINIMAL",
+                            params.model_id,
+                        )
                     kwargs["thinking_config"] = types.ThinkingConfig(
                         include_thoughts=False, thinking_level=types.ThinkingLevel.MINIMAL
                     )

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -142,9 +142,11 @@ def _extract_status_code(exception: Exception) -> int | None:
 
     response = getattr(exception, "response", None)
     if response is not None:
-        response_status = getattr(response, "status_code", None)
-        if isinstance(response_status, int):
-            return response_status
+        # httpx and requests spell it status_code; aiohttp spells it status
+        for name in ("status_code", "status"):
+            response_status = getattr(response, name, None)
+            if isinstance(response_status, int):
+                return response_status
 
     return None
 

--- a/tests/unit/providers/test_gemini_exceptions.py
+++ b/tests/unit/providers/test_gemini_exceptions.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E402
 from __future__ import annotations
 
+import httpx
 import pytest
 
 google_genai = pytest.importorskip("google.genai")
@@ -63,4 +64,37 @@ def test_api_error_generic() -> None:
 
     assert isinstance(result, ProviderError)
     assert result.provider_name == "gemini"
+    assert result.original_exception is original
+
+
+def test_client_error_when_model_rejects_zero_thinking_budget() -> None:
+    """Models that only work in thinking mode reject thinking_budget=0 with a 400."""
+    original = ClientError(
+        code=400,
+        response_json={"error": {"message": "Budget 0 is invalid. This model only works in thinking mode."}},
+    )
+
+    result = convert_exception(original, "gemini")
+
+    assert isinstance(result, InvalidRequestError)
+    assert "Budget 0 is invalid" in str(result)
+    assert result.original_exception is original
+
+
+def test_client_error_when_model_rejects_minimal_thinking_level() -> None:
+    """Models without a MINIMAL thinking level reject the clamp with a 400."""
+    original = ClientError(
+        code=400,
+        response_json={
+            "error": {
+                "message": "Thinking level MINIMAL is not supported for this model. Please retry with other thinking level."
+            }
+        },
+        response=httpx.Response(400),
+    )
+
+    result = convert_exception(original, "gemini")
+
+    assert isinstance(result, InvalidRequestError)
+    assert "Thinking level MINIMAL is not supported" in str(result)
     assert result.original_exception is original

--- a/tests/unit/providers/test_gemini_exceptions.py
+++ b/tests/unit/providers/test_gemini_exceptions.py
@@ -98,3 +98,22 @@ def test_client_error_when_model_rejects_minimal_thinking_level() -> None:
     assert isinstance(result, InvalidRequestError)
     assert "Thinking level MINIMAL is not supported" in str(result)
     assert result.original_exception is original
+
+
+def test_client_error_without_attached_response_still_maps_to_invalid_request() -> None:
+    """With no usable response object, the status Google puts in the error body still classifies the 400."""
+    original = ClientError(
+        code=400,
+        response_json={
+            "error": {
+                "code": 400,
+                "message": "Thinking level MINIMAL is not supported for this model. Please retry with other thinking level.",
+                "status": "INVALID_ARGUMENT",
+            }
+        },
+    )
+
+    result = convert_exception(original, "gemini")
+
+    assert isinstance(result, InvalidRequestError)
+    assert "Thinking level MINIMAL is not supported" in str(result)

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -662,25 +662,30 @@ def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
 
 
 @pytest.mark.parametrize("reasoning_effort", [None, "none"])
-def test_none_disables_thinking_on_thinking_budget_models(reasoning_effort: ReasoningEffort | None) -> None:
-    """Test that reasoning_effort='none' sends thinking_budget=0 instead of only hiding thoughts."""
-    result = GoogleProvider._convert_completion_params(
-        CompletionParams(
-            model_id="gemini-2.5-flash",
-            messages=[{"role": "user", "content": "Hello"}],
-            reasoning_effort=reasoning_effort,
-        ),
-        provider_name="gemini",
-    )
+def test_none_disables_thinking_on_thinking_budget_models(
+    reasoning_effort: ReasoningEffort | None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that reasoning_effort='none' sends thinking_budget=0 instead of only hiding thoughts, without a warning."""
+    with caplog.at_level("WARNING"):
+        result = GoogleProvider._convert_completion_params(
+            CompletionParams(
+                model_id="gemini-2.5-flash",
+                messages=[{"role": "user", "content": "Hello"}],
+                reasoning_effort=reasoning_effort,
+            ),
+            provider_name="gemini",
+        )
 
     assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=False, thinking_budget=0)
+    assert not caplog.records
 
 
 @pytest.mark.parametrize("reasoning_effort", [None, "none"])
 def test_none_clamps_to_minimal_on_thinking_level_models(
-    reasoning_effort: ReasoningEffort | None, caplog: pytest.LogCaptureFixture
+    reasoning_effort: ReasoningEffort | None, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that models without a thinking off tier clamp 'none' to MINIMAL and warn."""
+    monkeypatch.setattr("any_llm.providers.gemini.base._MINIMAL_CLAMP_WARNED", set())
     with caplog.at_level("WARNING"):
         result = GoogleProvider._convert_completion_params(
             CompletionParams(
@@ -694,7 +699,21 @@ def test_none_clamps_to_minimal_on_thinking_level_models(
     assert result["config"].thinking_config == types.ThinkingConfig(
         include_thoughts=False, thinking_level=types.ThinkingLevel.MINIMAL
     )
-    assert "cannot disable thinking" in caplog.text
+    assert "clamping reasoning_effort='none' to thinking_level=MINIMAL" in caplog.text
+
+
+def test_minimal_clamp_warns_once_per_model(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller that sets 'none' on every request sees the clamp warning once per model, not once per call."""
+    monkeypatch.setattr("any_llm.providers.gemini.base._MINIMAL_CLAMP_WARNED", set())
+    params = CompletionParams(
+        model_id="gemini-3.5-flash", messages=[{"role": "user", "content": "Hello"}], reasoning_effort="none"
+    )
+
+    with caplog.at_level("WARNING"):
+        GoogleProvider._convert_completion_params(params, provider_name="gemini")
+        GoogleProvider._convert_completion_params(params, provider_name="gemini")
+
+    assert len(caplog.records) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -608,7 +608,7 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
         if reasoning_effort == "auto":
             assert thinking_config is None
         elif reasoning_effort is None or reasoning_effort == "none":
-            assert thinking_config == types.ThinkingConfig(include_thoughts=False)
+            assert thinking_config == types.ThinkingConfig(include_thoughts=False, thinking_budget=0)
         else:
             assert thinking_config == types.ThinkingConfig(
                 include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
@@ -659,6 +659,42 @@ def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
     )
 
     assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
+
+
+@pytest.mark.parametrize("reasoning_effort", [None, "none"])
+def test_none_disables_thinking_on_thinking_budget_models(reasoning_effort: ReasoningEffort | None) -> None:
+    """Test that reasoning_effort='none' sends thinking_budget=0 instead of only hiding thoughts."""
+    result = GoogleProvider._convert_completion_params(
+        CompletionParams(
+            model_id="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort=reasoning_effort,
+        ),
+        provider_name="gemini",
+    )
+
+    assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=False, thinking_budget=0)
+
+
+@pytest.mark.parametrize("reasoning_effort", [None, "none"])
+def test_none_clamps_to_minimal_on_thinking_level_models(
+    reasoning_effort: ReasoningEffort | None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that models without a thinking off tier clamp 'none' to MINIMAL and warn."""
+    with caplog.at_level("WARNING"):
+        result = GoogleProvider._convert_completion_params(
+            CompletionParams(
+                model_id="gemini-3.5-flash",
+                messages=[{"role": "user", "content": "Hello"}],
+                reasoning_effort=reasoning_effort,
+            ),
+            provider_name="gemini",
+        )
+
+    assert result["config"].thinking_config == types.ThinkingConfig(
+        include_thoughts=False, thinking_level=types.ThinkingLevel.MINIMAL
+    )
+    assert "cannot disable thinking" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -175,6 +175,14 @@ def test_convert_exception_carries_status_code_from_response() -> None:
     assert result.status_code == 400
 
 
+def test_convert_exception_carries_status_from_aiohttp_style_response() -> None:
+    """aiohttp responses spell it ``status``, which google-genai attaches on its async path."""
+    error = _ResponseStatusError(400, "Invalid request")
+    del error.response.status_code  # type: ignore[attr-defined]
+    error.response.status = 400  # type: ignore[attr-defined]
+    assert convert_exception(error, "openai").status_code == 400
+
+
 def test_convert_exception_prefers_status_code_attribute_over_response() -> None:
     error = _ResponseStatusError(500, "Invalid request")
     error.status_code = 400  # type: ignore[attr-defined]


### PR DESCRIPTION
## Description

`reasoning_effort="none"` (and `None`) currently maps to `ThinkingConfig(include_thoughts=False)`, which hides thought summaries instead of turning off thinking. 

`"none"` already means off everywhere else in this codebase:
- anthropic sends `thinking={"type": "disabled"}`, 
- cohere and deepseek send their disable flags, 
- ollama sends `think=False`,
- `messages_compat.py` maps Anthropic's `disabled` back to `reasoning_effort="none"`. 
 
**Gemini is the one provider where "none" means "keep thinking just hide the thinking summaries".**

The fix, per path:

- **`thinking_budget` models**: send `ThinkingConfig(include_thoughts=False, thinking_budget=0)`, so thinking is actually off.
- **Models that reject `thinking_budget=0`** (e.g. `gemini-2.5-pro`): Google's own 400 surfaces as the typed error, reacting to the provider's error rather than predicting it with a model list. 
   - This is the chosen approach for this repo (mozilla-ai/any-llm#1189). 
   - The live error is self-explanatory: `[gemini] 400 INVALID_ARGUMENT ... "Budget 0 is invalid. This model only works in thinking mode."`
- **`thinking_level` models (3.5+)**: `thinking_level` has no off value since the lowest tier is `MINIMAL`.
   - So `"none"` maps to `ThinkingLevel.MINIMAL` with a `logger.warning`, the same clamp-to-nearest convention already used in mozilla-ai/any-llm#1241 and mozilla-ai/any-llm#1108.

<details>
<summary>Why clamp with warning, instead of error?</summary>

On 3.5/3.6 the clamp billed zero thought tokens (table below), so `"none"` callers get what they asked for. Erroring up front instead would mean guessing from the version string which models those are, the kind of guess mozilla-ai/any-llm#1189 declined. A model that doesn't support `MINIMAL` rejects it, and the caller gets the typed 400 (3.7, note below).

The warning is because `MINIMAL` is the least thinking the model allows, not a promise of zero, and mozilla-ai/any-llm#1107 treats surprise thinking costs as a bug.

</details>

`None` stays merged with `"none"` as it has been since mozilla-ai/any-llm#708; `"auto"` remains the unset default, so callers who don't set the parameter are untouched.

Verified live across every path with `reasoning_effort="none"` (gap = thought tokens billed but hidden; before the fix, `gemini-2.5-flash` billed 424 hidden thought tokens):

| gemini models | path | result |
|---|---|---|
| 2.5-flash, 2.5-flash-lite, 3-flash-preview, 3.1-flash-lite | budget → 0 | OK, gap 0 |
| 2.5-pro, 3.1-pro-preview | budget → 0, rejected | typed `InvalidRequestError`: "Budget 0 is invalid. This model only works in thinking mode." |
| 3.5-flash, 3.5-flash-lite, 3.6-flash | level → MINIMAL | OK, gap 0, warning emitted |
| 3.7-flash | level → MINIMAL, rejected | typed `InvalidRequestError`: "Thinking level MINIMAL is not supported", details below |

Every failure surfaces as a typed any-llm exception; no raw `google.genai` errors leak.

<details>
<summary>Why gemini-3.7-flash rejects the clamp</summary>

`gemini-3.7-flash` cannot disable thinking: `MINIMAL` is gone, the new floor `LOW` thinks for real (220 thought tokens on the test prompt), and `thinking_budget=0` is silently ignored but still billed. So the 400 is correct, same as the thinking-only pros, and clamping to `LOW` would just bring back the bug this PR fixes. The removal also breaks the existing `"minimal"` mapping (mozilla-ai/any-llm#1281) on 3.7.

For reference, `thinking_budget=0` today is honored on 3.5, rejected on 3.6, and ignored-and-billed on 3.7. Three behaviors in three consecutive minor versions is why this PR trusts the SDK enum and provider errors instead of a model matrix.

</details>

### Behavior change

`reasoning_effort="none"` previously kept thinking active (billed, hidden); it now genuinely disables it. Models that cannot run without thinking now raise Google's 400 instead of silently billing. Callers who relied on "hidden but active" thinking should use `"auto"` or a graded level. Default (`"auto"`) behavior is unchanged.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1293

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when reasoning is disabled for Gemini models.
  * Models without an off setting now use minimal thinking and provide a one-time warning.
  * Improved conversion of Gemini and asynchronous API errors into clearer request errors, including HTTP status details.

* **Documentation**
  * Clarified how to disable reasoning and which settings to use for models that require thinking.

* **Tests**
  * Expanded coverage for reasoning configurations, unsupported thinking settings, and API error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->