### PR TITLE
fix(bedrock,sagemaker): keep temperature=0 and top_p=0

### DIFF
--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -171,9 +171,9 @@ def _convert_params(params: CompletionParams, kwargs: dict[str, Any]) -> dict[st
     inference_config: dict[str, Any] = {}
     if params.max_tokens:
         inference_config["maxTokens"] = params.max_tokens
-    if params.temperature:
+    if params.temperature is not None:
         inference_config["temperature"] = params.temperature
-    if params.top_p:
+    if params.top_p is not None:
         inference_config["topP"] = params.top_p
     if params.stop:
         inference_config["stopSequences"] = params.stop

--- a/src/any_llm/providers/sagemaker/utils.py
+++ b/src/any_llm/providers/sagemaker/utils.py
@@ -51,9 +51,9 @@ def _convert_params(params: CompletionParams, kwargs: dict[str, Any]) -> dict[st
 
     if params.max_tokens:
         result_kwargs["max_tokens"] = params.max_tokens
-    if params.temperature:
+    if params.temperature is not None:
         result_kwargs["temperature"] = params.temperature
-    if params.top_p:
+    if params.top_p is not None:
         result_kwargs["top_p"] = params.top_p
     if params.stop:
         result_kwargs["stop"] = params.stop

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -1378,6 +1378,36 @@ def test_convert_params_rejects_reserved_tool_name_without_response_format() -> 
         )
 
 
+def test_convert_params_forwards_zero_temperature() -> None:
+    """temperature=0.0 asks for greedy decoding and must not be dropped as a falsy value."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}], temperature=0.0),
+        {},
+    )
+
+    assert result["inferenceConfig"] == {"temperature": 0.0}
+
+
+def test_convert_params_forwards_zero_top_p() -> None:
+    """top_p=0.0 is inside the documented range, so it must reach inferenceConfig."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}], top_p=0.0),
+        {},
+    )
+
+    assert result["inferenceConfig"] == {"topP": 0.0}
+
+
+def test_convert_params_omits_unset_sampling_params() -> None:
+    """Params the caller never set stay absent so the model applies its own defaults."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}]),
+        {},
+    )
+
+    assert "inferenceConfig" not in result
+
+
 def test_convert_response_structured_output_tool_call_becomes_content() -> None:
     """The synthetic structured-output tool call is unwrapped back into message.content."""
     response: dict[str, Any] = {

--- a/tests/unit/providers/test_sagemaker_provider.py
+++ b/tests/unit/providers/test_sagemaker_provider.py
@@ -1,6 +1,39 @@
 from any_llm.providers.sagemaker.sagemaker import SagemakerProvider
+from any_llm.providers.sagemaker.utils import _convert_params
+from any_llm.types.completion import CompletionParams
 
 
 def test_per_request_timeout_is_declared_unsupported() -> None:
     """SageMaker serializes completion kwargs into the request body, so the base class rejects a timeout."""
     assert SagemakerProvider.TIMEOUT_SUPPORT == "unsupported"
+
+
+def test_convert_params_forwards_zero_temperature() -> None:
+    """temperature=0.0 asks for greedy decoding and must not be dropped as a falsy value."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}], temperature=0.0),
+        {},
+    )
+
+    assert result["temperature"] == 0.0
+
+
+def test_convert_params_forwards_zero_top_p() -> None:
+    """top_p=0.0 is inside the documented range, so it must reach the request body."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}], top_p=0.0),
+        {},
+    )
+
+    assert result["top_p"] == 0.0
+
+
+def test_convert_params_omits_unset_sampling_params() -> None:
+    """Params the caller never set stay absent so the model applies its own defaults."""
+    result = _convert_params(
+        CompletionParams(model_id="model-id", messages=[{"role": "user", "content": "hi"}]),
+        {},
+    )
+
+    assert "temperature" not in result
+    assert "top_p" not in result


### PR DESCRIPTION
## Description
Bedrock and SageMaker `_convert_params` gated `temperature` and `top_p` on truthiness, so `0.0` was dropped and the request used the model default (e.g. Claude 1.0 on Bedrock) instead of greedy decoding. Other providers already use `is not None`.

`max_tokens` and `stop` stay on truthiness: `0` and empty sequences are rejected by both providers.

## PR Type
- Bug Fix

## Relevant issues
No open issue. Distinct from #1292 (Anthropic tool_choice) and our #1296/#1297/#1298.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)

`uv run pytest tests/unit` → 2161 passed, 69 skipped. Target files fail on current main (`KeyError: inferenceConfig` / missing keys) and pass after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS Bedrock and SageMaker integrations now correctly honour explicitly configured zero values for temperature and top-p sampling parameters.
  * Unset sampling parameters continue to be omitted from requests.

* **Tests**
  * Added coverage confirming zero-valued parameters are forwarded and unset values are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->