### PR TITLE
fix(gemini): name tool results from the tool_call they answer

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -198,6 +198,7 @@ def _convert_messages(
     """Convert messages to Google GenAI format."""
     formatted_messages = []
     system_instruction = None
+    tool_names: dict[str, str] = {}  # tool_call id -> function name, for tool results that carry no name
 
     for message in messages:
         if message["role"] == "system":
@@ -225,6 +226,7 @@ def _convert_messages(
                 parts = []
                 for i, tool_call in enumerate(message["tool_calls"]):
                     function_call = tool_call["function"]
+                    tool_names[tool_call.get("id", "")] = function_call["name"]
                     args = json.loads(function_call["arguments"]) if function_call["arguments"] else {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)
@@ -251,16 +253,13 @@ def _convert_messages(
 
             formatted_messages.append(types.Content(role="model", parts=parts))
         elif message["role"] == "tool":
+            name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
             try:
                 content_json = json.loads(message["content"])
-                part = types.Part.from_function_response(
-                    name=message.get("name", "unknown"), response=_normalize_tool_response(content_json)
-                )
+                part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content_json))
                 formatted_messages.append(types.Content(role="function", parts=[part]))
             except json.JSONDecodeError:
-                part = types.Part.from_function_response(
-                    name=message.get("name", "unknown"), response={"result": message["content"]}
-                )
+                part = types.Part.from_function_response(name=name, response={"result": message["content"]})
                 formatted_messages.append(types.Content(role="function", parts=[part]))
 
     return formatted_messages, system_instruction

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -226,7 +226,8 @@ def _convert_messages(
                 parts = []
                 for i, tool_call in enumerate(message["tool_calls"]):
                     function_call = tool_call["function"]
-                    tool_names[tool_call.get("id", "")] = function_call["name"]
+                    if tool_call_id := tool_call.get("id"):
+                        tool_names[tool_call_id] = function_call["name"]
                     args = json.loads(function_call["arguments"]) if function_call["arguments"] else {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1570,6 +1570,12 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
         },
         {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
         {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"type": "function", "function": {"name": "no_id", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "{}"},  # neither side carries an id: nothing to resolve
     ]
 
     formatted_messages, _ = _convert_messages(messages)
@@ -1580,7 +1586,7 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
             assert content.parts is not None
             assert content.parts[0].function_response is not None
             names.append(content.parts[0].function_response.name)
-    assert names == ["get_population", "get_temperature"]
+    assert names == ["get_population", "get_temperature", "unknown"]
 
 
 def test_convert_messages_with_base64_image() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1556,6 +1556,33 @@ def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     assert assistant_message.parts[0].thought_signature == original_bytes
 
 
+def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
+    """OpenAI tool messages carry no name: resolve it from the assistant's tool_calls by id, in any order."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Temperature and population of Toronto?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_temperature", "arguments": "{}"}},
+                {"id": "call_2", "type": "function", "function": {"name": "get_population", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
+        {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    names = []
+    for content in formatted_messages:
+        if content.role == "function":
+            assert content.parts is not None
+            assert content.parts[0].function_response is not None
+            names.append(content.parts[0].function_response.name)
+    assert names == ["get_population", "get_temperature"]
+
+
 def test_convert_messages_with_base64_image() -> None:
     image_b64 = base64.b64encode(TEST_IMAGE_BYTES).decode("utf-8")
     messages = [

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1556,6 +1556,16 @@ def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     assert assistant_message.parts[0].thought_signature == original_bytes
 
 
+def _function_response_names(contents: list[types.Content]) -> list[str | None]:
+    names = []
+    for content in contents:
+        if content.role == "function":
+            assert content.parts is not None
+            assert content.parts[0].function_response is not None
+            names.append(content.parts[0].function_response.name)
+    return names
+
+
 def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
     """OpenAI tool messages carry no name: resolve it from the assistant's tool_calls by id, in any order."""
     messages: list[dict[str, Any]] = [
@@ -1570,23 +1580,31 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
         },
         {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
         {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    assert _function_response_names(formatted_messages) == ["get_population", "get_temperature"]
+
+
+def test_convert_messages_tool_result_name_explicit_wins_else_unknown() -> None:
+    messages: list[dict[str, Any]] = [
         {
             "role": "assistant",
             "content": None,
-            "tool_calls": [{"type": "function", "function": {"name": "no_id", "arguments": "{}"}}],
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+                {"type": "function", "function": {"name": "no_id", "arguments": "{}"}},
+            ],
         },
+        {"role": "tool", "tool_call_id": "call_1", "name": "explicit_name", "content": "{}"},
+        {"role": "tool", "tool_call_id": "call_9", "content": "{}"},  # an id no tool_call carries
         {"role": "tool", "content": "{}"},  # neither side carries an id: nothing to resolve
     ]
 
     formatted_messages, _ = _convert_messages(messages)
 
-    names = []
-    for content in formatted_messages:
-        if content.role == "function":
-            assert content.parts is not None
-            assert content.parts[0].function_response is not None
-            names.append(content.parts[0].function_response.name)
-    assert names == ["get_population", "get_temperature", "unknown"]
+    assert _function_response_names(formatted_messages) == ["explicit_name", "unknown", "unknown"]
 
 
 def test_convert_messages_with_base64_image() -> None:


### PR DESCRIPTION
## Description

`_convert_messages` names a gemini `function_response` from `message["name"]`, defaulting to `"unknown"`. OpenAI's tool message has no `name` — its keys are `role`, `content`, `tool_call_id` (`ChatCompletionToolMessageParam`) — so every standard tool loop reaches gemini as `name="unknown"`. The Messages bridge emits exactly that shape too (`messages_compat.py:192`), so `messages()` routed to gemini always sends `unknown`. The integration agent-loop test avoids it only by adding a `name` key by hand.

Gemini accepts the unnamed response, so this never errors. It costs accuracy when it matters: with two tools called in parallel and results supplied in a different order (legal on the OpenAI side, `tool_call_id` disambiguates), gemini has to guess which result answers which call.

The fix records `id → function name` while walking the assistant's `tool_calls` and uses it for tool messages that carry no `name`. An explicit `name` still wins; an unknown id still falls back to `"unknown"`.

Verified live with `get_temperature` / `get_population` for Toronto, results returned in reverse call order and both shaped `{"value": n}`, no `name` on the tool messages, 3 trials per model:

| | names sent | gemini-2.5-flash | gemini-3-flash-preview |
|---|---|---|---|
| before | `unknown, unknown` | 2/3 correct — one answer swapped: `temperature=2794356 population=8` | 3/3 |
| after | `get_population, get_temperature` | 3/3 | 3/3 |

The test feeds two tool results in reversed order without names and asserts the resolved names. It fails on main.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool responses by resolving names from matching tool calls, including when results arrive out of order.
  * Explicit tool names now take precedence, with a safe fallback for missing or unrecognised names.

* **Tests**
  * Added regression coverage for tool-name resolution, explicit-name precedence, out-of-order responses, and unknown or missing tool-call IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->