### PR TITLE
fix(responses): flatten function tools for the Responses API

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -18,7 +18,7 @@ from any_llm.exceptions import (
     UnsupportedParameterError,
     UnsupportedProviderError,
 )
-from any_llm.tools import prepare_tools
+from any_llm.tools import _flatten_responses_tool, prepare_tools
 from any_llm.types.audio import AudioSpeechParams, AudioTranscriptionParams, Transcription
 from any_llm.types.completion import (
     ChatCompletion,
@@ -1292,7 +1292,9 @@ class AnyLLM(ABC):
 
         prepared_tools = None
         if tools:
-            prepared_tools = prepare_tools(tools, built_in_tools=self.BUILT_IN_TOOLS)
+            prepared_tools = [
+                _flatten_responses_tool(tool) for tool in prepare_tools(tools, built_in_tools=self.BUILT_IN_TOOLS)
+            ]
 
         params = ResponsesParams(
             model=model,

--- a/src/any_llm/tools.py
+++ b/src/any_llm/tools.py
@@ -236,6 +236,13 @@ def _python_type_to_json_schema(python_type: Any) -> dict[str, Any]:
     return {"type": "string"}
 
 
+def _flatten_responses_tool(tool: Any) -> Any:
+    """Flatten a chat-format function tool for the Responses API, which takes function tools flat."""
+    if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+        return {"type": "function", **tool["function"]}
+    return tool
+
+
 def prepare_tools(
     tools: list[dict[str, Any] | Callable[..., Any] | Any], built_in_tools: list[Any] | None = None
 ) -> list[dict[str, Any] | Any]:

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -110,6 +110,8 @@ async def test_tools_flattened_for_responses() -> None:
 
     tools = mock_aresponses.call_args.args[0].tools
     assert [tool.get("name") for tool in tools[:3]] == ["add", "sub", "mul"]
+    assert [tool["type"] for tool in tools[:3]] == ["function"] * 3
     assert all("function" not in tool for tool in tools[:3])
+    assert tools[1]["parameters"] == {}
     assert tools[1]["strict"] is True
     assert tools[3] == {"type": "web_search"}

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -1,8 +1,10 @@
 from typing import Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import ValidationError
 
+from any_llm import AnyLLM
 from any_llm.api import aresponses
 from any_llm.types.responses import ResponsesParams
 
@@ -88,3 +90,26 @@ def test_responses_params_rejects_top_level_dictionary_input() -> None:
     """Responses input must be text or a list of dictionaries."""
     with pytest.raises(ValidationError):
         ResponsesParams(model="test", input=cast("Any", {"role": "user", "content": "hello"}))
+
+
+@pytest.mark.asyncio
+async def test_tools_flattened_for_responses() -> None:
+    """Callables and chat-format tools must reach the provider flat; built-ins pass untouched."""
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    chat_format = {"type": "function", "function": {"name": "sub", "parameters": {}, "strict": True}}
+    flat = {"type": "function", "name": "mul", "parameters": {}}
+    builtin = {"type": "web_search"}
+
+    llm = AnyLLM.create("openai", api_key="test-key")
+    with patch.object(type(llm), "_aresponses", new=AsyncMock(return_value=object())) as mock_aresponses:
+        await llm.aresponses("gpt-4.1-mini", "hello", tools=[add, chat_format, flat, builtin])
+
+    tools = mock_aresponses.call_args.args[0].tools
+    assert [tool.get("name") for tool in tools[:3]] == ["add", "sub", "mul"]
+    assert all("function" not in tool for tool in tools[:3])
+    assert tools[1]["strict"] is True
+    assert tools[3] == {"type": "web_search"}


### PR DESCRIPTION
## Description

`aresponses()` accepts the same `tools` input as `acompletion()` — callables, tool dicts, built-ins — and runs them through the same `prepare_tools`. But `prepare_tools` was written for the chat path: `callable_to_tool` emits the chat-completions shape, with the function nested under a `"function"` key. The Responses API takes function tools flat, `name` and `parameters` at the top level, so the nested dict reaches `client.responses.create` unchanged and OpenAI rejects it:

```
InvalidRequestError: [openai] Error code: 400 - Missing required parameter: 'tools[0].name'.
```

Every callable and every chat-format tool dict fails this way on the Responses path. It went unnoticed because that path had no tool coverage, and callers who passed already-flat responses-native dicts never hit the conversion.

The fix flattens function tools at the responses seam: `{"type": "function", "function": {...}}` becomes `{"type": "function", **function}`. Flattening here rather than inside `callable_to_tool` keeps one intermediate shape for both call paths and the responses spelling local to the one API that wants it. Already-flat dicts and built-in tools (`{"type": "web_search"}`) pass untouched, and the chat-completions path is unchanged — callers who worked around the bug by passing flat dicts directly keep working.

Verified live on `gpt-5.1` with a plain Python callable in `tools`:

| | result |
|---|---|
| before | 400 `Missing required parameter: 'tools[0].name'` |
| after | completes with a `function_call` output item |

The test covers all four shapes in one call: callable flattens, chat-format dict flattens (keeping `strict`), flat stays flat, built-in untouched.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Responses API tool handling by converting supported function tools into the required format.
  * Preserved built-in tools and other compatible tool types without modification.
  * Ensured callable and chat-format tools are processed correctly before requests are sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->