### PR TITLE
fix(responses): accept per-request timeout on aresponses

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1270,7 +1270,11 @@ class AnyLLM(ABC):
             prompt_cache_key: A key to use when reading from or writing to the prompt cache.
             prompt_cache_retention: How long to retain a prompt cache entry created by this request.
             conversation: The conversation to associate this response with (ID string or ConversationParam object).
-            timeout: Per-request timeout in seconds, forwarded to the provider's SDK call.
+            timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+                An explicit ``None`` is treated the same as omitting it (the provider's default
+                applies), so it cannot request an unbounded timeout. Providers that have no
+                per-request timeout raise `UnsupportedParameterError`; set a timeout on their
+                client via `client_args` instead.
             extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1222,6 +1222,7 @@ class AnyLLM(ABC):
         prompt_cache_key: str | None = None,
         prompt_cache_retention: str | None = None,
         conversation: str | dict[str, Any] | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
         extra_body: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> ResponseResource | Response | AsyncIterator[ResponseStreamEvent] | ParsedResponse[Any]:
@@ -1269,6 +1270,10 @@ class AnyLLM(ABC):
             prompt_cache_key: A key to use when reading from or writing to the prompt cache.
             prompt_cache_retention: How long to retain a prompt cache entry created by this request.
             conversation: The conversation to associate this response with (ID string or ConversationParam object).
+            timeout: Per-request timeout in seconds, passed through to the provider's client/SDK call.
+                It is a transport option, not request-body JSON. Providers with no per-request
+                timeout raise `UnsupportedParameterError`; set a timeout on their client via
+                client_args instead.
             extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 
@@ -1327,6 +1332,7 @@ class AnyLLM(ABC):
         )
 
         provider_kwargs: dict[str, Any] = {}
+        self._validate_and_forward_timeout(timeout, provider_kwargs)
         if extra_body is not None:
             provider_kwargs["extra_body"] = extra_body
         result = await self._aresponses(params, **provider_kwargs)

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1270,10 +1270,7 @@ class AnyLLM(ABC):
             prompt_cache_key: A key to use when reading from or writing to the prompt cache.
             prompt_cache_retention: How long to retain a prompt cache entry created by this request.
             conversation: The conversation to associate this response with (ID string or ConversationParam object).
-            timeout: Per-request timeout in seconds, passed through to the provider's client/SDK call.
-                It is a transport option, not request-body JSON. Providers with no per-request
-                timeout raise `UnsupportedParameterError`; set a timeout on their client via
-                client_args instead.
+            timeout: Per-request timeout in seconds, forwarded to the provider's SDK call.
             extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
             **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
 

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -300,6 +300,7 @@ def responses(
     prompt_cache_key: str | None = None,
     prompt_cache_retention: str | None = None,
     conversation: str | dict[str, Any] | None = None,
+    timeout: float | None = None,
     extra_body: dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
@@ -354,6 +355,11 @@ def responses(
         prompt_cache_key: A key to use when reading from or writing to the prompt cache.
         prompt_cache_retention: How long to retain a prompt cache entry created by this request.
         conversation: The conversation to associate this response with (ID string or ConversationParam object).
+        timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+            An explicit ``None`` is treated the same as omitting it (the provider's default
+            applies), so it cannot request an unbounded timeout. Providers that have no
+            per-request timeout raise `UnsupportedParameterError`; set a timeout on their
+            client via `client_args` instead.
         extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
@@ -410,6 +416,7 @@ def responses(
         prompt_cache_key=prompt_cache_key,
         prompt_cache_retention=prompt_cache_retention,
         conversation=conversation,
+        timeout=timeout,
         extra_body=extra_body,
         **kwargs,
     )
@@ -449,6 +456,7 @@ async def aresponses(
     prompt_cache_key: str | None = None,
     prompt_cache_retention: str | None = None,
     conversation: str | dict[str, Any] | None = None,
+    timeout: float | None = None,  # noqa: ASYNC109  # forwarded to the provider SDK, which owns the timeout
     extra_body: dict[str, Any] | None = None,
     client_args: dict[str, Any] | None = None,
     **kwargs: Any,
@@ -503,6 +511,11 @@ async def aresponses(
         prompt_cache_key: A key to use when reading from or writing to the prompt cache.
         prompt_cache_retention: How long to retain a prompt cache entry created by this request.
         conversation: The conversation to associate this response with (ID string or ConversationParam object).
+        timeout: Per-request timeout in seconds, passed through to the provider's client/SDK.
+            An explicit ``None`` is treated the same as omitting it (the provider's default
+            applies), so it cannot request an unbounded timeout. Providers that have no
+            per-request timeout raise `UnsupportedParameterError`; set a timeout on their
+            client via `client_args` instead.
         extra_body: Additional fields to merge into an OpenAI-compatible Responses request body.
         client_args: Additional provider-specific arguments that will be passed to the provider's client instantiation.
         **kwargs: Additional provider-specific arguments that will be passed to the provider's API call.
@@ -559,6 +572,7 @@ async def aresponses(
         prompt_cache_key=prompt_cache_key,
         prompt_cache_retention=prompt_cache_retention,
         conversation=conversation,
+        timeout=timeout,
         extra_body=extra_body,
         **kwargs,
     )

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -120,10 +120,6 @@ async def test_tools_flattened_for_responses() -> None:
 @pytest.mark.asyncio
 async def test_timeout_forwarded_to_provider_not_params() -> None:
     """timeout is an SDK request option: it must reach the provider call, never ResponsesParams."""
-    from unittest.mock import AsyncMock, patch
-
-    from any_llm import AnyLLM
-
     llm = AnyLLM.create("openai", api_key="test-key")
     with patch.object(type(llm), "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses:
         await llm.aresponses("gpt-4.1-mini", "hello", timeout=60)

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -115,3 +115,19 @@ async def test_tools_flattened_for_responses() -> None:
     assert tools[1]["parameters"] == {}
     assert tools[1]["strict"] is True
     assert tools[3] == {"type": "web_search"}
+
+
+@pytest.mark.asyncio
+async def test_timeout_forwarded_to_provider_not_params() -> None:
+    """timeout is an SDK request option: it must reach the provider call, never ResponsesParams."""
+    from unittest.mock import AsyncMock, patch
+
+    from any_llm import AnyLLM
+
+    llm = AnyLLM.create("openai", api_key="test-key")
+    with patch.object(type(llm), "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses:
+        await llm.aresponses("gpt-4.1-mini", "hello", timeout=60)
+
+    assert mock_aresponses.call_args.kwargs["timeout"] == 60
+    params = mock_aresponses.call_args.args[0]
+    assert "timeout" not in params.model_dump(exclude_none=True)

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
@@ -5,7 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from any_llm import AnyLLM
-from any_llm.api import aresponses
+from any_llm.api import aresponses, responses
+from any_llm.exceptions import UnsupportedParameterError
 from any_llm.types.responses import ResponsesParams
 
 
@@ -117,13 +119,62 @@ async def test_tools_flattened_for_responses() -> None:
     assert tools[3] == {"type": "web_search"}
 
 
+def test_responses_exposes_timeout_parameter() -> None:
+    """The Responses entry points advertise timeout the same way the completion ones do."""
+    assert "timeout" in signature(responses).parameters
+    assert "timeout" in signature(aresponses).parameters
+    assert "timeout" in signature(AnyLLM.aresponses).parameters
+
+
 @pytest.mark.asyncio
-async def test_timeout_forwarded_to_provider_not_params() -> None:
+@pytest.mark.parametrize(("requested_timeout", "expected"), [(60, 60), (None, None)])
+async def test_timeout_forwarded_to_provider_not_params(
+    requested_timeout: float | None, expected: float | None
+) -> None:
     """timeout is an SDK request option: it must reach the provider call, never ResponsesParams."""
     llm = AnyLLM.create("openai", api_key="test-key")
     with patch.object(type(llm), "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses:
-        await llm.aresponses("gpt-4.1-mini", "hello", timeout=60)
+        await llm.aresponses("gpt-4.1-mini", "hello", timeout=requested_timeout)
 
-    assert mock_aresponses.call_args.kwargs["timeout"] == 60
+    assert mock_aresponses.call_args.kwargs.get("timeout") == expected
     params = mock_aresponses.call_args.args[0]
     assert "timeout" not in params.model_dump(exclude_none=True)
+
+
+@pytest.mark.asyncio
+async def test_aresponses_helper_forwards_timeout_to_provider() -> None:
+    """The public aresponses() helper routes timeout through to the provider call."""
+    provider = AnyLLM.create("openai", api_key="test-key")
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses,
+    ):
+        await aresponses("gpt-4.1-mini", "hello", provider="openai", api_key="test-key", timeout=60)
+
+    assert mock_aresponses.call_args.kwargs["timeout"] == 60
+
+
+def test_responses_helper_forwards_timeout_to_provider_sync() -> None:
+    """The synchronous responses() helper routes timeout through the same path."""
+    provider = AnyLLM.create("openai", api_key="test-key")
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses,
+    ):
+        responses("gpt-4.1-mini", "hello", provider="openai", api_key="test-key", timeout=60)
+
+    assert mock_aresponses.call_args.kwargs["timeout"] == 60
+
+
+@pytest.mark.asyncio
+async def test_aresponses_rejects_timeout_for_unsupported_provider() -> None:
+    """A provider declaring no per-request timeout support is rejected before the request is built."""
+    llm = AnyLLM.create("openai", api_key="test-key")
+    llm.TIMEOUT_SUPPORT = "unsupported"
+    with (
+        patch.object(llm, "_aresponses", new=AsyncMock()) as mock_aresponses,
+        pytest.raises(UnsupportedParameterError, match="timeout"),
+    ):
+        await llm.aresponses("gpt-4.1-mini", "hello", timeout=60)
+
+    mock_aresponses.assert_not_called()


### PR DESCRIPTION
## Description

`aresponses()` has no `timeout` parameter, and `ResponsesParams` is `extra="forbid"`, so a caller-supplied timeout dies in validation before any request is made:

```
ValidationError: 1 validation error for ResponsesParams
timeout
  Extra inputs are not permitted [type=extra_forbidden, input_value=60, input_type=int]
```

mozilla-ai/any-llm#1263 added per-request timeouts and wired them into `acompletion` and `amessages`. `aresponses` was left out, so the Responses path is the one call path with no per-request timeout; a client-wide timeout via `client_args` is the only workaround.

The fix repeats the #1263 pattern on `aresponses`, unchanged:

- `timeout: float | None = None` on the signature, with the same `# noqa: ASYNC109` convention as `acompletion` / `amessages`.
- Routed through `_validate_and_forward_timeout` into the provider kwargs. From there `TIMEOUT_SUPPORT` governs it: `native` providers hand it to their SDK as a request option; `unsupported` providers raise `UnsupportedParameterError`.
- It never enters `ResponsesParams` — per #1263, timeout is a transport option, not request-body JSON.

No provider changes are needed: every `_aresponses` implementation already forwards `**kwargs` into its SDK call.

Verified live against OpenAI `gpt-5.1`:

| call | before | after |
|---|---|---|
| `aresponses(..., timeout=0.001)` | `ValidationError` | `ProviderError: [openai] Request timed out.` |
| `aresponses(..., timeout=60)` | `ValidationError` | completes normally |

The new unit test asserts both halves of the routing: the value reaches the `_aresponses` call kwargs, and never appears in the params model.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Follow-up to mozilla-ai/any-llm#1263.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional timeout settings for synchronous and asynchronous Responses API requests.
  * Timeout values are forwarded to supported providers, helping requests complete within the specified duration.
  * Timeout handling is consistently available across the Responses API and its helper methods.

* **Bug Fixes**
  * Unsupported providers now reject timeout settings clearly before any request is initiated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->