### PR TITLE
fix(bedrock): reject per-request timeout with a custom client

### DIFF
--- a/src/any_llm/providers/bedrock/bedrock.py
+++ b/src/any_llm/providers/bedrock/bedrock.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from any_llm.any_llm import AnyLLM
-from any_llm.exceptions import BatchNotCompleteError, InvalidRequestError, MissingApiKeyError
+from any_llm.exceptions import (
+    BatchNotCompleteError,
+    InvalidRequestError,
+    MissingApiKeyError,
+    UnsupportedParameterError,
+)
 from any_llm.logging import logger
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, CreateEmbeddingResponse
 from any_llm.types.model import Model
@@ -60,7 +65,8 @@ class BedrockProvider(AnyLLM):
     SUPPORTS_RERANK = False
 
     # boto3's Converse API has no per-request timeout, so it is translated into a per-timeout
-    # boto3 client in _completion via _client_for_timeout.
+    # boto3 client in _completion via _client_for_timeout. A caller-supplied `client=` can't be
+    # rebuilt that way, so a timeout is rejected on that path instead.
     TIMEOUT_SUPPORT = "mapped"
 
     MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
@@ -295,20 +301,27 @@ class BedrockProvider(AnyLLM):
 
         boto3 has no per-request timeout; connect/read timeouts are only configurable at
         client-construction time via ``botocore.config.Config``. When a custom client was
-        supplied, any-llm doesn't own its construction, so `timeout` is dropped with a warning
-        instead of being silently ignored or crashing.
+        supplied, any-llm doesn't own its construction and cannot apply the timeout, so the
+        parameter is rejected the same way an ``unsupported`` provider rejects it centrally
+        (see ``AnyLLM._validate_and_forward_timeout``). Dropping it instead would let the call
+        run unbounded while the caller believed a deadline was in force.
 
         ``_completion`` runs on executor threads (via ``_acompletion``), so the cache miss path
         is locked: concurrent calls with the same not-yet-cached timeout must not each build and
         leak their own client. The cache is also bounded, since a caller deriving `timeout` from
         a remaining deadline would otherwise produce a new distinct value (and client) per call.
         """
-        if timeout is None or self._boto_session is None:
+        if self._boto_session is None:
             if timeout is not None:
-                logger.warning(
-                    "Bedrock does not support a per-request 'timeout' when a custom client is provided; "
-                    "ignoring it. Configure timeouts via botocore.config.Config when constructing your client."
+                parameter_name = "timeout"
+                additional_message = (
+                    "A per-request 'timeout' cannot be applied to a custom client. Set "
+                    "connect_timeout/read_timeout via botocore.config.Config when constructing it, "
+                    "or let any-llm build the client."
                 )
+                raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME, additional_message)
+            return self.client
+        if timeout is None:
             return self.client
 
         with self._timeout_clients_lock:

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -1,7 +1,6 @@
 import base64
 import dataclasses
 import json
-import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
@@ -337,28 +336,67 @@ def test_timeout_client_creation_is_thread_safe() -> None:
         assert mock_client_call.call_count == 2
 
 
-def test_completion_timeout_with_custom_client_logs_warning_and_is_ignored(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that `timeout` is dropped with a warning (not a crash) when a custom client is used.
+def test_completion_timeout_with_custom_client_raises_unsupported_parameter_error() -> None:
+    """Test that `timeout` is rejected when a custom client is used.
 
-    any-llm doesn't own a custom client's construction, so it can't safely reconfigure its
-    connection timeouts.
+    any-llm doesn't own a custom client's construction, so it can't reconfigure its connection
+    timeouts. Rejecting matches the centralized `TIMEOUT_SUPPORT` contract instead of dropping a
+    requested timeout, which would leave the caller believing a bound was applied.
     """
+    custom_client = Mock()
+
+    provider = BedrockProvider(client=custom_client)
+    with pytest.raises(UnsupportedParameterError, match="timeout") as exc_info:
+        provider._completion(
+            CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]),
+            timeout=5,
+        )
+
+    assert "botocore.config.Config" in str(exc_info.value)
+    custom_client.converse.assert_not_called()
+
+
+def test_streaming_completion_timeout_with_custom_client_raises_unsupported_parameter_error() -> None:
+    """Test that the rejection happens before the streaming request is opened."""
+    custom_client = Mock()
+
+    provider = BedrockProvider(client=custom_client)
+    with pytest.raises(UnsupportedParameterError, match="timeout"):
+        provider._completion(
+            CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}], stream=True),
+            timeout=5,
+        )
+
+    custom_client.converse_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_acompletion_timeout_with_custom_client_raises_unsupported_parameter_error() -> None:
+    """Test that the rejection surfaces through the public async entry point too."""
+    custom_client = Mock()
+
+    provider = BedrockProvider(client=custom_client)
+    with pytest.raises(UnsupportedParameterError, match="timeout"):
+        await provider.acompletion(
+            model="model-id",
+            messages=[{"role": "user", "content": "Hello"}],
+            timeout=5,
+        )
+
+    custom_client.converse.assert_not_called()
+
+
+def test_completion_without_timeout_still_uses_custom_client() -> None:
+    """Test that a custom client keeps working when no per-request `timeout` is requested."""
     custom_client = Mock()
     custom_client.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
 
     with patch("any_llm.providers.bedrock.bedrock._convert_response"):
         provider = BedrockProvider(client=custom_client)
-        with caplog.at_level(logging.WARNING, logger="any_llm"):
-            provider._completion(
-                CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]),
-                timeout=5,
-            )
+        provider._completion(CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "Hello"}]))
 
+    assert provider._client_for_timeout(None) is custom_client
     custom_client.converse.assert_called_once()
-    assert "timeout" not in custom_client.converse.call_args[1]
-    assert "timeout" in caplog.text.lower()
 
 
 def test_custom_client_used_when_provided() -> None:


### PR DESCRIPTION
## Description
Fixes #1264.

Bedrock with a caller-supplied client= ignored per-request timeout (TIMEOUT_SUPPORT is mapped). Raise UnsupportedParameterError when timeout is set alongside a custom client, matching the centralized rejection. Provider-built clients are unchanged.

## PR Type
- Bug Fix

## Relevant issues
Fixes #1264

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)

tests/unit/providers/test_aws_provider.py timeout/custom_client: 12 passed. tests/unit: 2158 passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom Bedrock clients now clearly reject unsupported per-request timeout settings instead of silently ignoring them.
  * Provider-managed Bedrock clients continue to support configured timeouts.
  * Custom clients remain available for synchronous, streaming and asynchronous requests when no timeout is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->