### PR TITLE
fix: route streamed tool-call args by tool_calls index

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -29,7 +29,6 @@ from any_llm.types.completion import (
 )
 from any_llm.types.image import ImageGenerationParams, ImagesResponse
 from any_llm.types.messages import (
-    ContentBlockStopEvent,
     MessageDelta,
     MessageDeltaEvent,
     MessageDeltaUsage,
@@ -1030,6 +1029,7 @@ class AnyLLM(ABC):
             StreamingState,
             chat_completion_chunk_to_message_stream_events,
             chat_completion_to_message_response,
+            close_open_blocks,
             messages_params_to_completion_params,
             split_cached_input_tokens,
         )
@@ -1069,11 +1069,8 @@ class AnyLLM(ABC):
                 raise
             # Emit the closing events after the full stream is consumed so trailing-chunk usage is included.
             if state.started:
-                if state.current_block_type is not None:
-                    yield ContentBlockStopEvent(
-                        type="content_block_stop",
-                        index=state.current_block_index,
-                    )
+                for stop_event in close_open_blocks(state):
+                    yield stop_event
                 yield usage_delta(state.stop_reason or "end_turn")
                 yield MessageStopEvent(type="message_stop")
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -376,6 +376,8 @@ class StreamingState:
         self.stop_reason: StopReason | None = None
         self.tool_call_id: str | None = None
         self.tool_call_name: str | None = None
+        self.tool_block_indexes: dict[int, int] = {}
+        """Content block index of each open tool_use block, keyed by OpenAI ``tool_calls[].index``."""
 
 
 def chat_completion_chunk_to_message_stream_events(
@@ -467,12 +469,17 @@ def chat_completion_chunk_to_message_stream_events(
 
     if delta.tool_calls:
         for tc in delta.tool_calls:
-            if tc.id:
-                _close_current_block(state, events)
+            # An id repeated on later fragments of the same tool call must not open a second block.
+            if tc.id and tc.index not in state.tool_block_indexes:
+                # Parallel tool calls share one tool_use section: only a text or thinking block
+                # is closed here, so a block stays open for every call still receiving arguments.
+                if state.current_block_type != "tool_use":
+                    _close_current_block(state, events)
                 state.current_block_index += 1
                 state.current_block_type = "tool_use"
                 state.tool_call_id = tc.id
                 state.tool_call_name = tc.function.name if tc.function else ""
+                state.tool_block_indexes[tc.index] = state.current_block_index
                 events.append(
                     ContentBlockStartEvent(
                         type="content_block_start",
@@ -486,10 +493,12 @@ def chat_completion_chunk_to_message_stream_events(
                     )
                 )
             if tc.function and tc.function.arguments:
+                # Providers may interleave the fragments of parallel calls, so the destination
+                # block comes from the tool call's own index rather than from the newest block.
                 events.append(
                     ContentBlockDeltaEvent(
                         type="content_block_delta",
-                        index=state.current_block_index,
+                        index=state.tool_block_indexes.get(tc.index, state.current_block_index),
                         delta=InputJSONDelta(type="input_json_delta", partial_json=tc.function.arguments),
                     )
                 )
@@ -501,16 +510,23 @@ def chat_completion_chunk_to_message_stream_events(
     return events
 
 
+def close_open_blocks(state: StreamingState) -> list[ContentBlockStopEvent]:
+    """Build a content_block_stop event for every block still open, in block order.
+
+    A tool_use section can hold more than one open block, because each parallel tool call gets
+    its own block and stays open until the section ends.
+    """
+    if state.current_block_type is None:
+        return []
+    open_indexes = sorted(state.tool_block_indexes.values()) or [state.current_block_index]
+    state.tool_block_indexes.clear()
+    state.current_block_type = None
+    return [ContentBlockStopEvent(type="content_block_stop", index=index) for index in open_indexes]
+
+
 def _close_current_block(
     state: StreamingState,
     events: list[MessageStartEvent | ContentBlockStartEvent | ContentBlockDeltaEvent | ContentBlockStopEvent],
 ) -> None:
-    """Emit a content_block_stop event for the current block if one is open."""
-    if state.current_block_type is not None:
-        events.append(
-            ContentBlockStopEvent(
-                type="content_block_stop",
-                index=state.current_block_index,
-            )
-        )
-        state.current_block_type = None
+    """Emit content_block_stop events for any open blocks."""
+    events.extend(close_open_blocks(state))

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -10,19 +10,31 @@ from any_llm.types.completion import (
     ChatCompletionMessageFunctionToolCall,
     Choice,
     ChoiceDelta,
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
     ChunkChoice,
     CompletionUsage,
     Function,
     PromptTokensDetails,
     Reasoning,
 )
-from any_llm.types.messages import MessagesParams, MessageStartEvent, ThinkingBlock
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    InputJSONDelta,
+    MessagesParams,
+    MessageStartEvent,
+    ThinkingBlock,
+    ToolUseBlock,
+)
 from any_llm.utils.messages_compat import (
     StreamingState,
     _cached_tokens_from_usage,
     _convert_system_to_openai,
     chat_completion_chunk_to_message_stream_events,
     chat_completion_to_message_response,
+    close_open_blocks,
     messages_params_to_completion_params,
     split_cached_input_tokens,
 )
@@ -735,6 +747,137 @@ def test_streaming_tool_call_events() -> None:
     assert isinstance(delta_event, ContentBlockDeltaEvent)
     assert isinstance(delta_event.delta, InputJSONDelta)
     assert delta_event.delta.partial_json == '{"city":"London"}'
+
+
+def _tool_calls_chunk(*tool_calls: ChoiceDeltaToolCall) -> ChatCompletionChunk:
+    """Build a chunk whose only delta content is the given tool-call fragments."""
+    return ChatCompletionChunk(
+        id="chunk",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(tool_calls=list(tool_calls)), finish_reason=None)],
+    )
+
+
+def test_streaming_parallel_tool_calls_route_arguments_by_tool_index() -> None:
+    """Argument fragments follow tool_calls[].index instead of the most recently opened block.
+
+    Providers may announce every parallel tool call before streaming any arguments, so routing
+    every delta to the newest block would file one tool's arguments under another tool's block.
+    """
+    state = StreamingState()
+
+    announce = _tool_calls_chunk(
+        ChoiceDeltaToolCall(
+            index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather", arguments="")
+        ),
+        ChoiceDeltaToolCall(index=1, id="call_b", function=ChoiceDeltaToolCallFunction(name="get_time", arguments="")),
+    )
+    starts = [
+        e for e in chat_completion_chunk_to_message_stream_events(announce, state) if e.type == "content_block_start"
+    ]
+    assert len(starts) == 2
+    for start, expected_index, expected_name in zip(starts, [0, 1], ["get_weather", "get_time"], strict=True):
+        assert isinstance(start, ContentBlockStartEvent)
+        assert start.index == expected_index
+        assert isinstance(start.content_block, ToolUseBlock)
+        assert start.content_block.name == expected_name
+
+    interleaved = [
+        _tool_calls_chunk(ChoiceDeltaToolCall(index=1, function=ChoiceDeltaToolCallFunction(arguments='{"tz":'))),
+        _tool_calls_chunk(
+            ChoiceDeltaToolCall(index=0, function=ChoiceDeltaToolCallFunction(arguments='{"city":"Paris"}'))
+        ),
+        _tool_calls_chunk(ChoiceDeltaToolCall(index=1, function=ChoiceDeltaToolCallFunction(arguments='"UTC"}'))),
+    ]
+    partial_json: dict[int, str] = {}
+    for chunk in interleaved:
+        for event in chat_completion_chunk_to_message_stream_events(chunk, state):
+            assert isinstance(event, ContentBlockDeltaEvent)
+            assert isinstance(event.delta, InputJSONDelta)
+            partial_json[event.index] = partial_json.get(event.index, "") + event.delta.partial_json
+
+    assert json.loads(partial_json[0]) == {"city": "Paris"}
+    assert json.loads(partial_json[1]) == {"tz": "UTC"}
+
+
+def test_streaming_parallel_tool_calls_stop_every_block() -> None:
+    """Both parallel tool_use blocks are closed once the turn finishes."""
+    state = StreamingState()
+    announce = _tool_calls_chunk(
+        ChoiceDeltaToolCall(index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather")),
+        ChoiceDeltaToolCall(index=1, id="call_b", function=ChoiceDeltaToolCallFunction(name="get_time")),
+    )
+    chat_completion_chunk_to_message_stream_events(announce, state)
+
+    finish = ChatCompletionChunk(
+        id="chunk-final",
+        model="gpt-4",
+        created=0,
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="tool_calls")],
+    )
+    events = chat_completion_chunk_to_message_stream_events(finish, state)
+    assert len(events) == 2
+    assert [(e.type, e.index) for e in events if isinstance(e, ContentBlockStopEvent)] == [
+        ("content_block_stop", 0),
+        ("content_block_stop", 1),
+    ]
+    assert state.stop_reason == "tool_use"
+
+
+def test_streaming_tool_call_id_repeated_reuses_the_same_block() -> None:
+    """Providers that resend the id on every fragment must not open a block per fragment."""
+    state = StreamingState()
+    first = _tool_calls_chunk(
+        ChoiceDeltaToolCall(
+            index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather", arguments='{"city":')
+        )
+    )
+    chat_completion_chunk_to_message_stream_events(first, state)
+    second = _tool_calls_chunk(
+        ChoiceDeltaToolCall(
+            index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather", arguments='"Paris"}')
+        )
+    )
+    events = chat_completion_chunk_to_message_stream_events(second, state)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ContentBlockDeltaEvent)
+    assert events[0].index == 0
+    assert state.current_block_index == 0
+
+
+def test_streaming_tool_call_arguments_without_a_known_index_use_the_open_block() -> None:
+    """A fragment for an index that was never announced still lands on the open tool block."""
+    state = StreamingState()
+    announce = _tool_calls_chunk(
+        ChoiceDeltaToolCall(index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather"))
+    )
+    chat_completion_chunk_to_message_stream_events(announce, state)
+
+    orphan = _tool_calls_chunk(ChoiceDeltaToolCall(index=7, function=ChoiceDeltaToolCallFunction(arguments="{}")))
+    events = chat_completion_chunk_to_message_stream_events(orphan, state)
+
+    assert len(events) == 1
+    assert [(e.type, e.index) for e in events if isinstance(e, ContentBlockDeltaEvent)] == [("content_block_delta", 0)]
+
+
+def test_close_open_blocks_closes_every_open_tool_block() -> None:
+    """A stream that ends without a finish_reason still closes all parallel tool blocks."""
+    state = StreamingState()
+    announce = _tool_calls_chunk(
+        ChoiceDeltaToolCall(index=0, id="call_a", function=ChoiceDeltaToolCallFunction(name="get_weather")),
+        ChoiceDeltaToolCall(index=1, id="call_b", function=ChoiceDeltaToolCallFunction(name="get_time")),
+    )
+    chat_completion_chunk_to_message_stream_events(announce, state)
+
+    assert [(e.type, e.index) for e in close_open_blocks(state)] == [
+        ("content_block_stop", 0),
+        ("content_block_stop", 1),
+    ]
+    assert close_open_blocks(state) == []
 
 
 def test_optional_params_not_included_when_none() -> None:


### PR DESCRIPTION
## Description
chat_completion_chunk_to_message_stream_events attached every streamed tool-call argument fragment to state.current_block_index instead of the block for that tool_calls[].index. Parallel interleaved calls mixed arguments (one tool got unparseable JSON, the other got none).

StreamingState now maps each tool_calls index to its content block. tool_use blocks stay open through the tool section and stop together. Repeated ids reuse the same block.

Tests: uv run pytest tests/unit — 2160 passed, 69 skipped. Distinct from #1296-#1304.

## PR Type
- Bug Fix

## Relevant issues
No open issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)
