### PR TITLE
fix(cohere): map API finish_reason instead of hardcoding stop

### DIFF
--- a/src/any_llm/providers/cohere/utils.py
+++ b/src/any_llm/providers/cohere/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Literal
 
 from cohere import V2ChatResponse
 from cohere.types import ListModelsResponse as CohereListModelsResponse
@@ -19,6 +19,24 @@ from any_llm.types.completion import (
 )
 from any_llm.types.model import Model
 from any_llm.types.rerank import RerankMeta, RerankResponse, RerankResult, RerankUsage
+
+_FinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
+
+# Cohere reports its own finish reasons (COMPLETE, STOP_SEQUENCE, MAX_TOKENS, TOOL_CALL, ERROR,
+# TIMEOUT). ERROR and TIMEOUT have no OpenAI equivalent, so they fall back to "stop" along with
+# any reason a future SDK release adds.
+_COHERE_FINISH_REASON_MAP: dict[str, _FinishReason] = {
+    "COMPLETE": "stop",
+    "STOP_SEQUENCE": "stop",
+    "MAX_TOKENS": "length",
+    "TOOL_CALL": "tool_calls",
+}
+
+
+def _map_cohere_finish_reason(finish_reason: Any) -> _FinishReason:
+    if not isinstance(finish_reason, str):
+        return "stop"
+    return _COHERE_FINISH_REASON_MAP.get(finish_reason, "stop")
 
 
 def _patch_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -126,22 +144,22 @@ def _create_openai_chunk_from_cohere_chunk(chunk: Any) -> ChatCompletionChunk:
         finish_reason = "tool_calls"
 
     elif chunk_type == "message-end":
-        finish_reason = "stop"
+        chunk_delta = getattr(chunk, "delta", None)
+        finish_reason = _map_cohere_finish_reason(getattr(chunk_delta, "finish_reason", None))
 
         if (
-            hasattr(chunk, "delta")
-            and chunk.delta
-            and hasattr(chunk.delta, "usage")
-            and chunk.delta.usage
-            and hasattr(chunk.delta.usage, "tokens")
-            and chunk.delta.usage.tokens
+            chunk_delta
+            and hasattr(chunk_delta, "usage")
+            and chunk_delta.usage
+            and hasattr(chunk_delta.usage, "tokens")
+            and chunk_delta.usage.tokens
         ):
             chunk_dict["usage"] = {
-                "prompt_tokens": int(getattr(chunk.delta.usage.tokens, "input_tokens", 0) or 0),
-                "completion_tokens": int(getattr(chunk.delta.usage.tokens, "output_tokens", 0) or 0),
+                "prompt_tokens": int(getattr(chunk_delta.usage.tokens, "input_tokens", 0) or 0),
+                "completion_tokens": int(getattr(chunk_delta.usage.tokens, "output_tokens", 0) or 0),
                 "total_tokens": int(
-                    (getattr(chunk.delta.usage.tokens, "input_tokens", 0) or 0)
-                    + (getattr(chunk.delta.usage.tokens, "output_tokens", 0) or 0)
+                    (getattr(chunk_delta.usage.tokens, "input_tokens", 0) or 0)
+                    + (getattr(chunk_delta.usage.tokens, "output_tokens", 0) or 0)
                 ),
             }
 
@@ -209,9 +227,14 @@ def _convert_response(response: V2ChatResponse, model: str) -> ChatCompletion:
                     reasoning_content = Reasoning(content=item.thinking)
 
     message = ChatCompletionMessage(role="assistant", content=content, tool_calls=None, reasoning=reasoning_content)
+    finish_reason = _map_cohere_finish_reason(response.finish_reason)
+    if finish_reason == "tool_calls":
+        # Reaching this branch means Cohere reported TOOL_CALL without any usable tool calls;
+        # reporting them anyway would break consumers that key off finish_reason.
+        finish_reason = "stop"
     choice = Choice(
         index=0,
-        finish_reason="stop",
+        finish_reason=finish_reason,
         message=message,
     )
     return ChatCompletion(

--- a/tests/unit/providers/test_cohere_provider.py
+++ b/tests/unit/providers/test_cohere_provider.py
@@ -364,6 +364,104 @@ def test_streaming_tool_call_delta_uses_chunk_index() -> None:
     assert tool_calls[0].function.arguments == '{"partial'  # type: ignore[union-attr]
 
 
+def _mock_v2chat_text_response(finish_reason: Any, text: str = "Hello there") -> Mock:
+    """Create a mock V2ChatResponse carrying a plain text turn."""
+    response = Mock()
+    response.finish_reason = finish_reason
+    response.id = "resp-456"
+    response.created = 0
+    response.message = Mock()
+    response.message.tool_calls = None
+    response.message.tool_plan = None
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = text
+    response.message.content = [text_block]
+    response.usage = Mock()
+    response.usage.tokens = Mock()
+    response.usage.tokens.input_tokens = 10
+    response.usage.tokens.output_tokens = 20
+    return response
+
+
+def test_convert_response_maps_max_tokens_to_length() -> None:
+    """A truncated Cohere turn must be reported as `length`, not `stop`."""
+    result = _convert_response(_mock_v2chat_text_response("MAX_TOKENS"), model="command-a-03-2025")
+
+    assert result.choices[0].finish_reason == "length"
+
+
+@pytest.mark.parametrize("cohere_finish_reason", ["COMPLETE", "STOP_SEQUENCE"])
+def test_convert_response_maps_natural_endings_to_stop(cohere_finish_reason: str) -> None:
+    result = _convert_response(_mock_v2chat_text_response(cohere_finish_reason), model="command-a-03-2025")
+
+    assert result.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.parametrize("cohere_finish_reason", ["ERROR", "TIMEOUT", "SOMETHING_NEW", None])
+def test_convert_response_maps_unmappable_finish_reasons_to_stop(cohere_finish_reason: str | None) -> None:
+    """Cohere reasons without an OpenAI equivalent fall back to `stop` rather than failing validation."""
+    result = _convert_response(_mock_v2chat_text_response(cohere_finish_reason), model="command-a-03-2025")
+
+    assert result.choices[0].finish_reason == "stop"
+
+
+def test_convert_response_tool_call_without_tool_calls_reports_stop() -> None:
+    """Claiming `tool_calls` on a message that carries none would break tool-calling consumers."""
+    result = _convert_response(_mock_v2chat_text_response("TOOL_CALL"), model="command-a-03-2025")
+
+    assert result.choices[0].message.tool_calls is None
+    assert result.choices[0].finish_reason == "stop"
+
+
+def _mock_message_end_chunk(finish_reason: Any) -> Mock:
+    chunk = Mock()
+    chunk.type = "message-end"
+    chunk.delta = Mock()
+    chunk.delta.finish_reason = finish_reason
+    chunk.delta.usage = None
+    return chunk
+
+
+def test_streaming_message_end_maps_max_tokens_to_length() -> None:
+    """Streaming: the terminal chunk must surface truncation instead of a plain stop."""
+    result = _create_openai_chunk_from_cohere_chunk(_mock_message_end_chunk("MAX_TOKENS"))
+
+    assert result.choices[0].finish_reason == "length"
+
+
+def test_streaming_message_end_maps_tool_call_to_tool_calls() -> None:
+    result = _create_openai_chunk_from_cohere_chunk(_mock_message_end_chunk("TOOL_CALL"))
+
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_streaming_message_end_without_delta_falls_back_to_stop() -> None:
+    chunk = Mock()
+    chunk.type = "message-end"
+    chunk.delta = None
+
+    result = _create_openai_chunk_from_cohere_chunk(chunk)
+
+    assert result.choices[0].finish_reason == "stop"
+
+
+def test_streaming_message_end_still_reports_usage() -> None:
+    chunk = _mock_message_end_chunk("COMPLETE")
+    chunk.delta.usage = Mock()
+    chunk.delta.usage.tokens = Mock()
+    chunk.delta.usage.tokens.input_tokens = 12
+    chunk.delta.usage.tokens.output_tokens = 8
+
+    result = _create_openai_chunk_from_cohere_chunk(chunk)
+
+    assert result.choices[0].finish_reason == "stop"
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 12
+    assert result.usage.completion_tokens == 8
+    assert result.usage.total_tokens == 20
+
+
 def test_streaming_tool_call_index_defaults_to_zero_when_none() -> None:
     """Streaming: falls back to index 0 when chunk.index is None."""
     chunk = Mock()


### PR DESCRIPTION
## Description
The Cohere provider ignored the API `finish_reason` and hardcoded `"stop"`. A response truncated by `max_tokens` looked identical to a normal completion.

`MAX_TOKENS` now maps to `"length"`, `TOOL_CALL` to `"tool_calls"`, `COMPLETE`/`STOP_SEQUENCE` to `"stop"`. `ERROR`/`TIMEOUT` and unknown values fall back to `"stop"`. If Cohere reports `TOOL_CALL` with no usable tool calls, the non-streaming text path stays `"stop"` so consumers are not given `finish_reason="tool_calls"` next to `tool_calls=None`.

## PR Type
- Bug Fix

## Relevant issues
No open issue. Distinct from #1296–#1300.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)

`uv run pytest tests/unit/providers/test_cohere_provider.py` → 57 passed.
`uv run pytest tests/unit` → 2167 passed, 69 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cohere response handling by consistently translating completion reasons into compatible values.
  - Added safer fallbacks for missing, unsupported, or malformed completion reasons.
  - Corrected tool-call completion handling when no tool calls are present.
  - Improved usage reporting for streamed responses.

- **Tests**
  - Added coverage for streamed and non-streamed completion reasons, tool calls, missing data, fallbacks, and usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->