### PR TITLE
fix(types): keep tool-call extra_content when a ChatCompletionMessage is dumped

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from anthropic import transform_schema
 from anthropic.types import (
@@ -29,18 +29,6 @@ from any_llm.types.completion import (
 )
 from any_llm.types.model import Model
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 DEFAULT_MAX_TOKENS = 8192
 REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
@@ -354,7 +342,7 @@ def _convert_response(response: Message) -> ChatCompletion:
         role="assistant",
         content="".join(content_parts),
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
-        tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls or None),
+        tool_calls=tool_calls or None,
         extra_content={"anthropic": {"signature": thinking_signature}} if thinking_signature else None,
     )
 

--- a/src/any_llm/providers/azure/utils.py
+++ b/src/any_llm/providers/azure/utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
 from azure.ai.inference.models import (
     ChatCompletions,
@@ -28,18 +28,6 @@ from any_llm.types.completion import (
 )
 from any_llm.types.model import Model
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _convert_response_format(
@@ -119,7 +107,7 @@ def _convert_response(response_data: ChatCompletions) -> ChatCompletion:
     message = ChatCompletionMessage(
         role="assistant",
         content=message_data.content,
-        tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+        tool_calls=tool_calls,
     )
 
     choice = Choice(

--- a/src/any_llm/providers/cerebras/utils.py
+++ b/src/any_llm/providers/cerebras/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
 from cerebras.cloud.sdk.types import ModelListResponse as CerebrasModelListResponse
 from cerebras.cloud.sdk.types.chat.chat_completion import ChatChunkResponse
@@ -15,18 +15,6 @@ from any_llm.types.completion import (
     Reasoning,
 )
 from any_llm.types.model import Model
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _create_openai_chunk_from_cerebras_chunk(chunk: ChatChunkResponse) -> ChatCompletionChunk:
@@ -139,7 +127,7 @@ def _convert_response(response_data: dict[str, Any]) -> ChatCompletion:
         message = ChatCompletionMessage(
             role=message_data.get("role", "assistant"),
             content=message_data.get("content"),
-            tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+            tool_calls=tool_calls,
             reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         )
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -47,19 +47,9 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
 
     from google import genai
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
 
     from any_llm.types.batch import Batch, BatchResult
     from any_llm.types.model import Model
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "minimal": 256,
@@ -248,7 +238,7 @@ class GoogleProvider(AnyLLM):
             message = ChatCompletionMessage(
                 role="assistant",
                 content=message_dict.get("content"),
-                tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+                tool_calls=tool_calls,
                 reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
             )
             from typing import Literal

--- a/src/any_llm/providers/groq/utils.py
+++ b/src/any_llm/providers/groq/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Literal, cast
 
 from groq.types import ModelListResponse as GroqModelListResponse
 from groq.types.chat import ChatCompletion as GroqChatCompletion
@@ -22,18 +22,6 @@ from any_llm.types.completion import (
     Reasoning,
 )
 from any_llm.types.model import Model
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _extract_groq_timing_details(usage: GroqCompletionUsage) -> dict[str, float]:
@@ -94,7 +82,7 @@ def to_chat_completion(response: GroqChatCompletion) -> ChatCompletion:
         msg = ChatCompletionMessage(
             role="assistant",
             content=message.content,
-            tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+            tool_calls=tool_calls,
             reasoning=Reasoning(content=cast("str", message.reasoning))
             if getattr(message, "reasoning", None)
             else None,

--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -42,16 +42,6 @@ DEFAULT_COMPLETION_WINDOW = f"{DEFAULT_TIMEOUT_HOURS}h"
 if TYPE_CHECKING:
     from mistralai.client.models import BatchJob, ListBatchJobsResponse
     from mistralai.client.models.embeddingresponse import EmbeddingResponse
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _convert_mistral_tool_calls_to_any_llm(
@@ -230,7 +220,7 @@ def _create_mistral_completion_from_response(
         message = ChatCompletionMessage(
             role="assistant",
             content=content,
-            tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls_final),
+            tool_calls=tool_calls_final,
             reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
             extra_content={"mistral": {"signature": thinking_signature}} if thinking_signature else None,
         )

--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
 from ollama import ChatResponse as OllamaChatResponse
 from ollama import EmbedResponse
@@ -27,18 +27,6 @@ from any_llm.types.completion import (
     Usage,
 )
 from any_llm.types.model import Model
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _convert_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -225,7 +213,7 @@ def _create_chat_completion_from_ollama_response(response: OllamaChatResponse) -
     message = ChatCompletionMessage(
         role="assistant",
         content=response_message.content,
-        tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", openai_tool_calls),
+        tool_calls=openai_tool_calls,
         reasoning=Reasoning(content=response_message.thinking) if response_message.thinking else None,
     )
 

--- a/src/any_llm/providers/sagemaker/utils.py
+++ b/src/any_llm/providers/sagemaker/utils.py
@@ -1,6 +1,6 @@
 import json
 from time import time
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
 from any_llm.types.completion import (
     ChatCompletion,
@@ -18,18 +18,6 @@ from any_llm.types.completion import (
     Function,
     Usage,
 )
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _convert_params(params: CompletionParams, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -91,7 +79,7 @@ def _convert_response(response: dict[str, Any], model: str) -> ChatCompletion:
             message = ChatCompletionMessage(
                 role=message_data.get("role", "assistant"),
                 content=message_data.get("content"),
-                tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+                tool_calls=tool_calls,
             )
 
             finish_reason = choice_data.get("finish_reason", "stop")

--- a/src/any_llm/providers/xai/utils.py
+++ b/src/any_llm/providers/xai/utils.py
@@ -1,6 +1,6 @@
 import uuid
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal
 
 from xai_sdk.chat import Chunk as XaiChunk
 from xai_sdk.chat import Response as XaiResponse
@@ -24,18 +24,6 @@ from any_llm.types.completion import (
     Reasoning,
 )
 from any_llm.types.model import Model
-
-if TYPE_CHECKING:
-    from openai.types.chat.chat_completion_message_custom_tool_call import (
-        ChatCompletionMessageCustomToolCall,
-    )
-    from openai.types.chat.chat_completion_message_function_tool_call import (
-        ChatCompletionMessageFunctionToolCall as OpenAIChatCompletionMessageFunctionToolCall,
-    )
-
-    ChatCompletionMessageToolCallType = (
-        OpenAIChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    )
 
 
 def _map_xai_role_to_openai(
@@ -123,7 +111,7 @@ def _convert_xai_completion_to_anyllm_response(response: XaiResponse) -> ChatCom
     message = ChatCompletionMessage(
         role="assistant",
         content=response.content,
-        tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
+        tool_calls=tool_calls,
         reasoning=reasoning,
     )
 

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -57,6 +57,7 @@ class Reasoning(BaseModel):
 
 
 class ChatCompletionMessage(OpenAIChatCompletionMessage):
+    tool_calls: list["ChatCompletionMessageToolCall"] | None = None  # type: ignore[assignment]
     reasoning: Reasoning | None = None
     annotations: list[dict[str, Any]] | None = None  # type: ignore[assignment]
     extra_content: dict[str, Any] | None = None

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -56,8 +56,25 @@ class Reasoning(BaseModel):
         return self.content
 
 
+class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionToolCall):
+    """Extended tool call type that includes extra_content for provider-specific data.
+
+    The extra_content field is used to store provider-specific metadata that needs
+    to be preserved across multi-turn conversations. For example, Gemini 3 models
+    require thought_signature to be passed back with function calls.
+
+    Example extra_content structure for Gemini:
+        {"google": {"thought_signature": "<base64-encoded-signature>"}}
+    """
+
+    extra_content: dict[str, Any] | None = None
+
+
+ChatCompletionMessageToolCall = ChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
+
+
 class ChatCompletionMessage(OpenAIChatCompletionMessage):
-    tool_calls: list["ChatCompletionMessageToolCall"] | None = None  # type: ignore[assignment]
+    tool_calls: list[ChatCompletionMessageToolCall] | None = None  # type: ignore[assignment]
     reasoning: Reasoning | None = None
     annotations: list[dict[str, Any]] | None = None  # type: ignore[assignment]
     extra_content: dict[str, Any] | None = None
@@ -126,21 +143,6 @@ class ChatCompletionChunk(OpenAIChatCompletionChunk):
     service_tier: str | None = None  # type: ignore[assignment]
 
 
-class ChatCompletionMessageFunctionToolCall(OpenAIChatCompletionMessageFunctionToolCall):
-    """Extended tool call type that includes extra_content for provider-specific data.
-
-    The extra_content field is used to store provider-specific metadata that needs
-    to be preserved across multi-turn conversations. For example, Gemini 3 models
-    require thought_signature to be passed back with function calls.
-
-    Example extra_content structure for Gemini:
-        {"google": {"thought_signature": "<base64-encoded-signature>"}}
-    """
-
-    extra_content: dict[str, Any] | None = None
-
-
-ChatCompletionMessageToolCall = ChatCompletionMessageFunctionToolCall | OpenAIChatCompletionMessageToolCall
 Function = OpenAIFunction
 CompletionUsage = OpenAICompletionUsage
 CompletionTokensDetails = OpenAICompletionTokensDetails

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -26,8 +26,11 @@ from any_llm.providers.gemini.utils import (
 )
 from any_llm.types.completion import (
     ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
     CompletionParams,
     CompletionTokensDetails,
+    Function,
     PromptTokensDetails,
     ReasoningEffort,
 )
@@ -1554,6 +1557,30 @@ def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     assert assistant_message.parts is not None
     assert len(assistant_message.parts) == 1
     assert assistant_message.parts[0].thought_signature == original_bytes
+
+
+def test_convert_messages_replayed_message_object_keeps_thought_signature() -> None:
+    """Replaying a returned ChatCompletionMessage (dumped as acompletion does) must keep the signature."""
+    base64_signature = base64.b64encode(b"test-signature-bytes").decode("utf-8")
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id="call_123",
+                type="function",
+                function=Function(name="get_weather", arguments='{"location": "Paris"}'),
+                extra_content={"google": {"thought_signature": base64_signature}},
+            )
+        ],
+    )
+    replayed = message.model_dump(exclude_none=True, exclude={"reasoning"})
+
+    formatted_messages, _ = _convert_messages([{"role": "user", "content": "What is the weather?"}, replayed])
+
+    assert replayed["tool_calls"][0]["extra_content"] == {"google": {"thought_signature": base64_signature}}
+    assert formatted_messages[1].parts is not None
+    assert formatted_messages[1].parts[0].thought_signature == b"test-signature-bytes"
 
 
 def test_convert_messages_with_base64_image() -> None:

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -8,13 +8,22 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from pydantic import ValidationError
 from typing_extensions import override
 
 from any_llm import AnyLLM
 from any_llm.api import acompletion, aresponses, completion, responses
 from any_llm.constants import LLMProvider
 from any_llm.exceptions import UnsupportedParameterError
-from any_llm.types.completion import ChatCompletion, CompletionParams
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+    Choice,
+    CompletionParams,
+    Function,
+    Reasoning,
+)
 
 _PYTHON_314_INCOMPATIBLE_PROVIDERS = {"voyage", "watsonx"}
 
@@ -159,6 +168,107 @@ async def test_acompletion_rejects_prompt_cache_key_for_unsupported_provider() -
         )
 
     client.converse.assert_not_called()
+
+
+def _signed_tool_call_message() -> ChatCompletionMessage:
+    return ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        reasoning=Reasoning(content="thinking"),
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id="call_1",
+                type="function",
+                function=Function(name="get_weather", arguments='{"city": "Paris"}'),
+                extra_content={"google": {"thought_signature": "c2ln"}},
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_replays_message_object_with_tool_call_extra_content() -> None:
+    # A returned message appended to the history is dumped to a dict; the tool call keeps its
+    # provider metadata, while reasoning and unset fields stay out of the replayed message.
+    provider = AnyLLM.create("openai", api_key="sk-test")
+    with patch.object(provider, "_acompletion", new=AsyncMock(return_value=Mock(spec=ChatCompletion))) as mock_ac:
+        await provider.acompletion(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Weather in Paris?"}, _signed_tool_call_message()],
+        )
+
+    params = mock_ac.call_args.args[0]
+    assert isinstance(params, CompletionParams)
+    assert params.messages[1] == {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                "extra_content": {"google": {"thought_signature": "c2ln"}},
+            }
+        ],
+    }
+
+
+def test_chat_completion_message_tool_calls_validate_from_dicts() -> None:
+    # Dict input still resolves by ``type``: function calls become any-llm's extended type,
+    # custom calls stay OpenAI's, and a call with no ``type`` is rejected as before.
+    message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                    "extra_content": {"google": {"thought_signature": "c2ln"}},
+                },
+                {"id": "call_2", "type": "custom", "custom": {"name": "c", "input": "raw"}},
+            ],
+        }
+    )
+    assert message.tool_calls is not None
+    function_call, custom_call = message.tool_calls
+    assert isinstance(function_call, ChatCompletionMessageFunctionToolCall)
+    assert function_call.extra_content == {"google": {"thought_signature": "c2ln"}}
+    assert not isinstance(custom_call, ChatCompletionMessageFunctionToolCall)
+    assert custom_call.type == "custom"
+
+    with pytest.raises(ValidationError):
+        ChatCompletionMessage.model_validate(
+            {"role": "assistant", "tool_calls": [{"id": "call_3", "function": {"name": "f", "arguments": "{}"}}]}
+        )
+
+
+def test_chat_completion_round_trips_tool_call_extra_content() -> None:
+    completion_response = ChatCompletion(
+        id="id",
+        model="m",
+        created=1,
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="tool_calls", message=_signed_tool_call_message())],
+    )
+
+    restored = ChatCompletion.model_validate_json(completion_response.model_dump_json())
+
+    tool_calls = restored.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert isinstance(tool_calls[0], ChatCompletionMessageFunctionToolCall)
+    assert tool_calls[0].extra_content == {"google": {"thought_signature": "c2ln"}}
+
+    unsigned = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id="call_1", type="function", function=Function(name="f", arguments="{}")
+            )
+        ],
+    )
+    assert "extra_content" not in unsigned.model_dump(exclude_none=True)["tool_calls"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

#1153 added `extra_content` to `ChatCompletionMessageFunctionToolCall` so gemini's `thought_signature` rides along with each tool call and gets replayed on the next turn (`gemini/utils.py:_convert_messages` reads it back). The instance carries it — but `ChatCompletionMessage` never re-declared `tool_calls`, so the field kept OpenAI's declared type, and `model_dump()` serializes against that: the subclass field is dropped.

`acompletion` dumps replayed message objects exactly this way (`any_llm.py:756`), so the documented loop — append `response.choices[0].message`, add the tool result, call again — reaches gemini with no signature. The converter then falls back to the `skip_thought_signature_validator` sentinel: no 400, but the model's reasoning context for that call is gone. `tests/integration/test_agent_loop.py` builds its history the same way. The streaming side was already right — `ChoiceDelta.tool_calls` was re-annotated in #1153; only the non-streaming message missed it.

The fix re-declares `tool_calls` with the any-llm union that already exists (`ChatCompletionMessageToolCall`), as a forward reference since the alias sits below the class. One line; validation from plain dicts is unchanged (function calls resolve to the any-llm subclass, `custom` tool calls to OpenAI's), and `ChatCompletion` round-trips still carry `extra_content`.

Nine converters had been casting their tool-call lists into the OpenAI-typed field through a `TYPE_CHECKING` alias (`ChatCompletionMessageToolCallType`). With the field typed as any-llm's own union those lists match directly and the casts point the wrong way for mypy, so the second commit deletes the aliases and casts — 9 files, no behavior change.

Verified live on `gemini-3-flash-preview`: turn 1 returns a `get_weather` call with a signature; the message object is appended and replayed with the tool result; the outgoing `Part.thought_signature` is captured at the SDK call:

| | outgoing thought_signature | equals the one returned |
|---|---|---|
| before | `skip_thought_signature_validator` sentinel | no |
| after | real signature | yes |

The test dumps a signed `ChatCompletionMessage` the way `acompletion` does and asserts the gemini converter emits the real signature. It fails on main.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Completes #1153; related to the open RFC #1053.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of Google thought signatures when replaying saved chat messages.
  * Improved consistency when handling tool calls across supported providers.
  * Preserved tool-call metadata, including additional content, through message conversion and JSON round-tripping.
  * Improved validation and handling of malformed tool-call data.

* **Tests**
  * Added regression coverage for tool-call metadata, validation, serialisation, and thought-signature preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->