### PR TITLE
fix: map Anthropic refusal and context-window stop reasons

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -43,6 +43,18 @@ if TYPE_CHECKING:
     )
 
 DEFAULT_MAX_TOKENS = 8192
+# OpenAI has no counterpart for the "stop_sequence" and "pause_turn" stop reasons, so those
+# fall through to the "stop" default. "refusal" (a safety stop) and
+# "model_context_window_exceeded" (the model ran out of context rather than out of max_tokens)
+# do have one, and without it a refused or truncated answer looks like a normal completion.
+# See https://docs.claude.com/en/docs/build-with-claude/handling-stop-reasons
+ANTHROPIC_STOP_REASON_TO_FINISH_REASON = {
+    "end_turn": "stop",
+    "max_tokens": "length",
+    "model_context_window_exceeded": "length",
+    "tool_use": "tool_calls",
+    "refusal": "content_filter",
+}
 REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
     "minimal": "low",
     "low": "low",
@@ -309,8 +321,7 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
 def _convert_response(response: Message) -> ChatCompletion:
     """Convert Anthropic Message to OpenAI ChatCompletion format."""
     finish_reason_raw = response.stop_reason or "end_turn"
-    finish_reason_map = {"end_turn": "stop", "max_tokens": "length", "tool_use": "tool_calls"}
-    finish_reason = finish_reason_map.get(finish_reason_raw, "stop")
+    finish_reason = ANTHROPIC_STOP_REASON_TO_FINISH_REASON.get(finish_reason_raw, "stop")
 
     content_parts: list[str] = []
     tool_calls: list[ChatCompletionMessageFunctionToolCall | ChatCompletionMessageToolCall] = []

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -9,6 +9,7 @@ import pytest
 from anthropic import transform_schema
 from anthropic.types import Message
 from anthropic.types.model_info import ModelInfo
+from anthropic.types.stop_reason import StopReason
 from pydantic import BaseModel
 
 from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
@@ -1071,6 +1072,66 @@ def test_non_streaming_response_preserves_multiple_tool_calls() -> None:
     assert isinstance(result.choices[0].message.tool_calls[1], ChatCompletionMessageFunctionToolCall)
     assert result.choices[0].message.tool_calls[1].function is not None
     assert result.choices[0].message.tool_calls[1].function.name == "get_time"
+
+
+@pytest.mark.parametrize("stop_reason", get_args(StopReason))
+def test_non_streaming_response_maps_every_anthropic_stop_reason(stop_reason: StopReason) -> None:
+    """Every stop reason the API can return needs an explicit OpenAI finish_reason.
+
+    An unmapped one falls back to "stop", which tells callers the model answered normally
+    when it actually refused or ran out of context.
+    """
+    from anthropic.types import Message, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    expected_finish_reasons: dict[str, str] = {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "pause_turn": "stop",
+        "max_tokens": "length",
+        "model_context_window_exceeded": "length",
+        "tool_use": "tool_calls",
+        "refusal": "content_filter",
+    }
+    assert stop_reason in expected_finish_reasons, (
+        f"New Anthropic stop reason {stop_reason!r} needs a finish_reason mapping."
+    )
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason=stop_reason,
+        content=[TextBlock(type="text", text="Hello")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == expected_finish_reasons[stop_reason]
+
+
+def test_non_streaming_response_without_stop_reason_finishes_as_stop() -> None:
+    """A response with no stop_reason at all still needs a valid finish_reason."""
+    from anthropic.types import Message, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason=None,
+        content=[TextBlock(type="text", text="Hello")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == "stop"
 
 
 def test_non_streaming_response_preserves_thinking_signature() -> None:


### PR DESCRIPTION
## Description
_convert_response only mapped end_turn / max_tokens / tool_use. refusal and model_context_window_exceeded fell through to stop, so a safety refusal and a truncated answer both looked like a normal completion.

refusal -> content_filter, model_context_window_exceeded -> length. Test parametrizes over the SDK StopReason union so a new reason cannot silently default.

Tests: uv run pytest tests/unit — 2163 passed, 69 skipped. Distinct from #1296-#1305.

## PR Type
- Bug Fix

## Relevant issues
No open issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the contribution guidelines
- [x] **AI Usage:**
    - [x] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude Opus 5
- AI Developer Tool used: Cursor cloud agent
- [x] I am an AI Agent filling out this form (check box if true)
