### PR TITLE
test: ignore spurious tool-call args in agent-loop integration harness

### DIFF
--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import inspect
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +33,29 @@ def get_weather(location: str) -> str:
         location: The city name to get weather for.
     """
     return json.dumps({"location": location, "temperature": "15C", "condition": "sunny"})
+
+
+def call_tool(tool_fn: Callable[..., str], raw_arguments: str | None) -> str:
+    """Call a tool with model supplied arguments, dropping the ones it does not declare.
+
+    Models sometimes hallucinate arguments, such as a `result` key for a tool that takes no
+    parameters. Forwarding those verbatim raises `TypeError` and fails the agent loop for a
+    reason unrelated to what these tests cover.
+    """
+    arguments = json.loads(raw_arguments) if raw_arguments else {}
+    if not isinstance(arguments, dict):
+        arguments = {}
+
+    parameters = inspect.signature(tool_fn).parameters
+    if not any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        accepted = {
+            name
+            for name, parameter in parameters.items()
+            if parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        }
+        arguments = {name: value for name, value in arguments.items() if name in accepted}
+
+    return tool_fn(**arguments)
 
 
 @pytest.mark.asyncio
@@ -69,8 +95,7 @@ async def test_agent_loop_parallel_tool_calls(
             if not isinstance(tool_call, OpenAIChatCompletionMessageFunctionToolCall):
                 continue
             assert tool_call.function.name == "get_weather"
-            args = json.loads(tool_call.function.arguments)
-            tool_result = get_weather(**args)
+            tool_result = call_tool(get_weather, tool_call.function.arguments)
 
             messages.append(
                 {
@@ -154,8 +179,7 @@ async def test_agent_loop_sequential_tool_calls(
                 assert tool_name in available_tools, f"Unknown tool: {tool_name}"
                 tool_fn = available_tools[tool_name]
 
-                args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                tool_result = tool_fn(**args)
+                tool_result = call_tool(tool_fn, tool_call.function.arguments)
 
                 messages.append(
                     {

--- a/tests/unit/test_agent_loop_tool_calls.py
+++ b/tests/unit/test_agent_loop_tool_calls.py
@@ -1,0 +1,117 @@
+import json
+from typing import Any
+
+import pytest
+
+from any_llm import AnyLLM, LLMProvider
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+    Choice,
+    Function,
+)
+from tests.integration import test_agent_loop as agent_loop
+
+
+def _tool_call_completion(name: str, arguments: str) -> ChatCompletion:
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id=f"call_{name}",
+                type="function",
+                function=Function(name=name, arguments=arguments),
+            )
+        ],
+    )
+    return _completion(message, "tool_calls")
+
+
+def _text_completion(content: str) -> ChatCompletion:
+    return _completion(ChatCompletionMessage(role="assistant", content=content), "stop")
+
+
+def _completion(message: ChatCompletionMessage, finish_reason: Any) -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-stub",
+        created=0,
+        model="stub-model",
+        object="chat.completion",
+        choices=[Choice(finish_reason=finish_reason, index=0, message=message)],
+    )
+
+
+class _StubLLM:
+    """Replays a fixed sequence of completions so the agent loop is deterministic."""
+
+    SUPPORTS_COMPLETION = True
+
+    def __init__(self, responses: list[ChatCompletion]) -> None:
+        self.responses = responses
+        self.calls = 0
+
+    async def acompletion(self, **kwargs: Any) -> ChatCompletion:
+        response = self.responses[self.calls]
+        self.calls += 1
+        return response
+
+
+@pytest.mark.asyncio
+async def test_sequential_agent_loop_tolerates_spurious_tool_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression for #1170: Together sometimes calls the zero-parameter tool with a `result` argument."""
+    llm = _StubLLM(
+        [
+            _tool_call_completion("get_current_date", json.dumps({"result": "2026-01-01 00:00"})),
+            _tool_call_completion("get_weather", json.dumps({"location": "Paris"})),
+            _text_completion("It is sunny in Paris."),
+        ]
+    )
+    monkeypatch.setattr(AnyLLM, "create", lambda provider, **kwargs: llm)
+
+    await agent_loop.test_agent_loop_sequential_tool_calls(
+        LLMProvider.TOGETHER,
+        {LLMProvider.TOGETHER: "openai/gpt-oss-20b"},
+        {},
+    )
+
+    assert llm.calls == len(llm.responses)
+
+
+def test_call_tool_ignores_spurious_argument_for_zero_parameter_tool() -> None:
+    date = agent_loop.get_current_date()
+
+    assert agent_loop.call_tool(agent_loop.get_current_date, json.dumps({"result": "2026-01-01 00:00"})) == date
+
+
+def test_call_tool_forwards_declared_arguments() -> None:
+    weather = json.loads(agent_loop.call_tool(agent_loop.get_weather, json.dumps({"location": "Paris"})))
+
+    assert weather["location"] == "Paris"
+
+
+def test_call_tool_drops_only_undeclared_arguments() -> None:
+    arguments = json.dumps({"location": "London", "unit": "celsius"})
+    weather = json.loads(agent_loop.call_tool(agent_loop.get_weather, arguments))
+
+    assert weather["location"] == "London"
+
+
+def test_call_tool_without_arguments() -> None:
+    date = agent_loop.get_current_date()
+
+    assert agent_loop.call_tool(agent_loop.get_current_date, None) == date
+    assert agent_loop.call_tool(agent_loop.get_current_date, "") == date
+
+
+def test_call_tool_ignores_non_object_arguments() -> None:
+    assert agent_loop.call_tool(agent_loop.get_current_date, json.dumps(["result"])) == agent_loop.get_current_date()
+
+
+def test_call_tool_forwards_everything_to_var_keyword_tool() -> None:
+    def echo(**kwargs: Any) -> str:
+        """Echo the arguments the tool was called with."""
+        return json.dumps(kwargs, sort_keys=True)
+
+    assert agent_loop.call_tool(echo, json.dumps({"anything": 1})) == json.dumps({"anything": 1})


### PR DESCRIPTION
## Description
`test_agent_loop_sequential_tool_calls[together]` flakes when the model emits extra tool-call arguments (e.g. `result` on zero-arg `get_current_date()`). The harness did `tool_fn(**args)` and raised `TypeError`.

This adds a small `call_tool()` helper that drops undeclared kwargs (keeps them when the tool accepts `**kwargs`) and routes both sequential and parallel agent-loop tests through it. Library behavior is unchanged.

A unit test replays the Together failure sequence against the real integration test and fails on current main with the issue's exact TypeError.

Does not address the separate Together `400 Input validation error` mode from the same issue.

## PR Type
- 🐛 Bug Fix
- 🚦 Infrastructure

## Relevant issues
Fixes #1170

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus
- AI Developer Tool used: Cursor
- Any other info you'd like to share: Tests were run locally (`pytest tests/unit/test_agent_loop_tool_calls.py` → 7 passed; `pytest tests/unit -n auto` → 2162 passed).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent-loop tool calls to safely handle missing, malformed, or unexpected arguments.
  * Undeclared arguments are ignored, while valid declared arguments continue to be passed through correctly.
  * Supports tools that accept arbitrary keyword arguments.

* **Tests**
  * Added comprehensive coverage for sequential and parallel tool execution, including invalid argument formats and zero-parameter tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->