### PR TITLE
fix(anthropic): skip redacted_thinking instead of crashing

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -340,9 +340,15 @@ def _convert_response(response: Message) -> ChatCompletion:
             # continuity. See https://docs.claude.com/en/docs/build-with-claude/extended-thinking
             if content_block.signature:
                 thinking_signature = content_block.signature
+        elif content_block.type == "redacted_thinking":
+            # Anthropic encrypts thinking that its safety systems flag, so the block carries
+            # no readable text to surface. The rest of the turn is a normal response.
+            logger.debug("Skipping redacted_thinking block with no readable content.")
         else:
-            msg = f"Unsupported content block type: {content_block.type}"
-            raise ValueError(msg)
+            # Server-side tool blocks (web search, code execution, ...) have no Chat
+            # Completions equivalent. Dropping them keeps the answer the model did return,
+            # which is what the streaming converter already does for the same block types.
+            logger.warning("Skipping unsupported Anthropic content block type: %s", content_block.type)
 
     message = ChatCompletionMessage(
         role="assistant",

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1,4 +1,5 @@
 import dataclasses
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime
@@ -1138,6 +1139,107 @@ def test_non_streaming_response_empty_thinking_signature_has_no_extra_content() 
     result = _convert_response(response)
 
     assert result.choices[0].message.extra_content is None
+
+
+def test_non_streaming_response_keeps_text_alongside_redacted_thinking() -> None:
+    """Anthropic encrypts thinking its safety systems flag, and the block has no readable text.
+
+    The response still carries the answer, so the conversion must skip the redacted block
+    rather than failing the whole completion.
+    """
+    from anthropic.types import Message, RedactedThinkingBlock, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason="end_turn",
+        content=[
+            RedactedThinkingBlock(type="redacted_thinking", data="EroBCkYIBBgCKkA"),
+            TextBlock(type="text", text="Here is the answer."),
+        ],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].message.content == "Here is the answer."
+    assert result.choices[0].message.reasoning is None
+    assert result.choices[0].message.extra_content is None
+
+
+def test_non_streaming_response_keeps_visible_thinking_next_to_redacted_thinking() -> None:
+    """A partially redacted turn keeps the readable thinking and its replayable signature."""
+    from anthropic.types import Message, RedactedThinkingBlock, TextBlock, ThinkingBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason="end_turn",
+        content=[
+            ThinkingBlock(type="thinking", thinking="Let me reason...", signature="sig-12345"),
+            RedactedThinkingBlock(type="redacted_thinking", data="EroBCkYIBBgCKkA"),
+            TextBlock(type="text", text="Here is the answer."),
+        ],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].message.content == "Here is the answer."
+    assert result.choices[0].message.reasoning is not None
+    assert result.choices[0].message.reasoning.content == "Let me reason..."
+    assert result.choices[0].message.extra_content == {"anthropic": {"signature": "sig-12345"}}
+
+
+def test_non_streaming_response_skips_server_tool_blocks(caplog: pytest.LogCaptureFixture) -> None:
+    """Anthropic's server-side tools add blocks with no Chat Completions equivalent.
+
+    They are reported instead of raised, matching how the streaming converter already
+    ignores block types it does not map.
+    """
+    from anthropic.types import (
+        Message,
+        ServerToolUseBlock,
+        TextBlock,
+        Usage,
+        WebSearchToolResultBlock,
+        WebSearchToolResultError,
+    )
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason="end_turn",
+        content=[
+            ServerToolUseBlock(type="server_tool_use", id="srvtoolu_1", name="web_search", input={"query": "any-llm"}),
+            WebSearchToolResultBlock(
+                type="web_search_tool_result",
+                tool_use_id="srvtoolu_1",
+                content=WebSearchToolResultError(type="web_search_tool_result_error", error_code="max_uses_exceeded"),
+            ),
+            TextBlock(type="text", text="Here is the answer."),
+        ],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="any_llm"):
+        result = _convert_response(response)
+
+    assert result.choices[0].message.content == "Here is the answer."
+    assert "server_tool_use" in caplog.text
+    assert "web_search_tool_result" in caplog.text
 
 
 def test_convert_messages_replays_thinking_block_with_tool_call() -> None:


### PR DESCRIPTION
## Description
Non-streaming _convert_response mapped only text, tool_use, and thinking, then raised ValueError on anything else. Anthropic returns redacted_thinking when safety flags part of an extended-thinking trace, so completion() crashed even though the rest of the answer was fine. The streaming converter already ignores unmapped block types.

Skip redacted_thinking quietly; warn and skip other unmapped types. Shared by anthropic, azureanthropic, vertexaianthropic, and meta. Tests: uv run pytest tests/unit -> 2158 passed.

Distinct from #1292 and #1296-#1302.

## PR Type
- Bug Fix

## Relevant issues
No open issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)
