### PR TITLE
fix: preserve fields the anthropic messages bridge dropped on encode

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1036,7 +1036,15 @@ class AnyLLM(ABC):
 
         completion_kwargs = messages_params_to_completion_params(params)
         completion_params = CompletionParams(**completion_kwargs)
-        result = await self._acompletion(completion_params, **kwargs)
+        try:
+            result = await self._acompletion(completion_params, **kwargs)
+        except UnsupportedParameterError as exc:
+            # parallel_tool_calls is synthesized here from Anthropic's tool_choice, so a
+            # provider that rejects it would otherwise name a parameter the caller never sent.
+            if exc.parameter_name != "parallel_tool_calls" or "parallel_tool_calls" not in completion_kwargs:
+                raise
+            msg = "tool_choice.disable_parallel_tool_use"
+            raise UnsupportedParameterError(msg, self.PROVIDER_NAME) from exc
 
         if isinstance(result, ChatCompletion):
             return chat_completion_to_message_response(result)

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -25,7 +25,7 @@ from any_llm.types.messages import (
     MessageStopEvent,
     MessageStreamEvent,
 )
-from any_llm.utils.structured_output import is_structured_output_type
+from any_llm.utils.structured_output import is_structured_output_type, normalize_output_config
 
 MISSING_PACKAGES_ERROR = None
 try:
@@ -339,10 +339,11 @@ class BaseAnthropicProvider(AnyLLM, ABC):
                 with _translating_nonstreaming_guard(self, params.max_tokens):
                     parsed = await messages_resource.parse(output_format=params.output_format, **native_kwargs)
                 return cast("ParsedMessage[Any] | ParsedBetaMessage[Any]", parsed)
+            # Normalize here as well as on the bridge so a bare format object means the same
+            # thing on both paths; the native API requires the output_config nesting.
+            output_config = normalize_output_config(cast("dict[str, Any]", params.output_format))
             with _translating_nonstreaming_guard(self, params.max_tokens):
-                message = await messages_resource.create(
-                    output_config=cast("Any", params.output_format), **native_kwargs
-                )
+                message = await messages_resource.create(output_config=cast("Any", output_config), **native_kwargs)
             return self._convert_native_message_to_response(message)
 
         api_kwargs = params.model_dump(exclude_none=True, exclude={"betas"})

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -84,12 +84,16 @@ def _extract_reasoning_text(message: dict[str, Any]) -> str:
 
     ``reasoning`` may be a plain string (the OpenAI-wire-compatible serialized form) or a
     ``{"content": str}`` dict, depending on how the caller constructed the message.
+    ``reasoning_content`` is the wire spelling, which is what arrives on a message replayed
+    from a backend that reports reasoning there and on one built by the Messages bridge.
     """
     reasoning = message.get("reasoning")
     if isinstance(reasoning, str):
         return reasoning
     if isinstance(reasoning, dict) and isinstance(content := reasoning.get("content"), str):
         return content
+    if isinstance(reasoning_content := message.get("reasoning_content"), str):
+        return reasoning_content
     return ""
 
 

--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -294,7 +294,8 @@ def _convert_messages(messages: list[dict[str, Any]]) -> tuple[list[dict[str, An
 
     Bedrock requires that consecutive tool results are merged into a single user message.
     This is necessary because Bedrock expects all toolResult blocks that correspond to
-    tool calls from a single assistant message to be grouped together.
+    tool calls from a single assistant message to be grouped together. Consecutive user
+    messages are merged for the same reason: Bedrock rejects two user turns in a row.
     """
     system_message = []
     if messages and messages[0]["role"] == "system":
@@ -332,12 +333,19 @@ def _convert_messages(messages: list[dict[str, Any]]) -> tuple[list[dict[str, An
             else:
                 # Simple text content
                 converted_content = [{"text": content}]
-            formatted_messages.append(
-                {
-                    "role": message["role"],
-                    "content": converted_content,
-                }
-            )
+            # Bedrock requires alternating roles, so a user turn landing straight after another
+            # one extends it instead of starting a second. Reachable whenever a user message
+            # follows a tool-result flush, as it does for an attachment carried out of a tool
+            # result by the Anthropic Messages bridge.
+            if formatted_messages and formatted_messages[-1]["role"] == "user":
+                formatted_messages[-1]["content"].extend(converted_content)
+            else:
+                formatted_messages.append(
+                    {
+                        "role": message["role"],
+                        "content": converted_content,
+                    }
+                )
 
     # Flush any remaining tool results at the end
     flush_tool_results()

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -232,9 +232,13 @@ class MessagesParams(BaseModel):
 
     Either a Pydantic ``BaseModel`` subclass or dataclass **type**, or a raw Anthropic
     ``output_config`` **dict** (e.g. ``{"format": {"type": "json_schema", "schema": {...}}}``)
-    for non-Pydantic JSON schemas. A type goes to native ``messages.parse`` on Anthropic; a
-    dict is passed through to native ``messages.create(output_config=...)``. Other providers
-    route either form through the completion bridge. The result is Anthropic's ``ParsedMessage``:
-    its ``parsed_output`` holds the typed object for a type, or the parsed JSON (plain
-    ``dict``/``list``) for a raw schema.
+    for non-Pydantic JSON schemas. The bare ``format`` object
+    (``{"type": "json_schema", "schema": {...}}``) is accepted as well. A type goes to native
+    ``messages.parse`` on Anthropic; a dict is passed through to native
+    ``messages.create(output_config=...)``. Other providers route either form through the
+    completion bridge. The result is Anthropic's ``ParsedMessage``: its ``parsed_output`` holds
+    the typed object for a type, or the parsed JSON (plain ``dict``/``list``) for a raw schema.
+
+    A dict that carries no schema in either shape raises ``InvalidRequestError`` on the bridged
+    path rather than sending a ``response_format`` that constrains nothing.
     """

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -28,28 +28,36 @@ if TYPE_CHECKING:
     from any_llm.types.messages import MessageContentBlock, MessagesParams
 
 
-def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str, Any]:
+def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str, Any] | None:
     """Translate a raw Anthropic ``output_config`` dict into a completion ``response_format``.
 
     Lets the bridge carry a non-Pydantic JSON schema to non-Anthropic providers: the schema
     under ``output_config["format"]["schema"]`` is rewrapped as the OpenAI ``json_schema``
     response format. The name falls back to the schema's ``title`` (or ``"structured_output"``).
 
-    Both dict shapes ``normalize_output_config`` accepts are handled.
+    Both dict shapes ``normalize_output_config`` accepts are handled. ``None`` means the config
+    asked for no structured output, so the caller leaves ``response_format`` unset.
+
+    ``output_config.effort`` is never translated: chat completions has no equivalent, and the
+    nearest field, ``reasoning_effort``, governs reasoning rather than output. It is ignored
+    whether or not a schema sits beside it, so an effort-only config is not rejected in one
+    shape while being dropped in the other.
 
     Raises:
-        InvalidRequestError: when the config names no schema. There is nothing to translate,
-            and a ``response_format`` carrying an empty schema would sit on the wire
-            constraining nothing while the caller believes it is in force.
+        InvalidRequestError: when the config names a format but no usable schema. The caller
+            asked for structured output, and a ``response_format`` carrying an empty schema
+            would sit on the wire constraining nothing while they believe it is in force.
 
     """
     fmt = normalize_output_config(output_config).get("format")
+    if fmt is None:
+        return None
     schema = fmt.get("schema") if isinstance(fmt, dict) else None
     if not isinstance(schema, dict) or not schema:
         msg = (
-            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
-            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
-            '({"type": "json_schema", "schema": {...}}).'
+            "output_format names a format but carries no JSON schema. Expected an Anthropic "
+            'output_config ({"format": {"type": "json_schema", "schema": {...}}}) or the bare '
+            'format object ({"type": "json_schema", "schema": {...}}).'
         )
         raise InvalidRequestError(msg)
     name = schema.get("title", "structured_output")
@@ -114,8 +122,10 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
     if params.output_format is not None:
         if is_structured_output_type(params.output_format):
             result["response_format"] = params.output_format
-        else:
-            result["response_format"] = _output_config_to_response_format(cast("dict[str, Any]", params.output_format))
+        elif (
+            response_format := _output_config_to_response_format(cast("dict[str, Any]", params.output_format))
+        ) is not None:
+            result["response_format"] = response_format
 
     if params.tools:
         result["tools"] = _convert_tools_to_openai(params.tools)
@@ -168,15 +178,20 @@ def _convert_assistant_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[di
     is the one that belongs on the wire. The normalized ``reasoning`` field would not do,
     because ``AnyLLM.acompletion`` strips it as an any_llm extension to the OpenAI spec.
 
-    Dropping the block made the bridge lossy in one direction only:
-    ``chat_completion_to_message_response`` builds a ``ThinkingBlock`` out of an upstream
-    ``reasoning`` field, so a caller could read thinking out of a Messages response and then
-    had nowhere to put it back on the next request.
-
     The Anthropic ``signature`` travels in the ``extra_content["anthropic"]`` side-channel that
     ``anthropic``'s ``_extract_anthropic_thinking_signature`` already reads, so a bridged
     request that later reaches an Anthropic-native provider can rebuild the block whole.
     Anthropic requires that signature back unmodified while extended thinking is on.
+
+    A signature is emitted only when the turn holds a single ``thinking`` block. Interleaved
+    thinking can put several in one turn, and the OpenAI wire has one ``reasoning_content``
+    string to hold them, so the joined text is not what any one signature signs. Emitting one
+    anyway would pair a signature with text it does not cover, which Anthropic rejects on
+    replay; the text is kept either way, since that is what the backend reads.
+
+    ``redacted_thinking`` blocks are dropped. They carry encrypted payloads with no text to
+    join and nothing on the OpenAI wire to carry them, so preserving them needs a side-channel
+    schema of its own and is left out of this change.
     """
     text_parts: list[str] = []
     thinking_parts: list[str] = []
@@ -214,7 +229,7 @@ def _convert_assistant_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[di
     reasoning_content = "".join(thinking_parts)
     if reasoning_content:
         result["reasoning_content"] = reasoning_content
-    if signature is not None:
+    if signature is not None and len(thinking_parts) == 1:
         result["extra_content"] = {"anthropic": {"signature": signature}}
     return [result]
 
@@ -269,8 +284,12 @@ def _convert_document_block_to_openai(block: dict[str, Any]) -> dict[str, Any]:
     if source_type == "content":
         return {"type": "text", "text": _flatten_document_content_source(source.get("content"))}
     if source_type == "base64":
+        data = source.get("data", "")
+        if not data:
+            msg = "document block base64 source carries no data"
+            raise InvalidRequestError(msg)
         media_type = source.get("media_type", "application/pdf")
-        return {"type": "file", "file": {"file_data": f"data:{media_type};base64,{source.get('data', '')}"}}
+        return {"type": "file", "file": {"file_data": f"data:{media_type};base64,{data}"}}
     url = source.get("url", "")
     if not url:
         msg = f"document block source carries no payload (source type {source_type!r})"
@@ -322,9 +341,11 @@ def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[st
 
     A tool result marked ``is_error`` keeps that marker on the emitted ``role: tool`` message.
     OpenAI has no field for it, and the OpenAI SDK forwards unknown message keys verbatim, so
-    the flag reaches a backend that understands it and is inert on one that does not. Dropping
-    it left a failed tool call indistinguishable from a successful one whose output happened to
-    read like an error.
+    the flag reaches any backend reached through an OpenAI-shaped request and is inert on one
+    that does not read it. It travels no further than that: a provider that rebuilds the
+    message from known keys, as ``bedrock``, ``gemini`` and ``ollama`` do, drops it again.
+    Mapping it onto each of those representations, such as ``toolResult.status`` on Bedrock,
+    is left to a follow-up.
 
     A tool result carrying image or document blocks emits the text as the ``role: tool``
     message and holds the remaining parts back, because OpenAI accepts text only on a tool

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, cast
 
+from any_llm.exceptions import InvalidRequestError
 from any_llm.types.messages import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
@@ -33,9 +34,30 @@ def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str
     Lets the bridge carry a non-Pydantic JSON schema to non-Anthropic providers: the schema
     under ``output_config["format"]["schema"]`` is rewrapped as the OpenAI ``json_schema``
     response format. The name falls back to the schema's ``title`` (or ``"structured_output"``).
+
+    The bare ``format`` object (``{"type": "json_schema", "schema": {...}}``) is accepted as
+    well as the full ``output_config`` wrapper around it. Anthropic nests that object under
+    ``output_config.format``, so a caller holding the inner object is one level away from the
+    documented shape, and reading only the wrapper silently forwarded an empty schema:
+    ``response_format`` was present on the wire but constrained nothing.
+
+    Raises:
+        InvalidRequestError: when neither shape carries a schema, so the request cannot be
+            satisfied. Forwarding an empty schema instead would return unconstrained output
+            under a response_format the caller believes is in force.
+
     """
-    fmt = output_config.get("format") or {}
-    schema = fmt.get("schema") or {}
+    fmt = output_config.get("format")
+    if not isinstance(fmt, dict):
+        fmt = output_config
+    schema = fmt.get("schema")
+    if not isinstance(schema, dict) or not schema:
+        msg = (
+            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
+            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
+            '({"type": "json_schema", "schema": {...}}).'
+        )
+        raise InvalidRequestError(msg)
     name = schema.get("title", "structured_output")
     return {"type": "json_schema", "json_schema": {"name": name, "schema": schema}}
 
@@ -106,6 +128,11 @@ def messages_params_to_completion_params(params: MessagesParams) -> dict[str, An
 
     if params.tool_choice is not None:
         result["tool_choice"] = _convert_tool_choice_to_openai(params.tool_choice)
+        # Anthropic carries the sequential-tool-use switch inside tool_choice; OpenAI carries it
+        # as a sibling of it. Anthropic accepts the flag on every tool_choice type, so this does
+        # not depend on which type _convert_tool_choice_to_openai resolved.
+        if params.tool_choice.get("disable_parallel_tool_use") is True:
+            result["parallel_tool_calls"] = False
 
     if params.thinking:
         if params.thinking.get("type") == "enabled":
@@ -138,14 +165,39 @@ def _convert_message_to_openai(msg: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _convert_assistant_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Convert Anthropic assistant content blocks to OpenAI format."""
+    """Convert Anthropic assistant content blocks to OpenAI format.
+
+    A ``thinking`` block replayed from a previous turn becomes ``reasoning_content`` on the
+    assistant message. That is the first entry in ``REASONING_FIELD_NAMES``, and the field
+    ``deepseek``'s ``_reinject_reasoning_content`` restores for the same purpose, on the
+    grounds it states there: of the reasoning fields any_llm knows about, ``reasoning_content``
+    is the one that belongs on the wire. The normalized ``reasoning`` field would not do,
+    because ``AnyLLM.acompletion`` strips it as an any_llm extension to the OpenAI spec.
+
+    Dropping the block made the bridge lossy in one direction only:
+    ``chat_completion_to_message_response`` builds a ``ThinkingBlock`` out of an upstream
+    ``reasoning`` field, so a caller could read thinking out of a Messages response and then
+    had nowhere to put it back on the next request.
+
+    The Anthropic ``signature`` travels in the ``extra_content["anthropic"]`` side-channel that
+    ``anthropic``'s ``_extract_anthropic_thinking_signature`` already reads, so a bridged
+    request that later reaches an Anthropic-native provider can rebuild the block whole.
+    Anthropic requires that signature back unmodified while extended thinking is on.
+    """
     text_parts: list[str] = []
+    thinking_parts: list[str] = []
+    signature: str | None = None
     tool_calls: list[dict[str, Any]] = []
 
     for block in blocks:
         block_type = block.get("type", "")
         if block_type == "text":
             text_parts.append(block.get("text", ""))
+        elif block_type == "thinking":
+            thinking_parts.append(block.get("thinking", ""))
+            block_signature = block.get("signature")
+            if isinstance(block_signature, str) and block_signature:
+                signature = block_signature
         elif block_type == "tool_use":
             tool_calls.append(
                 {
@@ -165,13 +217,83 @@ def _convert_assistant_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[di
         result["content"] = None
     if tool_calls:
         result["tool_calls"] = tool_calls
+    reasoning_content = "".join(thinking_parts)
+    if reasoning_content:
+        result["reasoning_content"] = reasoning_content
+    if signature is not None:
+        result["extra_content"] = {"anthropic": {"signature": signature}}
     return [result]
+
+
+def _convert_image_block_to_openai(block: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic ``image`` block to an OpenAI ``image_url`` content part.
+
+    Inverse of the ``image_url`` branch in ``anthropic``'s ``_convert_content_for_anthropic``.
+    """
+    source = block.get("source", {})
+    if source.get("type") == "base64":
+        url = f"data:{source.get('media_type', 'image/png')};base64,{source.get('data', '')}"
+    else:
+        url = source.get("url", "")
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _convert_document_block_to_openai(block: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic ``document`` block to an OpenAI content part.
+
+    Inverse of the ``file`` branch in ``anthropic``'s ``_convert_content_for_anthropic``, which
+    pairs an Anthropic ``document`` with an OpenAI ``file`` part carrying a ``file_data`` data
+    URI. A ``text`` source has no ``file`` equivalent and its payload is already text, so it
+    becomes a text part rather than a data URI wrapping plain text.
+    """
+    source = block.get("source", {})
+    source_type = source.get("type")
+    if source_type == "text":
+        return {"type": "text", "text": source.get("data", "")}
+    if source_type == "base64":
+        media_type = source.get("media_type", "application/pdf")
+        return {"type": "file", "file": {"file_data": f"data:{media_type};base64,{source.get('data', '')}"}}
+    return {"type": "file", "file": {"file_data": source.get("url", "")}}
+
+
+def _convert_tool_result_content(tool_content: Any) -> tuple[str, list[dict[str, Any]]]:
+    """Split an Anthropic ``tool_result`` payload into wire text and non-text content parts.
+
+    OpenAI's ``role: tool`` message takes text only, so the two halves cannot ride in one
+    message. Concatenating the text blocks and discarding the rest is what deleted image and
+    document bytes that an agent had put in a tool result; the caller re-attaches the returned
+    parts as a following ``user`` message instead.
+    """
+    if not isinstance(tool_content, list):
+        return str(tool_content), []
+    text_parts: list[str] = []
+    extra_parts: list[dict[str, Any]] = []
+    for block in tool_content:
+        block_type = block.get("type", "")
+        if block_type == "text":
+            text_parts.append(block.get("text", ""))
+        elif block_type == "image":
+            extra_parts.append(_convert_image_block_to_openai(block))
+        elif block_type == "document":
+            extra_parts.append(_convert_document_block_to_openai(block))
+    return "".join(text_parts), extra_parts
 
 
 def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert Anthropic user content blocks to OpenAI format.
 
     Handles tool_result blocks (→ role:tool messages) and content blocks (text, image).
+
+    A tool result marked ``is_error`` keeps that marker on the emitted ``role: tool`` message.
+    OpenAI has no field for it, and the OpenAI SDK forwards unknown message keys verbatim, so
+    the flag reaches a backend that understands it and is inert on one that does not. Dropping
+    it left a failed tool call indistinguishable from a successful one whose output happened to
+    read like an error.
+
+    A tool result carrying image or document blocks emits the text as the ``role: tool``
+    message and the remaining parts as a ``user`` message directly after it, because OpenAI
+    accepts text only on a tool message. The bytes stay in the request at the same point in the
+    conversation rather than being dropped.
     """
     results: list[dict[str, Any]] = []
     content_blocks: list[dict[str, Any]] = []
@@ -183,26 +305,21 @@ def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[st
             if content_blocks:
                 results.append({"role": "user", "content": content_blocks})
                 content_blocks = []
-            tool_content = block.get("content", "")
-            if isinstance(tool_content, list):
-                text_parts = [b.get("text", "") for b in tool_content if b.get("type") == "text"]
-                tool_content = "".join(text_parts)
-            results.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": block.get("tool_use_id", ""),
-                    "content": str(tool_content),
-                }
-            )
+            tool_text, extra_parts = _convert_tool_result_content(block.get("content", ""))
+            tool_message: dict[str, Any] = {
+                "role": "tool",
+                "tool_call_id": block.get("tool_use_id", ""),
+                "content": tool_text,
+            }
+            if block.get("is_error") is True:
+                tool_message["is_error"] = True
+            results.append(tool_message)
+            if extra_parts:
+                results.append({"role": "user", "content": extra_parts})
         elif block_type == "text":
             content_blocks.append({"type": "text", "text": block.get("text", "")})
         elif block_type == "image":
-            source = block.get("source", {})
-            if source.get("type") == "base64":
-                url = f"data:{source.get('media_type', 'image/png')};base64,{source.get('data', '')}"
-            else:
-                url = source.get("url", "")
-            content_blocks.append({"type": "image_url", "image_url": {"url": url}})
+            content_blocks.append(_convert_image_block_to_openai(block))
         else:
             content_blocks.append(block)
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -35,11 +35,23 @@ def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str
     under ``output_config["format"]["schema"]`` is rewrapped as the OpenAI ``json_schema``
     response format. The name falls back to the schema's ``title`` (or ``"structured_output"``).
 
-    Both dict shapes ``normalize_output_config`` accepts are handled, and a dict carrying no
-    schema raises there rather than putting a ``response_format`` on the wire that constrains
-    nothing.
+    Both dict shapes ``normalize_output_config`` accepts are handled.
+
+    Raises:
+        InvalidRequestError: when the config names no schema. There is nothing to translate,
+            and a ``response_format`` carrying an empty schema would sit on the wire
+            constraining nothing while the caller believes it is in force.
+
     """
-    schema = normalize_output_config(output_config)["format"]["schema"]
+    fmt = normalize_output_config(output_config).get("format")
+    schema = fmt.get("schema") if isinstance(fmt, dict) else None
+    if not isinstance(schema, dict) or not schema:
+        msg = (
+            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
+            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
+            '({"type": "json_schema", "schema": {...}}).'
+        )
+        raise InvalidRequestError(msg)
     name = schema.get("title", "structured_output")
     return {"type": "json_schema", "json_schema": {"name": name, "schema": schema}}
 
@@ -315,12 +327,18 @@ def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[st
     read like an error.
 
     A tool result carrying image or document blocks emits the text as the ``role: tool``
-    message and the remaining parts as a ``user`` message directly after it, because OpenAI
-    accepts text only on a tool message. The bytes stay in the request at the same point in the
-    conversation rather than being dropped.
+    message and holds the remaining parts back, because OpenAI accepts text only on a tool
+    message. The held parts lead the ``user`` message that closes the turn, so they stay at the
+    same point in the conversation rather than being dropped.
+
+    They are held until the whole run of tool results ends rather than emitted after each one.
+    Anthropic puts every ``tool_result`` of a parallel tool call in a single user turn, so
+    emitting per result would interleave user messages between the ``role: tool`` messages, and
+    OpenAI requires those to follow the assistant ``tool_calls`` turn with nothing in between.
     """
     results: list[dict[str, Any]] = []
     content_blocks: list[dict[str, Any]] = []
+    held_parts: list[dict[str, Any]] = []
 
     for block in blocks:
         block_type = block.get("type", "")
@@ -338,8 +356,7 @@ def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[st
             if block.get("is_error") is True:
                 tool_message["is_error"] = True
             results.append(tool_message)
-            if extra_parts:
-                results.append({"role": "user", "content": extra_parts})
+            held_parts.extend(extra_parts)
         elif block_type == "text":
             content_blocks.append({"type": "text", "text": block.get("text", "")})
         elif block_type == "image":
@@ -347,8 +364,8 @@ def _convert_user_blocks_to_openai(blocks: list[dict[str, Any]]) -> list[dict[st
         else:
             content_blocks.append(block)
 
-    if content_blocks:
-        results.append({"role": "user", "content": content_blocks})
+    if held_parts or content_blocks:
+        results.append({"role": "user", "content": held_parts + content_blocks})
 
     return results
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -211,12 +211,27 @@ def _convert_image_block_to_openai(block: dict[str, Any]) -> dict[str, Any]:
     """Convert an Anthropic ``image`` block to an OpenAI ``image_url`` content part.
 
     Inverse of the ``image_url`` branch in ``anthropic``'s ``_convert_content_for_anthropic``.
+
+    Raises:
+        InvalidRequestError: when the source carries neither inline data nor a url, matching
+            what ``_convert_document_block_to_openai`` does. An empty ``image_url.url`` is not
+            an attachment a backend can fetch.
+
     """
     source = block.get("source", {})
     if source.get("type") == "base64":
-        url = f"data:{source.get('media_type', 'image/png')};base64,{source.get('data', '')}"
-    else:
-        url = source.get("url", "")
+        data = source.get("data", "")
+        if not data:
+            msg = "image block base64 source carries no data"
+            raise InvalidRequestError(msg)
+        return {
+            "type": "image_url",
+            "image_url": {"url": f"data:{source.get('media_type', 'image/png')};base64,{data}"},
+        }
+    url = source.get("url", "")
+    if not url:
+        msg = f"image block source carries no payload (source type {source.get('type')!r})"
+        raise InvalidRequestError(msg)
     return {"type": "image_url", "image_url": {"url": url}}
 
 

--- a/src/any_llm/utils/messages_compat.py
+++ b/src/any_llm/utils/messages_compat.py
@@ -21,7 +21,7 @@ from any_llm.types.messages import (
     ThinkingDelta,
     ToolUseBlock,
 )
-from any_llm.utils.structured_output import is_structured_output_type
+from any_llm.utils.structured_output import is_structured_output_type, normalize_output_config
 
 if TYPE_CHECKING:
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionUsage
@@ -35,29 +35,11 @@ def _output_config_to_response_format(output_config: dict[str, Any]) -> dict[str
     under ``output_config["format"]["schema"]`` is rewrapped as the OpenAI ``json_schema``
     response format. The name falls back to the schema's ``title`` (or ``"structured_output"``).
 
-    The bare ``format`` object (``{"type": "json_schema", "schema": {...}}``) is accepted as
-    well as the full ``output_config`` wrapper around it. Anthropic nests that object under
-    ``output_config.format``, so a caller holding the inner object is one level away from the
-    documented shape, and reading only the wrapper silently forwarded an empty schema:
-    ``response_format`` was present on the wire but constrained nothing.
-
-    Raises:
-        InvalidRequestError: when neither shape carries a schema, so the request cannot be
-            satisfied. Forwarding an empty schema instead would return unconstrained output
-            under a response_format the caller believes is in force.
-
+    Both dict shapes ``normalize_output_config`` accepts are handled, and a dict carrying no
+    schema raises there rather than putting a ``response_format`` on the wire that constrains
+    nothing.
     """
-    fmt = output_config.get("format")
-    if not isinstance(fmt, dict):
-        fmt = output_config
-    schema = fmt.get("schema")
-    if not isinstance(schema, dict) or not schema:
-        msg = (
-            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
-            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
-            '({"type": "json_schema", "schema": {...}}).'
-        )
-        raise InvalidRequestError(msg)
+    schema = normalize_output_config(output_config)["format"]["schema"]
     name = schema.get("title", "structured_output")
     return {"type": "json_schema", "json_schema": {"name": name, "schema": schema}}
 
@@ -243,17 +225,44 @@ def _convert_document_block_to_openai(block: dict[str, Any]) -> dict[str, Any]:
 
     Inverse of the ``file`` branch in ``anthropic``'s ``_convert_content_for_anthropic``, which
     pairs an Anthropic ``document`` with an OpenAI ``file`` part carrying a ``file_data`` data
-    URI. A ``text`` source has no ``file`` equivalent and its payload is already text, so it
-    becomes a text part rather than a data URI wrapping plain text.
+    URI. Anthropic's document source is one of ``base64``, ``text``, ``content`` or ``url``.
+    The two that already hold text (``text`` and ``content``) become a text part rather than a
+    data URI wrapping plain text, since ``file`` has no equivalent for them.
+
+    Raises:
+        InvalidRequestError: when the source carries no payload. An empty ``file_data`` is not
+            a usable attachment, so it would cost a backend round trip to learn the document
+            never made it.
+
     """
     source = block.get("source", {})
     source_type = source.get("type")
     if source_type == "text":
         return {"type": "text", "text": source.get("data", "")}
+    if source_type == "content":
+        return {"type": "text", "text": _flatten_document_content_source(source.get("content"))}
     if source_type == "base64":
         media_type = source.get("media_type", "application/pdf")
         return {"type": "file", "file": {"file_data": f"data:{media_type};base64,{source.get('data', '')}"}}
-    return {"type": "file", "file": {"file_data": source.get("url", "")}}
+    url = source.get("url", "")
+    if not url:
+        msg = f"document block source carries no payload (source type {source_type!r})"
+        raise InvalidRequestError(msg)
+    return {"type": "file", "file": {"file_data": url}}
+
+
+def _flatten_document_content_source(content: Any) -> str:
+    """Flatten a ``content``-source document into text.
+
+    Anthropic's ``content`` source holds either a string or a list of text and image blocks.
+    Only the text carries over: an OpenAI content part is a single typed value, so nested
+    images cannot ride inside the text part this returns.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+    return ""
 
 
 def _convert_tool_result_content(tool_content: Any) -> tuple[str, list[dict[str, Any]]]:

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def normalize_output_config(output_config: dict[str, Any]) -> dict[str, Any]:
-    """Return an Anthropic ``output_config`` wrapper for either accepted dict shape.
+    """Return an Anthropic ``output_config`` in its documented shape.
 
     Anthropic nests the JSON schema under ``output_config.format``, so a caller holding the
     inner ``format`` object (``{"type": "json_schema", "schema": {...}}``) is one level away
@@ -25,29 +25,25 @@ def normalize_output_config(output_config: dict[str, Any]) -> dict[str, Any]:
     ``output_format`` dict normalize through this function so the field means the same thing
     on the native Anthropic path and on the completion bridge.
 
+    Every field of ``output_config`` is optional, so a config that names no format is returned
+    untouched: ``{"effort": "high"}`` is a valid request that sets effort alone. Requiring a
+    schema belongs to the caller that needs one, which is the bridge, since translating to an
+    OpenAI ``response_format`` is what cannot proceed without it.
+
     Raises:
-        InvalidRequestError: when neither shape carries a schema, or when ``format`` is present
-            but is not the object it has to be. Passing the dict through would send a
-            structured-output request that constrains nothing.
+        InvalidRequestError: when ``format`` is present but is not the object it has to be.
+            Treating it as absent would silently re-nest the config around the malformed value.
 
     """
     raw_format = output_config.get("format")
-    if raw_format is None:
-        wrapped, fmt = False, output_config
-    elif isinstance(raw_format, dict):
-        wrapped, fmt = True, raw_format
-    else:
+    if isinstance(raw_format, dict):
+        return output_config
+    if raw_format is not None:
         msg = f"output_format dict has a non-object format value: {raw_format!r}"
         raise InvalidRequestError(msg)
-    schema = fmt.get("schema")
-    if not isinstance(schema, dict) or not schema:
-        msg = (
-            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
-            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
-            '({"type": "json_schema", "schema": {...}}).'
-        )
-        raise InvalidRequestError(msg)
-    return output_config if wrapped else {"format": fmt}
+    if "schema" in output_config or output_config.get("type") == "json_schema":
+        return {"format": output_config}
+    return output_config
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 
 from pydantic import BaseModel, TypeAdapter
 
+from any_llm.exceptions import InvalidRequestError
 from any_llm.logging import logger
 
 if TYPE_CHECKING:
@@ -13,6 +14,34 @@ if TYPE_CHECKING:
     from anthropic.types.parsed_message import ParsedMessage
 
     from any_llm.types.responses import ParsedResponse
+
+
+def normalize_output_config(output_config: dict[str, Any]) -> dict[str, Any]:
+    """Return an Anthropic ``output_config`` wrapper for either accepted dict shape.
+
+    Anthropic nests the JSON schema under ``output_config.format``, so a caller holding the
+    inner ``format`` object (``{"type": "json_schema", "schema": {...}}``) is one level away
+    from the documented shape. Both are accepted here, and both consumers of an
+    ``output_format`` dict normalize through this function so the field means the same thing
+    on the native Anthropic path and on the completion bridge.
+
+    Raises:
+        InvalidRequestError: when neither shape carries a schema. Passing the dict through
+            would send a structured-output request that constrains nothing.
+
+    """
+    fmt = output_config.get("format")
+    if not isinstance(fmt, dict):
+        fmt = output_config
+    schema = fmt.get("schema")
+    if not isinstance(schema, dict) or not schema:
+        msg = (
+            "output_format dict carries no JSON schema. Expected an Anthropic output_config "
+            '({"format": {"type": "json_schema", "schema": {...}}}) or the bare format object '
+            '({"type": "json_schema", "schema": {...}}).'
+        )
+        raise InvalidRequestError(msg)
+    return {**output_config, "format": fmt} if output_config.get("format") is not None else {"format": fmt}
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:

--- a/src/any_llm/utils/structured_output.py
+++ b/src/any_llm/utils/structured_output.py
@@ -26,13 +26,19 @@ def normalize_output_config(output_config: dict[str, Any]) -> dict[str, Any]:
     on the native Anthropic path and on the completion bridge.
 
     Raises:
-        InvalidRequestError: when neither shape carries a schema. Passing the dict through
-            would send a structured-output request that constrains nothing.
+        InvalidRequestError: when neither shape carries a schema, or when ``format`` is present
+            but is not the object it has to be. Passing the dict through would send a
+            structured-output request that constrains nothing.
 
     """
-    fmt = output_config.get("format")
-    if not isinstance(fmt, dict):
-        fmt = output_config
+    raw_format = output_config.get("format")
+    if raw_format is None:
+        wrapped, fmt = False, output_config
+    elif isinstance(raw_format, dict):
+        wrapped, fmt = True, raw_format
+    else:
+        msg = f"output_format dict has a non-object format value: {raw_format!r}"
+        raise InvalidRequestError(msg)
     schema = fmt.get("schema")
     if not isinstance(schema, dict) or not schema:
         msg = (
@@ -41,7 +47,7 @@ def normalize_output_config(output_config: dict[str, Any]) -> dict[str, Any]:
             '({"type": "json_schema", "schema": {...}}).'
         )
         raise InvalidRequestError(msg)
-    return {**output_config, "format": fmt} if output_config.get("format") is not None else {"format": fmt}
+    return output_config if wrapped else {"format": fmt}
 
 
 def is_structured_output_type(response_format: Any) -> TypeGuard[type]:

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -1007,6 +1007,56 @@ async def test_amessages_output_format_uses_native_parse() -> None:
 
 
 @pytest.mark.asyncio
+async def test_amessages_bare_output_format_object_is_nested_before_create() -> None:
+    """The bare format object is wrapped before the native call, which requires the nesting.
+
+    The bridge accepts either shape, so the field would otherwise mean two different things
+    depending on which provider served the request.
+    """
+    mock_message = _make_message(content=[TextBlock(type="text", text='{"city_name": "Paris"}')])
+
+    mock_client = Mock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+    mock_client.messages.parse = AsyncMock()
+
+    provider = Mock(spec=BaseAnthropicProvider)
+    provider.client = mock_client
+    provider._convert_native_message_to_response = BaseAnthropicProvider._convert_native_message_to_response
+
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=1024,
+        output_format={"type": "json_schema", "schema": {"type": "object"}},
+    )
+    await BaseAnthropicProvider._amessages(provider, params)
+
+    call_kwargs = mock_client.messages.create.call_args.kwargs
+    assert call_kwargs["output_config"] == {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+
+
+@pytest.mark.asyncio
+async def test_amessages_output_format_without_schema_raises() -> None:
+    """A dict with no schema is rejected before the native call rather than sent as-is."""
+    mock_client = Mock()
+    mock_client.messages.create = AsyncMock()
+    mock_client.messages.parse = AsyncMock()
+
+    provider = Mock(spec=BaseAnthropicProvider)
+    provider.client = mock_client
+
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=1024,
+        output_format={"format": {"type": "json_schema"}},
+    )
+    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+        await BaseAnthropicProvider._amessages(provider, params)
+    mock_client.messages.create.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_amessages_output_config_dict_passes_through_to_create() -> None:
     """A raw output_config dict goes to native messages.create(output_config=...), not parse."""
     output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -1036,8 +1036,32 @@ async def test_amessages_bare_output_format_object_is_nested_before_create() -> 
 
 
 @pytest.mark.asyncio
-async def test_amessages_output_format_without_schema_raises() -> None:
-    """A dict with no schema is rejected before the native call rather than sent as-is."""
+async def test_amessages_effort_only_output_config_reaches_create() -> None:
+    """Every output_config field is optional, so effort alone is a valid native request."""
+    mock_message = _make_message(content=[TextBlock(type="text", text="Paris")])
+
+    mock_client = Mock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+    mock_client.messages.parse = AsyncMock()
+
+    provider = Mock(spec=BaseAnthropicProvider)
+    provider.client = mock_client
+    provider._convert_native_message_to_response = BaseAnthropicProvider._convert_native_message_to_response
+
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=1024,
+        output_format={"effort": "high"},
+    )
+    await BaseAnthropicProvider._amessages(provider, params)
+
+    assert mock_client.messages.create.call_args.kwargs["output_config"] == {"effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_amessages_non_object_format_raises() -> None:
+    """A format value that is not an object is rejected rather than re-nested."""
     mock_client = Mock()
     mock_client.messages.create = AsyncMock()
     mock_client.messages.parse = AsyncMock()
@@ -1049,9 +1073,9 @@ async def test_amessages_output_format_without_schema_raises() -> None:
         model="claude-3-5-sonnet",
         messages=[{"role": "user", "content": "Capital of France?"}],
         max_tokens=1024,
-        output_format={"format": {"type": "json_schema"}},
+        output_format={"format": "json_schema"},
     )
-    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+    with pytest.raises(InvalidRequestError, match="non-object format value"):
         await BaseAnthropicProvider._amessages(provider, params)
     mock_client.messages.create.assert_not_called()
 

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -1562,3 +1562,25 @@ def test_convert_response_multiple_tool_calls_not_treated_as_structured_output()
     assert result.choices[0].finish_reason == "tool_calls"
     assert result.choices[0].message.tool_calls is not None
     assert len(result.choices[0].message.tool_calls) == 2
+
+
+def test_convert_messages_merges_consecutive_user_messages() -> None:
+    """Bedrock rejects two user turns in a row, so a user message after a tool-result flush
+    extends that turn instead of starting another."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "screenshot"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "t1", "type": "function", "function": {"name": "shot", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "t1", "content": "here"},
+        {"role": "user", "content": [{"type": "text", "text": "what is in it"}]},
+    ]
+    _, formatted_messages = _convert_messages(messages)
+
+    assert [message["role"] for message in formatted_messages] == ["user", "assistant", "user"]
+    assert formatted_messages[-1]["content"] == [
+        {"toolResult": {"toolUseId": "t1", "content": [{"text": "here"}]}},
+        {"text": "what is in it"},
+    ]

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -5,7 +5,7 @@ import threading
 from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from inspect import signature
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -1346,6 +1346,116 @@ class _StreamingHandler(BaseHTTPRequestHandler):
     @override
     def log_message(self, format: str, *args: Any) -> None:
         return
+
+
+class _CapturingHandler(BaseHTTPRequestHandler):
+    """Records every request body, then answers like a minimal OpenAI-compatible endpoint."""
+
+    protocol_version = "HTTP/1.1"
+    captured: ClassVar[list[dict[str, Any]]] = []
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(content_length)
+        type(self).captured.append(json.loads(raw or b"{}"))
+
+        encoded = json.dumps(
+            {
+                "id": "capture-1",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+        ).encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(encoded)
+        self.wfile.flush()
+
+    @override
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def test_messages_bridge_forwards_thinking_tool_result_and_parallel_flag_on_the_wire() -> None:
+    """Regression test for #1311.
+
+    Asserts the encode side against the bytes an OpenAI-compatible backend actually receives,
+    rather than against the intermediate params dict, because every one of these losses was
+    invisible in the response: the request returned 200 with the field silently gone. Exercises
+    the real OpenAI SDK and httpx against a local server, with no live provider or API key.
+    """
+    png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    _CapturingHandler.captured = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CapturingHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        api_base = f"http://127.0.0.1:{server.server_address[1]}/v1"
+        provider = AnyLLM.create_openai_compatible(name="local-capture", api_base=api_base, api_key="test")
+        provider.messages(
+            model="test-model",
+            messages=[
+                {"role": "user", "content": "take a screenshot"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "call the tool", "signature": "sig-abc"},
+                        {"type": "tool_use", "id": "toolu_1", "name": "screenshot", "input": {}},
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "is_error": True,
+                            "content": [
+                                {"type": "text", "text": "partial capture:"},
+                                {
+                                    "type": "image",
+                                    "source": {"type": "base64", "media_type": "image/png", "data": png},
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+            max_tokens=32,
+            tools=[{"name": "screenshot", "description": "grab the screen", "input_schema": {"type": "object"}}],
+            tool_choice={"type": "auto", "disable_parallel_tool_use": True},
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+    assert len(_CapturingHandler.captured) == 1
+    body = _CapturingHandler.captured[0]
+
+    assert body["parallel_tool_calls"] is False
+
+    assistant = body["messages"][1]
+    assert assistant["reasoning_content"] == "call the tool"
+    assert assistant["extra_content"] == {"anthropic": {"signature": "sig-abc"}}
+
+    tool_message = body["messages"][2]
+    assert tool_message["role"] == "tool"
+    assert tool_message["content"] == "partial capture:"
+    assert tool_message["is_error"] is True
+
+    attachment = body["messages"][3]
+    assert attachment["role"] == "user"
+    assert attachment["content"] == [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{png}"}}]
 
 
 def test_sync_messages_streaming_consumes_response_on_a_single_event_loop() -> None:

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -34,6 +34,7 @@ from any_llm.types.completion import (
     Choice,
     ChoiceDelta,
     ChunkChoice,
+    CompletionParams,
     CompletionUsage,
     PromptTokensDetails,
 )
@@ -1730,3 +1731,58 @@ async def test_amessages_output_config_dict_rejects_streaming() -> None:
             output_format=output_config,
             stream=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_amessages_parallel_tool_calls_rejection_names_the_anthropic_parameter() -> None:
+    """A provider that rejects parallel_tool_calls must not name a parameter the caller never sent.
+
+    The bridge synthesizes parallel_tool_calls out of Anthropic's tool_choice, so Gemini and
+    Cohere raise for it on a Messages call whose caller only set disable_parallel_tool_use.
+    The request still fails, since neither provider can honor sequential tool use, but the
+    error names the field that was actually passed.
+    """
+
+    class RejectingProvider(AnyLLM):
+        PROVIDER_NAME = "rejecting"
+
+        @override
+        async def _acompletion(self, params: CompletionParams, **kwargs: Any) -> Any:
+            if params.parallel_tool_calls is not None:
+                msg = "parallel_tool_calls"
+                raise UnsupportedParameterError(msg, self.PROVIDER_NAME)
+            return None
+
+    provider = Mock(spec=RejectingProvider)
+    provider.PROVIDER_NAME = "rejecting"
+    provider._acompletion = RejectingProvider._acompletion.__get__(provider)
+
+    params = MessagesParams(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=32,
+        tools=[{"name": "t", "description": "d", "input_schema": {"type": "object"}}],
+        tool_choice={"type": "auto", "disable_parallel_tool_use": True},
+    )
+    with pytest.raises(UnsupportedParameterError) as exc_info:
+        await AnyLLM._amessages(provider, params)
+    assert exc_info.value.parameter_name == "tool_choice.disable_parallel_tool_use"
+
+
+@pytest.mark.asyncio
+async def test_amessages_unrelated_unsupported_parameter_is_not_relabelled() -> None:
+    """Only the synthesized parameter is renamed; every other rejection passes through."""
+
+    provider = Mock(spec=AnyLLM)
+    provider.PROVIDER_NAME = "rejecting"
+
+    async def _acompletion(params: CompletionParams, **kwargs: Any) -> Any:
+        msg = "seed"
+        raise UnsupportedParameterError(msg, "rejecting")
+
+    provider._acompletion = _acompletion
+
+    params = MessagesParams(model="m", messages=[{"role": "user", "content": "hi"}], max_tokens=32)
+    with pytest.raises(UnsupportedParameterError) as exc_info:
+        await AnyLLM._amessages(provider, params)
+    assert exc_info.value.parameter_name == "seed"

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -2000,3 +2000,127 @@ def test_user_blocks_tool_result_attachment_keeps_conversation_order() -> None:
     )
     assert [message["role"] for message in result] == ["user", "tool", "user"]
     assert result[0]["content"] == [{"type": "text", "text": "before"}]
+
+
+def test_output_config_bare_format_object_normalized_for_the_native_path() -> None:
+    """The shared normalizer wraps the bare object so the native output_config nesting holds."""
+    from any_llm.utils.structured_output import normalize_output_config
+
+    assert normalize_output_config({"type": "json_schema", "schema": {"type": "object"}}) == {
+        "format": {"type": "json_schema", "schema": {"type": "object"}}
+    }
+
+
+def test_output_config_wrapper_preserved_by_normalizer() -> None:
+    """An already-nested output_config keeps its siblings, such as effort."""
+    from any_llm.utils.structured_output import normalize_output_config
+
+    output_config = {"effort": "high", "format": {"type": "json_schema", "schema": {"type": "object"}}}
+    assert normalize_output_config(output_config) == output_config
+
+
+def test_image_block_url_source_conversion() -> None:
+    """A url-sourced image in plain user content forwards the url rather than a data uri."""
+    params = MessagesParams(
+        model="claude-3-5-sonnet",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "url", "url": "https://example.test/a.png"}},
+                ],
+            }
+        ],
+        max_tokens=1024,
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["messages"][0]["content"] == [
+        {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}
+    ]
+
+
+def test_assistant_blocks_last_non_empty_thinking_signature_wins() -> None:
+    """Anthropic sends one thinking block per turn, so a hand-built multi-block turn keeps one.
+
+    The text still concatenates the way multiple text blocks do. Only a signature that pairs
+    with the whole concatenation would be meaningful, and none does, so this records the
+    chosen behavior rather than claiming the pairing survives.
+    """
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "first ", "signature": "sig-1"},
+            {"type": "thinking", "thinking": "second", "signature": "sig-2"},
+        ]
+    )
+    assert result[0]["reasoning_content"] == "first second"
+    assert result[0]["extra_content"] == {"anthropic": {"signature": "sig-2"}}
+
+
+def test_user_blocks_tool_result_content_source_document_flattened_to_text() -> None:
+    """A content-source document carries text already, so it becomes a text part."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "content",
+                            "content": [{"type": "text", "text": "page one"}, {"type": "text", "text": " page two"}],
+                        },
+                    },
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "text", "text": "page one page two"}]
+
+
+def test_user_blocks_tool_result_string_content_source_document() -> None:
+    """The content source also accepts a bare string."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "document", "source": {"type": "content", "content": "inline body"}},
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "text", "text": "inline body"}]
+
+
+def test_user_blocks_tool_result_content_source_without_blocks_is_empty_text() -> None:
+    """A content source of an unexpected type flattens to empty rather than raising."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "document", "source": {"type": "content", "content": 42}},
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "text", "text": ""}]
+
+
+def test_user_blocks_tool_result_document_without_payload_raises() -> None:
+    """A document source with no data and no url is rejected, not sent as an empty attachment."""
+    with pytest.raises(InvalidRequestError, match="carries no payload"):
+        _convert_user_blocks_to_openai(
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": [
+                        {"type": "document", "source": {"type": "unknown_source"}},
+                    ],
+                },
+            ]
+        )

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -1780,7 +1780,7 @@ def test_assistant_blocks_thinking_signature_round_trips_to_anthropic() -> None:
             {"type": "text", "text": "done"},
         ]
     )
-    rebuilt = _build_anthropic_thinking_block({**converted[0], "reasoning": converted[0]["reasoning_content"]})
+    rebuilt = _build_anthropic_thinking_block(converted[0])
     assert rebuilt == {"type": "thinking", "thinking": "considering", "signature": "sig-abc"}
 
 
@@ -1895,6 +1895,54 @@ def test_user_blocks_tool_result_image_emitted_as_following_user_message() -> No
     assert result[0] == {"role": "tool", "tool_call_id": "call_1", "content": "here it is:"}
     assert result[1]["role"] == "user"
     assert result[1]["content"] == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}}]
+
+
+def test_user_blocks_parallel_tool_results_keep_the_tool_run_contiguous() -> None:
+    """Anthropic puts every parallel tool_result in one user turn, so the tool messages adjoin.
+
+    OpenAI requires each tool message to follow the assistant tool_calls turn with nothing in
+    between, so attachments wait until the run ends instead of landing after each result.
+    """
+
+    def shot(tool_use_id: str, label: str) -> dict[str, Any]:
+        return {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": [
+                {"type": "text", "text": label},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}},
+            ],
+        }
+
+    result = _convert_user_blocks_to_openai([shot("call_1", "one"), shot("call_2", "two")])
+    assert [message["role"] for message in result] == ["tool", "tool", "user"]
+    assert [message["content"] for message in result[:2]] == ["one", "two"]
+    assert result[2]["content"] == [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+    ]
+
+
+def test_user_blocks_held_attachments_lead_trailing_user_text() -> None:
+    """An attachment belongs with the tool result, so it precedes the user's own text."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "shot"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}},
+                ],
+            },
+            {"type": "text", "text": "what is in it"},
+        ]
+    )
+    assert [message["role"] for message in result] == ["tool", "user"]
+    assert result[1]["content"] == [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+        {"type": "text", "text": "what is in it"},
+    ]
 
 
 def test_user_blocks_tool_result_image_url_source_emitted_as_url() -> None:
@@ -2139,3 +2187,48 @@ def test_user_blocks_base64_image_without_data_raises() -> None:
     """An empty base64 payload would build a data uri with nothing in it."""
     with pytest.raises(InvalidRequestError, match="carries no data"):
         _convert_user_blocks_to_openai([{"type": "image", "source": {"type": "base64", "media_type": "image/png"}}])
+
+
+def test_output_config_without_format_passes_through_untouched() -> None:
+    """Every output_config field is optional, so an effort-only config is a valid request."""
+    assert normalize_output_config({"effort": "high"}) == {"effort": "high"}
+
+
+def test_output_config_empty_dict_passes_through_untouched() -> None:
+    """A config naming nothing has no shape to correct; the bridge is what rejects it."""
+    assert normalize_output_config({}) == {}
+
+
+def test_output_config_bare_type_without_schema_is_still_wrapped() -> None:
+    """A format object naming json_schema is wrapped even when its schema is missing."""
+    assert normalize_output_config({"type": "json_schema"}) == {"format": {"type": "json_schema"}}
+
+
+def test_output_format_effort_only_rejected_by_the_bridge() -> None:
+    """The bridge cannot translate a config that names no schema, so it raises rather than
+    forwarding a response_format that constrains nothing."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"effort": "high"},
+    )
+    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+        messages_params_to_completion_params(params)
+
+
+def test_thinking_signature_round_trip_reads_wire_reasoning_content() -> None:
+    """A message carrying only the wire spelling still rebuilds the whole thinking block."""
+    pytest.importorskip("anthropic")
+    from any_llm.providers.anthropic.utils import _extract_reasoning_text
+
+    assert _extract_reasoning_text({"reasoning_content": "considering"}) == "considering"
+
+
+def test_normalized_reasoning_wins_over_the_wire_spelling() -> None:
+    """The normalized field is the one any_llm populates, so it is read first."""
+    pytest.importorskip("anthropic")
+    from any_llm.providers.anthropic.utils import _extract_reasoning_text
+
+    message = {"reasoning": {"content": "normalized"}, "reasoning_content": "wire"}
+    assert _extract_reasoning_text(message) == "normalized"

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -1669,7 +1669,7 @@ def test_output_config_without_schema_raises() -> None:
         max_tokens=1024,
         output_format={"format": {"type": "json_schema"}},
     )
-    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+    with pytest.raises(InvalidRequestError, match="carries no JSON schema"):
         messages_params_to_completion_params(params)
 
 
@@ -1681,7 +1681,7 @@ def test_output_config_with_empty_schema_raises() -> None:
         max_tokens=1024,
         output_format={"type": "json_schema", "schema": {}},
     )
-    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+    with pytest.raises(InvalidRequestError, match="carries no JSON schema"):
         messages_params_to_completion_params(params)
 
 
@@ -1693,7 +1693,7 @@ def test_output_config_with_non_dict_schema_raises() -> None:
         max_tokens=1024,
         output_format={"type": "json_schema", "schema": "not-a-schema"},
     )
-    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+    with pytest.raises(InvalidRequestError, match="carries no JSON schema"):
         messages_params_to_completion_params(params)
 
 
@@ -2084,12 +2084,12 @@ def test_image_block_url_source_conversion() -> None:
     ]
 
 
-def test_assistant_blocks_last_non_empty_thinking_signature_wins() -> None:
-    """Anthropic sends one thinking block per turn, so a hand-built multi-block turn keeps one.
+def test_assistant_blocks_multiple_thinking_blocks_emit_no_signature() -> None:
+    """Interleaved thinking puts several blocks in one turn, and no signature signs the join.
 
-    The text still concatenates the way multiple text blocks do. Only a signature that pairs
-    with the whole concatenation would be meaningful, and none does, so this records the
-    chosen behavior rather than claiming the pairing survives.
+    The text still concatenates the way multiple text blocks do, since that is what the
+    backend reads. Emitting one of the signatures would pair it with text it does not cover,
+    which Anthropic rejects on replay.
     """
     result = _convert_assistant_blocks_to_openai(
         [
@@ -2098,7 +2098,7 @@ def test_assistant_blocks_last_non_empty_thinking_signature_wins() -> None:
         ]
     )
     assert result[0]["reasoning_content"] == "first second"
-    assert result[0]["extra_content"] == {"anthropic": {"signature": "sig-2"}}
+    assert "extra_content" not in result[0]
 
 
 def test_user_blocks_tool_result_content_source_document_flattened_to_text() -> None:
@@ -2204,16 +2204,41 @@ def test_output_config_bare_type_without_schema_is_still_wrapped() -> None:
     assert normalize_output_config({"type": "json_schema"}) == {"format": {"type": "json_schema"}}
 
 
-def test_output_format_effort_only_rejected_by_the_bridge() -> None:
-    """The bridge cannot translate a config that names no schema, so it raises rather than
-    forwarding a response_format that constrains nothing."""
+def test_output_format_effort_only_leaves_response_format_unset() -> None:
+    """An effort-only config asks for no structured output, so there is nothing to translate."""
     params = MessagesParams(
         model="gpt-4o",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=1024,
         output_format={"effort": "high"},
     )
-    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+    assert "response_format" not in messages_params_to_completion_params(params)
+
+
+def test_output_format_effort_beside_a_schema_is_ignored_not_rejected() -> None:
+    """effort gets the same treatment in both shapes: ignored, never a reason to reject."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"effort": "high", "format": {"type": "json_schema", "schema": {"type": "object"}}},
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {"name": "structured_output", "schema": {"type": "object"}},
+    }
+
+
+def test_output_format_naming_a_format_without_a_schema_raises() -> None:
+    """Naming a format is asking for structured output, which needs a schema to translate."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"format": {"type": "json_schema"}},
+    )
+    with pytest.raises(InvalidRequestError, match="carries no JSON schema"):
         messages_params_to_completion_params(params)
 
 
@@ -2232,3 +2257,30 @@ def test_normalized_reasoning_wins_over_the_wire_spelling() -> None:
 
     message = {"reasoning": {"content": "normalized"}, "reasoning_content": "wire"}
     assert _extract_reasoning_text(message) == "normalized"
+
+
+def test_user_blocks_base64_document_without_data_raises() -> None:
+    """An empty base64 payload would build a data uri with nothing in it, like the image case."""
+    with pytest.raises(InvalidRequestError, match="carries no data"):
+        _convert_user_blocks_to_openai(
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": [{"type": "document", "source": {"type": "base64", "media_type": "application/pdf"}}],
+                },
+            ]
+        )
+
+
+def test_assistant_blocks_redacted_thinking_is_dropped() -> None:
+    """redacted_thinking carries no text to join and has no wire field, so it is left out."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "redacted_thinking", "data": "encrypted"},
+            {"type": "text", "text": "answer"},
+        ]
+    )
+    assert result[0]["content"] == "answer"
+    assert "reasoning_content" not in result[0]
+    assert "extra_content" not in result[0]

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -2127,3 +2127,15 @@ def test_output_config_non_object_format_raises() -> None:
     """A format key that is not the object it has to be is rejected, not re-nested."""
     with pytest.raises(InvalidRequestError, match="non-object format value"):
         normalize_output_config({"format": "json_schema", "schema": {"type": "object"}})
+
+
+def test_user_blocks_image_without_payload_raises() -> None:
+    """An image source with neither data nor a url is rejected, like the document converter."""
+    with pytest.raises(InvalidRequestError, match="carries no payload"):
+        _convert_user_blocks_to_openai([{"type": "image", "source": {"type": "unknown_source"}}])
+
+
+def test_user_blocks_base64_image_without_data_raises() -> None:
+    """An empty base64 payload would build a data uri with nothing in it."""
+    with pytest.raises(InvalidRequestError, match="carries no data"):
+        _convert_user_blocks_to_openai([{"type": "image", "source": {"type": "base64", "media_type": "image/png"}}])

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -3,6 +3,9 @@
 import json
 from typing import Any
 
+import pytest
+
+from any_llm.exceptions import InvalidRequestError
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -31,7 +34,9 @@ from any_llm.types.messages import (
 from any_llm.utils.messages_compat import (
     StreamingState,
     _cached_tokens_from_usage,
+    _convert_assistant_blocks_to_openai,
     _convert_system_to_openai,
+    _convert_user_blocks_to_openai,
     chat_completion_chunk_to_message_stream_events,
     chat_completion_to_message_response,
     close_open_blocks,
@@ -1121,7 +1126,6 @@ def test_user_blocks_tool_result_with_list_content() -> None:
                 "content": [
                     {"type": "text", "text": "Result: "},
                     {"type": "text", "text": "42"},
-                    {"type": "image", "data": "ignored"},
                 ],
             },
         ]
@@ -1639,3 +1643,360 @@ def test_streaming_usage_with_zero_tokens() -> None:
     chat_completion_chunk_to_message_stream_events(chunk, state)
     assert state.input_tokens == 100
     assert state.output_tokens == 50
+
+
+def test_output_config_bare_format_object_translated_to_json_schema_response_format() -> None:
+    """The bare Anthropic format object, without the output_config wrapper, is accepted."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"type": "json_schema", "schema": {"title": "City", "type": "object"}},
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {"name": "City", "schema": {"title": "City", "type": "object"}},
+    }
+
+
+def test_output_config_without_schema_raises() -> None:
+    """A dict with no schema in either shape is rejected instead of forwarding an empty schema."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"format": {"type": "json_schema"}},
+    )
+    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+        messages_params_to_completion_params(params)
+
+
+def test_output_config_with_empty_schema_raises() -> None:
+    """An explicitly empty schema constrains nothing, so it is rejected rather than forwarded."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"type": "json_schema", "schema": {}},
+    )
+    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+        messages_params_to_completion_params(params)
+
+
+def test_output_config_with_non_dict_schema_raises() -> None:
+    """A schema of the wrong type is rejected rather than forwarded as-is."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        output_format={"type": "json_schema", "schema": "not-a-schema"},
+    )
+    with pytest.raises(InvalidRequestError, match="no JSON schema"):
+        messages_params_to_completion_params(params)
+
+
+def test_tool_choice_disable_parallel_tool_use_sets_parallel_tool_calls_false() -> None:
+    """Anthropic's sequential-tool-use switch becomes the OpenAI parallel_tool_calls flag."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        tool_choice={"type": "auto", "disable_parallel_tool_use": True},
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["tool_choice"] == "auto"
+    assert result["parallel_tool_calls"] is False
+
+
+def test_tool_choice_disable_parallel_tool_use_applies_to_any_type() -> None:
+    """The flag is independent of the tool_choice type it arrived on."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        tool_choice={"type": "any", "disable_parallel_tool_use": True},
+    )
+    result = messages_params_to_completion_params(params)
+    assert result["tool_choice"] == "required"
+    assert result["parallel_tool_calls"] is False
+
+
+def test_tool_choice_without_disable_parallel_tool_use_omits_parallel_tool_calls() -> None:
+    """A tool_choice that does not disable parallel use leaves the OpenAI flag unset."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        tool_choice={"type": "auto"},
+    )
+    result = messages_params_to_completion_params(params)
+    assert "parallel_tool_calls" not in result
+
+
+def test_tool_choice_disable_parallel_tool_use_false_omits_parallel_tool_calls() -> None:
+    """An explicit false is not a request to disable parallel tool use."""
+    params = MessagesParams(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+        tool_choice={"type": "auto", "disable_parallel_tool_use": False},
+    )
+    result = messages_params_to_completion_params(params)
+    assert "parallel_tool_calls" not in result
+
+
+def test_assistant_blocks_thinking_becomes_reasoning_content() -> None:
+    """A replayed thinking block survives as reasoning_content next to the visible text."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "2 plus 2 is 4", "signature": "sig-abc"},
+            {"type": "text", "text": "4"},
+        ]
+    )
+    assert result[0]["content"] == "4"
+    assert result[0]["reasoning_content"] == "2 plus 2 is 4"
+
+
+def test_assistant_blocks_thinking_signature_travels_in_extra_content() -> None:
+    """The signature uses the extra_content side-channel the Anthropic provider reads."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "considering", "signature": "sig-abc"},
+        ]
+    )
+    assert result[0]["extra_content"] == {"anthropic": {"signature": "sig-abc"}}
+
+
+def test_assistant_blocks_thinking_signature_round_trips_to_anthropic() -> None:
+    """The emitted message is what the Anthropic provider needs to rebuild the block whole."""
+    pytest.importorskip("anthropic")
+    from any_llm.providers.anthropic.utils import _build_anthropic_thinking_block
+
+    converted = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "considering", "signature": "sig-abc"},
+            {"type": "text", "text": "done"},
+        ]
+    )
+    rebuilt = _build_anthropic_thinking_block({**converted[0], "reasoning": converted[0]["reasoning_content"]})
+    assert rebuilt == {"type": "thinking", "thinking": "considering", "signature": "sig-abc"}
+
+
+def test_assistant_blocks_thinking_without_signature_omits_extra_content() -> None:
+    """A thinking block with no signature still keeps its text and adds no side-channel."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "considering"},
+        ]
+    )
+    assert result[0]["reasoning_content"] == "considering"
+    assert "extra_content" not in result[0]
+
+
+def test_assistant_blocks_thinking_with_empty_signature_omits_extra_content() -> None:
+    """An empty signature is not a signature Anthropic would accept back."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "considering", "signature": ""},
+        ]
+    )
+    assert "extra_content" not in result[0]
+
+
+def test_assistant_blocks_multiple_thinking_blocks_concatenated() -> None:
+    """Several thinking blocks join the same way several text blocks do."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "first "},
+            {"type": "thinking", "thinking": "second"},
+        ]
+    )
+    assert result[0]["reasoning_content"] == "first second"
+
+
+def test_assistant_blocks_empty_thinking_omits_reasoning_content() -> None:
+    """A thinking block with no text adds no empty reasoning_content."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": ""},
+            {"type": "text", "text": "hello"},
+        ]
+    )
+    assert "reasoning_content" not in result[0]
+
+
+def test_assistant_blocks_thinking_alongside_tool_use_preserved() -> None:
+    """The agent-loop shape, thinking plus a tool call, keeps both halves."""
+    result = _convert_assistant_blocks_to_openai(
+        [
+            {"type": "thinking", "thinking": "need the weather", "signature": "sig-1"},
+            {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"city": "London"}},
+        ]
+    )
+    assert result[0]["content"] is None
+    assert result[0]["reasoning_content"] == "need the weather"
+    assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_user_blocks_tool_result_is_error_preserved() -> None:
+    """A failed tool result stays distinguishable from a successful one."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "is_error": True,
+                "content": "permission denied",
+            },
+        ]
+    )
+    assert result[0]["role"] == "tool"
+    assert result[0]["content"] == "permission denied"
+    assert result[0]["is_error"] is True
+
+
+def test_user_blocks_tool_result_without_is_error_omits_flag() -> None:
+    """A successful tool result carries no error marker."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {"type": "tool_result", "tool_use_id": "call_1", "content": "ok"},
+        ]
+    )
+    assert "is_error" not in result[0]
+
+
+def test_user_blocks_tool_result_is_error_false_omits_flag() -> None:
+    """An explicit false is not an error marker."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {"type": "tool_result", "tool_use_id": "call_1", "is_error": False, "content": "ok"},
+        ]
+    )
+    assert "is_error" not in result[0]
+
+
+def test_user_blocks_tool_result_image_emitted_as_following_user_message() -> None:
+    """An image in a tool result rides in a user message directly after the tool message."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "here it is:"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}},
+                ],
+            },
+        ]
+    )
+    assert len(result) == 2
+    assert result[0] == {"role": "tool", "tool_call_id": "call_1", "content": "here it is:"}
+    assert result[1]["role"] == "user"
+    assert result[1]["content"] == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}}]
+
+
+def test_user_blocks_tool_result_image_url_source_emitted_as_url() -> None:
+    """A url-sourced image in a tool result forwards the url rather than a data uri."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "image", "source": {"type": "url", "url": "https://example.test/a.png"}},
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}]
+
+
+def test_user_blocks_tool_result_text_document_emitted_as_text_part() -> None:
+    """A text-sourced document has no OpenAI file equivalent, so it becomes a text part."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "result text"},
+                    {"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": "DOCBODY"}},
+                ],
+            },
+        ]
+    )
+    assert result[0]["content"] == "result text"
+    assert result[1]["content"] == [{"type": "text", "text": "DOCBODY"}]
+
+
+def test_user_blocks_tool_result_base64_document_emitted_as_file_part() -> None:
+    """A base64 document becomes the OpenAI file part the Anthropic provider maps back."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {"type": "base64", "media_type": "application/pdf", "data": "cGRm"},
+                    },
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "file", "file": {"file_data": "data:application/pdf;base64,cGRm"}}]
+
+
+def test_user_blocks_tool_result_url_document_emitted_as_file_part() -> None:
+    """A url-sourced document forwards the url in the same file part shape."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "document", "source": {"type": "url", "url": "https://example.test/a.pdf"}},
+                ],
+            },
+        ]
+    )
+    assert result[1]["content"] == [{"type": "file", "file": {"file_data": "https://example.test/a.pdf"}}]
+
+
+def test_user_blocks_tool_result_unknown_block_type_dropped() -> None:
+    """A tool result block that is neither text nor a known attachment adds no content part."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "kept"},
+                    {"type": "mystery_block", "data": "x"},
+                ],
+            },
+        ]
+    )
+    assert len(result) == 1
+    assert result[0]["content"] == "kept"
+
+
+def test_user_blocks_tool_result_attachment_keeps_conversation_order() -> None:
+    """Text before a tool result still flushes first, and the attachment follows the tool message."""
+    result = _convert_user_blocks_to_openai(
+        [
+            {"type": "text", "text": "before"},
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "shot"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}},
+                ],
+            },
+        ]
+    )
+    assert [message["role"] for message in result] == ["user", "tool", "user"]
+    assert result[0]["content"] == [{"type": "text", "text": "before"}]

--- a/tests/unit/test_messages_compat.py
+++ b/tests/unit/test_messages_compat.py
@@ -43,6 +43,7 @@ from any_llm.utils.messages_compat import (
     messages_params_to_completion_params,
     split_cached_input_tokens,
 )
+from any_llm.utils.structured_output import normalize_output_config
 
 
 def test_basic_text_message_conversion() -> None:
@@ -2004,8 +2005,6 @@ def test_user_blocks_tool_result_attachment_keeps_conversation_order() -> None:
 
 def test_output_config_bare_format_object_normalized_for_the_native_path() -> None:
     """The shared normalizer wraps the bare object so the native output_config nesting holds."""
-    from any_llm.utils.structured_output import normalize_output_config
-
     assert normalize_output_config({"type": "json_schema", "schema": {"type": "object"}}) == {
         "format": {"type": "json_schema", "schema": {"type": "object"}}
     }
@@ -2013,8 +2012,6 @@ def test_output_config_bare_format_object_normalized_for_the_native_path() -> No
 
 def test_output_config_wrapper_preserved_by_normalizer() -> None:
     """An already-nested output_config keeps its siblings, such as effort."""
-    from any_llm.utils.structured_output import normalize_output_config
-
     output_config = {"effort": "high", "format": {"type": "json_schema", "schema": {"type": "object"}}}
     assert normalize_output_config(output_config) == output_config
 
@@ -2124,3 +2121,9 @@ def test_user_blocks_tool_result_document_without_payload_raises() -> None:
                 },
             ]
         )
+
+
+def test_output_config_non_object_format_raises() -> None:
+    """A format key that is not the object it has to be is rejected, not re-nested."""
+    with pytest.raises(InvalidRequestError, match="non-object format value"):
+        normalize_output_config({"format": "json_schema", "schema": {"type": "object"}})


### PR DESCRIPTION
## Description

Fixes six encode-side losses in `any_llm/utils/messages_compat.py`, the bridge that runs when the Anthropic Messages API is served by a non-Anthropic backend. The native Anthropic provider overrides `_amessages` and never reaches this module, so the losses only hit bridged providers, which is also the path Otari's `POST /v1/messages` takes.

They share a failure mode: the request returns 200 and the field is simply gone. Nothing raises, nothing warns, and the caller sees a slightly worse answer instead of an error.

### What each one was, and what it now does

**1. Assistant `thinking` blocks were dropped from replayed history.** `_convert_assistant_blocks_to_openai` handled `text` and `tool_use` and ignored everything else, so a multi-turn loop replaying extended-thinking history forwarded only the visible text.

This made the bridge lossy in one direction only. `chat_completion_to_message_response` builds a `ThinkingBlock` out of an upstream `reasoning` field, so a caller could read thinking out of a Messages response from this bridge and then had nowhere to put it back on the next request.

The block now becomes `reasoning_content` on the assistant message. That is the first entry in `REASONING_FIELD_NAMES`, and the field `deepseek`'s `_reinject_reasoning_content` restores for exactly this reason, on the grounds it states there: of the reasoning fields any-llm knows about, `reasoning_content` is the one that belongs on the wire. The normalized `reasoning` field cannot carry it, because `AnyLLM.acompletion` strips `reasoning` when dumping a message (`model_dump(exclude_none=True, exclude={"reasoning"})`) as an any-llm extension to the OpenAI spec. I confirmed both halves of that against a local server on `main`: `reasoning` does not reach the wire, `extra_content` does.

The Anthropic `signature` travels in `extra_content["anthropic"]["signature"]`, which is the exact key `anthropic`'s `_extract_anthropic_thinking_signature` already reads, so a bridged request that later reaches an Anthropic-native provider can rebuild the block whole. `test_assistant_blocks_thinking_signature_round_trips_to_anthropic` feeds the converted message straight into `_build_anthropic_thinking_block` and asserts the original block comes back.

**2. `disable_parallel_tool_use` was dropped.** `_convert_tool_choice_to_openai` reads `type` and nothing else, so `{"type": "auto", "disable_parallel_tool_use": true}` forwarded bare `"auto"`. Anthropic keeps the switch inside `tool_choice`; OpenAI keeps it as a sibling. It is now mapped to `parallel_tool_calls: false` in the caller, since the conversion function returns `str | dict` and cannot also return a sibling key. Anthropic accepts the flag on every `tool_choice` type, so the mapping does not depend on which type was resolved.

**3. `is_error` on tool results was dropped.** The `tool_result` branch built `{role, tool_call_id, content}` and discarded the rest, which left a failed tool call indistinguishable from a successful one whose output happened to read like an error. The marker now stays on the tool message. OpenAI has no field for it and the OpenAI SDK forwards unknown message keys verbatim, which is the same property `deepseek/utils.py` documents and relies on, so it reaches a backend that understands it and is inert on one that does not.

**4 and 5. Image and document bytes inside tool results were deleted.** When `tool_result.content` was a list, only `type: text` blocks were concatenated. A browser agent returning a screenshot, or a file-reading agent returning a document, kept the text prefix and lost the payload. Notably the same bytes survive in plain user content, so this was specific to `tool_result`.

OpenAI accepts text only on a `role: tool` message, so the two halves cannot ride together. The text stays on the tool message and the attachments follow immediately as a `user` message, which keeps them at the same point in the conversation. The block mappings are the inverse of `anthropic`'s `_convert_content_for_anthropic`, which is where this repo already pairs these shapes: Anthropic `image` with OpenAI `image_url`, Anthropic `document` with an OpenAI `file` part carrying a `file_data` data URI. A `text`-sourced document has no `file` equivalent and its payload is already text, so it becomes a text part rather than a data URI wrapping plain text.

**6. A near-miss `output_format` shape forwarded an empty schema.** `_output_config_to_response_format` read `output_config["format"]["schema"]`. A caller passing the bare format object, `{"type": "json_schema", "schema": {...}}`, hit `.get("format") or {}` and got `response_format` on the wire with `"schema": {}`: present, and constraining nothing. Anthropic nests that object under `output_config.format`, so a caller holding the inner object is one level away from the documented shape, which makes this an easy mistake with a silent result.

Both shapes are now accepted. A dict that carries no schema in either shape raises `InvalidRequestError` instead of sending a `response_format` the caller believes is in force.

### One existing test changed

`test_user_blocks_tool_result_with_list_content` asserted the old behavior directly, with a block literally named `{"type": "image", "data": "ignored"}` and `assert len(result) == 1`. It is narrowed to the text-only case its name describes, and the attachment cases are covered by new tests.

### Behavior change worth calling out

Mapping `disable_parallel_tool_use` onto `parallel_tool_calls` makes a Messages request that
carries that flag fail on Gemini and Cohere, which raise `UnsupportedParameterError` for
`parallel_tool_calls` (`gemini/base.py:149`, `cohere/cohere.py:212`). Before this branch the flag
was dropped and the call succeeded with parallel tool use still allowed.

The failure is kept on purpose. The caller asked for sequential tool use, neither provider can
honor it, and silently ignoring it is the class of loss this PR exists to remove: an agent loop
that set the flag because it breaks on parallel calls would break later and less legibly. What is
fixed is the error itself, which used to name a parameter the caller never sent. `_amessages` now
catches that rejection and re-raises it as `tool_choice.disable_parallel_tool_use`, so the message
describes what was actually passed. Covered by
`test_amessages_parallel_tool_calls_rejection_names_the_anthropic_parameter`.

### Notes for the reviewer

Two choices here are defensible more than one way, and I will change either if you prefer something else:

- `extra_content` reaches the wire on the generic OpenAI path. That is pre-existing behavior, not new: `acompletion` excludes only `reasoning` when dumping a message, and `deepseek` strips `extra_content` itself precisely because the shared path does not. I verified on `main` that a replayed `ChatCompletionMessage` already forwards `extra_content` today. Using it here keeps the signature inside any-llm's own carrier rather than inventing a second one, but if you would rather the generic OpenAI provider strip it the way `deepseek` does, that is a small follow-up.
- `is_error` is forwarded as a structured key, which a model cannot read directly. The alternative is folding an error marker into the tool message text so the model sees it. I picked the structured form because it does not mutate content the caller wrote.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1311

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)

## Verification

Reproduced all six against a local capture mock on `main` at 56d1e0c, then re-ran the same rig against this branch. Five runs per case, forwarded bodies byte-identical across runs, no API keys. The script is in the issue.

Before, on `main`:

```
1 thinking history      THINKPROBE 0/5   signature 0/5
2 disable_parallel      tool_choice="auto"  parallel_tool_calls=<absent>
3 is_error              is_error 0/5
4 tool_result image     png 0/5   image_url 0/5
5 tool_result document  DOCBODY 0/5
6 bare output_format    response_format.json_schema.schema == {}
```

After:

```
1 thinking history      THINKPROBE 5/5   signature 5/5
2 disable_parallel      tool_choice="auto"  parallel_tool_calls=False
3 is_error              is_error 5/5
4 tool_result image     png 5/5   image_url 5/5
5 tool_result document  DOCBODY 5/5
6 bare output_format    schema forwarded whole, 5/5
```

Controls unchanged in both directions: an image in plain user content still maps to `image_url` 5/5, the documented `output_config` shape still forwards its schema 5/5, and `completion(parallel_tool_calls=False)` still forwards the flag 5/5.

Checks:

- `uv run pre-commit run --all-files` clean, including mypy strict over 285 source files.
- `uv run pytest tests/unit`: 2194 passed, 69 skipped.
- Branch coverage on `src/any_llm/utils/messages_compat.py` is 100% (284 statements, 168 branches, 0 missed).

I did not run the live integration suite: I have no provider keys for it. The new regression test in `tests/unit/test_messages.py` drives the real OpenAI SDK and httpx against a local `ThreadingHTTPServer` and asserts the six fields on the bytes the server actually receives, following the pattern `test_sync_messages_streaming_consumes_response_on_a_single_event_loop` already uses. Happy to have the `run-integration-tests` label applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded output-format support for bare JSON schemas and native Anthropic requests.
  * Preserved assistant reasoning, signatures, tool-result errors, images and documents during message conversion.
  * Added support for disabling parallel tool calls.
  * Improved conversion of image URLs and document content.

* **Bug Fixes**
  * Added validation and clearer errors for missing or invalid output schemas and media sources.
  * Improved message ordering, unsupported attachment handling and Bedrock consecutive user messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
