### PR TITLE
fix(gemini): convert native tool dicts instead of silently dropping them

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -164,7 +164,7 @@ class GoogleProvider(AnyLLM):
         if params.temperature is not None:
             kwargs["temperature"] = params.temperature
         if params.tools is not None:
-            kwargs["tools"] = _convert_tool_spec(params.tools)
+            kwargs["tools"] = _convert_tool_spec(params.tools, provider_name)
         if isinstance(params.tool_choice, str):
             kwargs["tool_config"] = _convert_tool_choice(params.tool_choice)
         if params.top_p is not None:

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, cast
 
 from google.genai import types
 from google.genai.pagers import Pager
+from pydantic import ValidationError
 
 from any_llm.exceptions import InvalidRequestError
 from any_llm.logging import logger
@@ -62,7 +63,7 @@ def _has_additional_properties(schema: Any) -> bool:
     return False
 
 
-def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
+def _convert_tool_spec(tools: list[dict[str, Any] | Any], provider_name: str) -> list[types.Tool]:
     converted_tools = []
     function_declarations = []
 
@@ -72,6 +73,14 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any]) -> list[types.Tool]:
             continue
 
         if tool.get("type") != "function":
+            # No openai "function" wrapper: treat it as a gemini-native tool dict (e.g.
+            # {"google_search": {}}) and let the SDK schema validate it, instead of silently
+            # dropping it from the request.
+            try:
+                converted_tools.append(types.Tool.model_validate(tool))
+            except ValidationError as exc:
+                msg = f"Unsupported tool: {tool}"
+                raise InvalidRequestError(msg, provider_name=provider_name) from exc
             continue
 
         function = tool["function"]

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -73,9 +73,7 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any], provider_name: str) ->
             continue
 
         if tool.get("type") != "function":
-            # No openai "function" wrapper: treat it as a gemini-native tool dict (e.g.
-            # {"google_search": {}}) and let the SDK schema validate it, instead of silently
-            # dropping it from the request.
+            # not openai function format: validate as a gemini-native tool dict, e.g. {"google_search": {}}
             try:
                 converted_tools.append(types.Tool.model_validate(tool))
             except ValidationError as exc:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1183,7 +1183,7 @@ async def test_gemini_unknown_tool_dict_raises(bad_tool: dict[str, Any]) -> None
     messages = [{"role": "user", "content": "Hello"}]
     with mock_gemini_provider():
         provider = GeminiProvider(api_key="test-api-key")
-        with pytest.raises(InvalidRequestError, match="Unsupported tool"):
+        with pytest.raises(InvalidRequestError, match=r"\[gemini\] Unsupported tool"):
             await provider._acompletion(
                 CompletionParams(model_id="gemini-pro", messages=messages, tools=[bad_tool]),
             )

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -978,7 +978,7 @@ def test_convert_tool_spec_basic_mapping() -> None:
         }
     ]
 
-    tools = _convert_tool_spec(openai_tools)
+    tools = _convert_tool_spec(openai_tools, "gemini")
 
     assert len(tools) == 1
     assert tools[0].function_declarations[0].name == "search"  # type: ignore[index]
@@ -994,7 +994,7 @@ def test_convert_tool_spec_basic_mapping() -> None:
 
 def test_convert_tool_spec_none_parameters() -> None:
     """Regression: parameters=None must not raise 'NoneType' object is not subscriptable."""
-    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": None}}])
+    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": None}}], "gemini")
     assert len(tools) == 1
     decl = tools[0].function_declarations[0]  # type: ignore[index]
     assert decl.name == "ping"
@@ -1004,7 +1004,9 @@ def test_convert_tool_spec_none_parameters() -> None:
 
 def test_convert_tool_spec_parameters_missing_properties() -> None:
     """Regression: parameters without a 'properties' key must not raise KeyError."""
-    tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}])
+    tools = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}], "gemini"
+    )
     assert len(tools) == 1
     decl = tools[0].function_declarations[0]  # type: ignore[index]
     assert decl.parameters.properties == {}  # type: ignore[union-attr]
@@ -1056,7 +1058,7 @@ def test_convert_tool_spec_json_schema_with_defs_and_refs() -> None:
         }
     ]
 
-    tools = _convert_tool_spec(openai_tools)
+    tools = _convert_tool_spec(openai_tools, "gemini")
 
     assert len(tools) == 1
     decl = tools[0].function_declarations[0]  # type: ignore[index]
@@ -1076,7 +1078,9 @@ def test_convert_tool_spec_nested_ref_only() -> None:
             }
         },
     }
-    tools = _convert_tool_spec([{"type": "function", "function": {"name": "nested", "parameters": raw_params}}])
+    tools = _convert_tool_spec(
+        [{"type": "function", "function": {"name": "nested", "parameters": raw_params}}], "gemini"
+    )
     decl = tools[0].function_declarations[0]  # type: ignore[index]
     assert decl.parameters is None
     assert decl.parameters_json_schema == raw_params
@@ -1104,7 +1108,8 @@ def test_convert_tool_spec_mixed_ref_and_plain_tools() -> None:
                     "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
                 },
             },
-        ]
+        ],
+        "gemini",
     )
     assert len(tools) == 1
     decls = tools[0].function_declarations
@@ -1134,6 +1139,54 @@ async def test_gemini_with_built_in_tools() -> None:
         assert generation_config.tools is not None
         assert len(generation_config.tools) == 1
         assert generation_config.tools[0] == google_search
+
+
+@pytest.mark.asyncio
+async def test_gemini_native_tool_dict_converts() -> None:
+    """A gemini-native tool dict must reach the request as a typed Tool, not be dropped."""
+    messages = [{"role": "user", "content": "Hello"}]
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(model_id="gemini-pro", messages=messages, tools=[{"google_search": {}}]),
+        )
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        generation_config = call_kwargs["config"]
+        assert len(generation_config.tools) == 1
+        assert generation_config.tools[0].google_search is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_native_tool_dict_mixes_with_function_tools() -> None:
+    """Function tools and native tool dicts convert side by side."""
+    messages = [{"role": "user", "content": "Hello"}]
+    function_tool = {
+        "type": "function",
+        "function": {"name": "get_weather", "description": "d", "parameters": {"type": "object", "properties": {}}},
+    }
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(model_id="gemini-pro", messages=messages, tools=[function_tool, {"url_context": {}}]),
+        )
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        tools = call_kwargs["config"].tools
+        assert len(tools) == 2
+        assert any(t.url_context is not None for t in tools)
+        assert any(t.function_declarations for t in tools)
+
+
+@pytest.mark.parametrize("bad_tool", [{"type": "web_search"}, {"nonsense_tool": {}}])
+@pytest.mark.asyncio
+async def test_gemini_unknown_tool_dict_raises(bad_tool: dict[str, Any]) -> None:
+    """A dict that is neither function format nor a valid native tool must raise, not vanish."""
+    messages = [{"role": "user", "content": "Hello"}]
+    with mock_gemini_provider():
+        provider = GeminiProvider(api_key="test-api-key")
+        with pytest.raises(InvalidRequestError, match="Unsupported tool"):
+            await provider._acompletion(
+                CompletionParams(model_id="gemini-pro", messages=messages, tools=[bad_tool]),
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`_convert_tool_spec` skips any dict whose `type` isn't `"function"`, so a gemini-native tool dict like `{"google_search": {}}` silently vanishes from the request — no error, no search. The typed form of the same tool already passes through via `BUILT_IN_TOOLS`; the dict spelling is the one form that dies.

Non-function dicts now go through `types.Tool.model_validate`: any gemini built-in converts, and a dict the SDK schema rejects raises a typed `InvalidRequestError`. `provider_name` is threaded into the converter for the error message, as #1300 does for `_convert_tool_choice`.

Verified live on `gemini-2.5-flash` with "What was the S&P 500's closing value last Friday?" and `tools=[{"google_search": {}}]`:

| | result |
|---|---|
| before | tool silently dropped — answers `4997.58` from stale training data |
| after | grounded — "closing value last Friday, August 14, 2026, was 7,785.76" |

Tests: a native dict reaches the request as a typed Tool; function and native tools mix in one call; unknown dicts raise. Existing direct-caller tests updated for the new argument.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Same silent-drop family as mozilla-ai/any-llm#1300.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Gemini tool specifications, including native tool dictionaries and function tools.
  * Added clearer validation errors for unsupported or invalid tool definitions.
  * Preserved valid Gemini-native tools in mixed tool configurations.
  * Improved reliability when processing incomplete or invalid tool schemas.

* **Tests**
  * Expanded coverage for missing parameters, missing properties, schema references, invalid tool dictionaries, and mixed tool configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->