### PR TITLE
fix(gemini): map tool_choice none and named-function form

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -175,8 +175,8 @@ class GoogleProvider(AnyLLM):
             kwargs["temperature"] = params.temperature
         if params.tools is not None:
             kwargs["tools"] = _convert_tool_spec(params.tools)
-        if isinstance(params.tool_choice, str):
-            kwargs["tool_config"] = _convert_tool_choice(params.tool_choice)
+        if params.tool_choice is not None:
+            kwargs["tool_config"] = _convert_tool_choice(params.tool_choice, provider_name)
         if params.top_p is not None:
             kwargs["top_p"] = params.top_p
         if params.stop is not None:

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -125,7 +125,7 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
     if isinstance(tool_choice, dict):
         function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
         name = function.get("name") if isinstance(function, dict) else None
-        if not name:
+        if not isinstance(name, str) or not name:
             raise UnsupportedParameterError(error_message, provider_name, additional_message)
         return types.ToolConfig(
             function_calling_config=types.FunctionCallingConfig(

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -123,14 +123,22 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
     additional_message = f"Unsupported tool_choice: {tool_choice}"
 
     if isinstance(tool_choice, dict):
-        function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
-        name = function.get("name") if isinstance(function, dict) else None
-        if not isinstance(name, str) or not name:
+        if tool_choice.get("type") == "allowed_tools":
+            allowed = tool_choice.get("allowed_tools")
+            # Gemini only honors allowed_function_names in ANY mode, so mode="auto" has no equivalent.
+            if not isinstance(allowed, dict) or allowed.get("mode") != "required":
+                raise UnsupportedParameterError(error_message, provider_name, additional_message)
+            functions = [tool.get("function") for tool in allowed.get("tools", []) if isinstance(tool, dict)]
+        else:
+            functions = [tool_choice.get("function")] if tool_choice.get("type") == "function" else []
+        raw_names = [function.get("name") if isinstance(function, dict) else None for function in functions]
+        names = [name for name in raw_names if isinstance(name, str) and name]
+        if not names or len(names) != len(raw_names):
             raise UnsupportedParameterError(error_message, provider_name, additional_message)
         return types.ToolConfig(
             function_calling_config=types.FunctionCallingConfig(
                 mode=types.FunctionCallingConfigMode.ANY,
-                allowed_function_names=[name],
+                allowed_function_names=names,
             )
         )
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -128,7 +128,12 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
             # Gemini only honors allowed_function_names in ANY mode, so mode="auto" has no equivalent.
             if not isinstance(allowed, dict) or allowed.get("mode") != "required":
                 raise UnsupportedParameterError(error_message, provider_name, additional_message)
-            functions = [tool.get("function") for tool in allowed.get("tools", []) if isinstance(tool, dict)]
+            allowed_tools = allowed.get("tools")
+            if not isinstance(allowed_tools, list):
+                raise UnsupportedParameterError(error_message, provider_name, additional_message)
+            # Every entry is kept so that an unusable one fails the name check below rather than
+            # being dropped, which would silently narrow the set of tools the caller asked for.
+            functions = [tool.get("function") if isinstance(tool, dict) else None for tool in allowed_tools]
         else:
             functions = [tool_choice.get("function")] if tool_choice.get("type") == "function" else []
         raw_names = [function.get("name") if isinstance(function, dict) else None for function in functions]

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, cast
 from google.genai import types
 from google.genai.pagers import Pager
 
-from any_llm.exceptions import InvalidRequestError
+from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
 from any_llm.logging import logger
 from any_llm.types.batch import Batch, BatchRequestCounts, BatchResult, BatchResultError, BatchResultItem
 from any_llm.types.completion import (
@@ -118,13 +118,32 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
     return converted_tools
 
 
-def _convert_tool_choice(tool_choice: str) -> types.ToolConfig:
+def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) -> types.ToolConfig:
+    error_message = "tool_choice"
+    additional_message = f"Unsupported tool_choice: {tool_choice}"
+
+    if isinstance(tool_choice, dict):
+        function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
+        name = function.get("name") if isinstance(function, dict) else None
+        if not name:
+            raise UnsupportedParameterError(error_message, provider_name, additional_message)
+        return types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode=types.FunctionCallingConfigMode.ANY,
+                allowed_function_names=[name],
+            )
+        )
+
     tool_choice_to_mode = {
         "required": types.FunctionCallingConfigMode.ANY,
         "auto": types.FunctionCallingConfigMode.AUTO,
+        "none": types.FunctionCallingConfigMode.NONE,
     }
+    mode = tool_choice_to_mode.get(tool_choice)
+    if mode is None:
+        raise UnsupportedParameterError(error_message, provider_name, additional_message)
 
-    return types.ToolConfig(function_calling_config=types.FunctionCallingConfig(mode=tool_choice_to_mode[tool_choice]))
+    return types.ToolConfig(function_calling_config=types.FunctionCallingConfig(mode=mode))
 
 
 def _parse_data_uri(data_uri: str, field_name: str, provider_name: str) -> tuple[str, bytes]:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -285,6 +285,62 @@ async def test_completion_with_tool_choice_auto(tool_choice: str, expected_mode:
 
 
 @pytest.mark.asyncio
+async def test_completion_with_tool_choice_none_disables_function_calling() -> None:
+    """tool_choice='none' must map to Gemini's NONE mode instead of raising."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(model_id="gemini-pro", messages=messages, tool_choice="none"),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        generation_config = call_kwargs["config"]
+
+        assert generation_config.tool_config.function_calling_config.mode.value == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_completion_with_named_function_tool_choice() -> None:
+    """The OpenAI named-function tool_choice must force that function via allowed_function_names."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="gemini-pro",
+                messages=messages,
+                tool_choice={"type": "function", "function": {"name": "get_weather"}},
+            ),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        function_calling_config = call_kwargs["config"].tool_config.function_calling_config
+
+        assert function_calling_config.mode.value == "ANY"
+        assert function_calling_config.allowed_function_names == ["get_weather"]
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    ["sometimes", {"type": "custom", "custom": {"name": "get_weather"}}, {"type": "function"}],
+)
+@pytest.mark.asyncio
+async def test_completion_with_unsupported_tool_choice_raises(tool_choice: str | dict[str, Any]) -> None:
+    """Unrecognized tool_choice values report the offending value rather than leaking a KeyError."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider():
+        provider = GeminiProvider(api_key="test-api-key")
+        with pytest.raises(UnsupportedParameterError, match="tool_choice"):
+            await provider._acompletion(
+                CompletionParams(model_id="gemini-pro", messages=messages, tool_choice=tool_choice),
+            )
+
+
+@pytest.mark.asyncio
 async def test_completion_without_tool_choice() -> None:
     """Test that completion works correctly without tool_choice."""
     api_key = "test-api-key"

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -367,6 +367,16 @@ async def test_completion_with_allowed_tools_tool_choice() -> None:
             "allowed_tools": {"mode": "auto", "tools": [{"type": "function", "function": {"name": "get_weather"}}]},
         },
         {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": []}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required"}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": None}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": 1}},
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "required",
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}, "get_time"],
+            },
+        },
         {
             "type": "allowed_tools",
             "allowed_tools": {

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -323,6 +323,37 @@ async def test_completion_with_named_function_tool_choice() -> None:
         assert function_calling_config.allowed_function_names == ["get_weather"]
 
 
+@pytest.mark.asyncio
+async def test_completion_with_allowed_tools_tool_choice() -> None:
+    """A required allowed_tools choice must forward every listed name in ANY mode."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="gemini-pro",
+                messages=messages,
+                tool_choice={
+                    "type": "allowed_tools",
+                    "allowed_tools": {
+                        "mode": "required",
+                        "tools": [
+                            {"type": "function", "function": {"name": "get_weather"}},
+                            {"type": "function", "function": {"name": "get_time"}},
+                        ],
+                    },
+                },
+            ),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        function_calling_config = call_kwargs["config"].tool_config.function_calling_config
+
+        assert function_calling_config.mode.value == "ANY"
+        assert function_calling_config.allowed_function_names == ["get_weather", "get_time"]
+
+
 @pytest.mark.parametrize(
     "tool_choice",
     [
@@ -330,6 +361,26 @@ async def test_completion_with_named_function_tool_choice() -> None:
         {"type": "custom", "custom": {"name": "get_weather"}},
         {"type": "function"},
         {"type": "function", "function": {"name": 1}},
+        # Gemini honors allowed_function_names only in ANY mode, so "auto" cannot be expressed.
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {"mode": "auto", "tools": [{"type": "function", "function": {"name": "get_weather"}}]},
+        },
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": []}},
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "required",
+                "tools": [
+                    {"type": "function", "function": {"name": "get_weather"}},
+                    {"type": "function", "function": {"name": ""}},
+                ],
+            },
+        },
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {"mode": "required", "tools": [{"type": "function", "function": {"name": 1}}]},
+        },
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -325,7 +325,12 @@ async def test_completion_with_named_function_tool_choice() -> None:
 
 @pytest.mark.parametrize(
     "tool_choice",
-    ["sometimes", {"type": "custom", "custom": {"name": "get_weather"}}, {"type": "function"}],
+    [
+        "sometimes",
+        {"type": "custom", "custom": {"name": "get_weather"}},
+        {"type": "function"},
+        {"type": "function", "function": {"name": 1}},
+    ],
 )
 @pytest.mark.asyncio
 async def test_completion_with_unsupported_tool_choice_raises(tool_choice: str | dict[str, Any]) -> None:


### PR DESCRIPTION
## Description
Gemini `_convert_tool_choice` only knew `auto` and `required`. `"none"` raised `KeyError`, and the OpenAI named-function dict was ignored because the call site only accepted strings, so Gemini defaulted to AUTO.

`"none"` now maps to `FunctionCallingConfigMode.NONE`. The named-function dict maps to `mode=ANY` with `allowed_function_names`. Unrecognized values raise `UnsupportedParameterError`. VertexAI inherits the same conversion.

any-llm already emits both values from Anthropic `messages()` via `_convert_tool_choice_to_openai`.

## PR Type
- Bug Fix

## Relevant issues
No open issue. Distinct from #1291/#1294/#1296.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)

`uv run pytest tests/unit -q -n auto` → 2160 passed, 69 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Gemini tool-selection modes, including automatic, required, disabled, and specific-function selections.
  - Added support for selecting required tools from an allowed-tools list.

- **Bug Fixes**
  - Unsupported or malformed tool-selection values now produce clear, provider-specific errors.

- **Tests**
  - Added coverage for disabled tools, named-function selection, allowed-tool selections, and invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->