### PR TITLE
fix: close the provider stream when the wrapped stream is closed

### DIFF
--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -338,6 +338,11 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                         yield item
                 except Exception as e:
                     _handle_exception(e, provider_name)
+                finally:
+                    # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
+                    close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
+                    if close is not None:
+                        await close()
 
             @functools.wraps(func)
             async def streaming_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -341,7 +341,8 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                 except Exception as e:
                     _handle_exception(e, provider_name)
                 finally:
-                    # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
+                    # async for never closes its source, so without this the caller's aclose() would stop
+                    # here and leave the provider stream to the GC. SDK streams spell the method close().
                     close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
                     if callable(close):
                         with contextlib.suppress(Exception):  # cleanup never outranks the stream's own error

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import functools
+import inspect
 import os
 import re
 import warnings
@@ -341,8 +343,11 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                 finally:
                     # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
                     close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
-                    if close is not None:
-                        await close()
+                    if callable(close):
+                        with contextlib.suppress(Exception):  # cleanup never outranks the stream's own error
+                            maybe_awaitable = close()
+                            if inspect.isawaitable(maybe_awaitable):
+                                await maybe_awaitable
 
             @functools.wraps(func)
             async def streaming_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -521,6 +521,21 @@ class _SdkStream:
         self.closed = True
 
 
+_STREAM_ERROR = "stream broke"
+_CLOSE_ERROR = "close broke"
+
+
+class _SyncCloseStream:
+    """An iterable whose close() is synchronous and fails."""
+
+    async def __aiter__(self) -> Any:
+        yield 1
+        raise ValueError(_STREAM_ERROR)
+
+    def close(self) -> None:
+        raise RuntimeError(_CLOSE_ERROR)
+
+
 class _Provider:
     PROVIDER_NAME = "test"
 
@@ -543,6 +558,17 @@ class _Provider:
     async def stream_sdk(self) -> Any:
         return self.sdk_stream
 
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_sync_close(self) -> Any:
+        return _SyncCloseStream()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_plain(self) -> Any:
+        async def generate() -> Any:
+            yield 1
+
+        return generate().__aiter__()
+
 
 @pytest.mark.asyncio
 async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
@@ -558,3 +584,18 @@ async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
     await wrapped.__anext__()
     await wrapped.aclose()
     assert provider.sdk_stream.closed
+
+
+@pytest.mark.asyncio
+async def test_provider_stream_closes_on_exhaustion_and_iteration_errors() -> None:
+    """Cleanup runs on every exit: exhaustion, an iteration error (still surfaced), a sync closer that fails."""
+    provider = _Provider()
+
+    assert [item async for item in await provider.stream_generator()] == [0, 1, 2]
+    assert provider.generator_closed
+
+    with pytest.raises(ValueError, match=_STREAM_ERROR):  # the stream's error wins over the failing closer
+        async for _ in await provider.stream_sync_close():
+            pass
+
+    assert [item async for item in await provider.stream_plain()] == [1]  # no close method at all is fine

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -21,6 +21,7 @@ from any_llm.utils.exception_handler import (
     _STATUS_ERROR_CLASSES,
     _handle_exception,
     convert_exception,
+    handle_exceptions,
 )
 
 
@@ -504,3 +505,56 @@ def test_status_free_failures_still_use_the_message_patterns() -> None:
     status classifies exactly as it did before."""
     assert type(convert_exception(Exception("Rate limit reached"), "openai")) is RateLimitError
     assert type(convert_exception(TimeoutError("request timed out"), "openai")) is ProviderError
+
+
+class _SdkStream:
+    """An SDK stream like openai's AsyncStream: iterable, closed via close(), no aclose()."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def __aiter__(self) -> Any:
+        for item in range(3):
+            yield item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Provider:
+    PROVIDER_NAME = "test"
+
+    def __init__(self) -> None:
+        self.generator_closed = False
+        self.sdk_stream = _SdkStream()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_generator(self) -> Any:
+        async def generate() -> Any:
+            try:
+                for item in range(3):
+                    yield item
+            finally:
+                self.generator_closed = True
+
+        return generate()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_sdk(self) -> Any:
+        return self.sdk_stream
+
+
+@pytest.mark.asyncio
+async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
+    """A caller's aclose() must reach the provider stream, whether it spells it aclose or close."""
+    provider = _Provider()
+
+    wrapped = await provider.stream_generator()
+    await wrapped.__anext__()
+    await wrapped.aclose()
+    assert provider.generator_closed
+
+    wrapped = await provider.stream_sdk()
+    await wrapped.__anext__()
+    await wrapped.aclose()
+    assert provider.sdk_stream.closed

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,3 +1,5 @@
+import asyncio
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
@@ -507,95 +509,149 @@ def test_status_free_failures_still_use_the_message_patterns() -> None:
     assert type(convert_exception(TimeoutError("request timed out"), "openai")) is ProviderError
 
 
-class _SdkStream:
-    """An SDK stream like openai's AsyncStream: iterable, closed via close(), no aclose()."""
-
-    def __init__(self) -> None:
-        self.closed = False
-
-    async def __aiter__(self) -> Any:
-        for item in range(3):
-            yield item
-
-    async def close(self) -> None:
-        self.closed = True
-
-
 _STREAM_ERROR = "stream broke"
 _CLOSE_ERROR = "close broke"
 
 
-class _SyncCloseStream:
-    """An iterable whose close() is synchronous and fails."""
+class _SdkStream:
+    """An SDK stream like openai's AsyncStream: iterable, closed through an async close(), no aclose()."""
 
-    async def __aiter__(self) -> Any:
+    def __init__(self, *, hang: bool = False, close_error: Exception | None = None) -> None:
+        self.hang = hang
+        self.hanging = asyncio.Event()
+        self.close_error = close_error
+        self.close_calls = 0
+
+    async def __aiter__(self) -> AsyncIterator[int]:
+        yield 0
+        if self.hang:
+            self.hanging.set()
+            await asyncio.Event().wait()
         yield 1
-        raise ValueError(_STREAM_ERROR)
+        yield 2
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _SyncCloseStream:
+    """A stream that fails after its first item and spells its close synchronously."""
+
+    def __init__(self, *, close_error: Exception | None = None) -> None:
+        self.close_error = close_error
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[int]:
+        yield 1
+        raise ProviderError(_STREAM_ERROR)
 
     def close(self) -> None:
-        raise RuntimeError(_CLOSE_ERROR)
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _PlainIterator:
+    """An async iterator with neither aclose() nor close()."""
+
+    def __init__(self) -> None:
+        self.items = iter([1, 2])
+
+    def __aiter__(self) -> AsyncIterator[int]:
+        return self
+
+    async def __anext__(self) -> int:
+        try:
+            return next(self.items)
+        except StopIteration:
+            raise StopAsyncIteration from None
 
 
 class _Provider:
     PROVIDER_NAME = "test"
 
-    def __init__(self) -> None:
-        self.generator_closed = False
-        self.sdk_stream = _SdkStream()
-
     @handle_exceptions(wrap_streaming=True)
-    async def stream_generator(self) -> Any:
-        async def generate() -> Any:
-            try:
-                for item in range(3):
-                    yield item
-            finally:
-                self.generator_closed = True
+    async def stream(self, source: Any) -> Any:
+        return source
 
-        return generate()
 
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_sdk(self) -> Any:
-        return self.sdk_stream
-
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_sync_close(self) -> Any:
-        return _SyncCloseStream()
-
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_plain(self) -> Any:
-        async def generate() -> Any:
-            yield 1
-
-        return generate().__aiter__()
+async def _wrapped(source: Any) -> Any:
+    return await _Provider().stream(source)
 
 
 @pytest.mark.asyncio
 async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
-    """A caller's aclose() must reach the provider stream, whether it spells it aclose or close."""
-    provider = _Provider()
+    """A caller's aclose() reaches the provider stream, whether it spells it aclose or close, exactly once."""
+    closed: list[str] = []
 
-    wrapped = await provider.stream_generator()
+    async def generate() -> AsyncIterator[int]:
+        try:
+            yield 0
+            yield 1
+        finally:
+            closed.append("generator")
+
+    wrapped = await _wrapped(generate())
     await wrapped.__anext__()
     await wrapped.aclose()
-    assert provider.generator_closed
+    assert closed == ["generator"]
 
-    wrapped = await provider.stream_sdk()
+    sdk_stream = _SdkStream()
+    wrapped = await _wrapped(sdk_stream)
     await wrapped.__anext__()
     await wrapped.aclose()
-    assert provider.sdk_stream.closed
+    await wrapped.aclose()
+    assert sdk_stream.close_calls == 1
 
 
 @pytest.mark.asyncio
-async def test_provider_stream_closes_on_exhaustion_and_iteration_errors() -> None:
-    """Cleanup runs on every exit: exhaustion, an iteration error (still surfaced), a sync closer that fails."""
-    provider = _Provider()
+async def test_provider_stream_closes_after_exhaustion() -> None:
+    sdk_stream = _SdkStream()
+    assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
+    assert sdk_stream.close_calls == 1
 
-    assert [item async for item in await provider.stream_generator()] == [0, 1, 2]
-    assert provider.generator_closed
 
-    with pytest.raises(ValueError, match=_STREAM_ERROR):  # the stream's error wins over the failing closer
-        async for _ in await provider.stream_sync_close():
+@pytest.mark.asyncio
+async def test_provider_stream_closes_when_the_consumer_is_cancelled() -> None:
+    """Cancellation lands inside the provider stream; the wrapper still closes it on the way out."""
+    sdk_stream = _SdkStream(hang=True)
+    wrapped = await _wrapped(sdk_stream)
+
+    async def consume() -> None:
+        async for _ in wrapped:
             pass
 
-    assert [item async for item in await provider.stream_plain()] == [1]  # no close method at all is fine
+    task = asyncio.create_task(consume())
+    await sdk_stream.hanging.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sdk_stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_iteration_error_surfaces_after_a_sync_close() -> None:
+    """The failing stream is still closed, without awaiting its sync close(), and its error is what the caller sees."""
+    stream = _SyncCloseStream()
+    with pytest.raises(ProviderError, match=_STREAM_ERROR):
+        async for _ in await _wrapped(stream):
+            pass
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_a_failing_close_never_outranks_the_stream_outcome() -> None:
+    """A close() that raises changes nothing: the stream's own error wins, and a clean run stays clean."""
+    with pytest.raises(ProviderError, match=_STREAM_ERROR):
+        async for _ in await _wrapped(_SyncCloseStream(close_error=RuntimeError(_CLOSE_ERROR))):
+            pass
+
+    sdk_stream = _SdkStream(close_error=RuntimeError(_CLOSE_ERROR))
+    assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_iterator_without_a_close_method_is_left_alone() -> None:
+    assert [item async for item in await _wrapped(_PlainIterator())] == [1, 2]


### PR DESCRIPTION
## Description

Every stream any-llm hands out — `acompletion`, `amessages`, `aresponses` — is the `_wrap_async_iterator` generator from `handle_exceptions(wrap_streaming=True)`, wrapped around the provider's own iterator so mid-stream errors get converted. When the caller stops early and closes it (`await it.aclose()`, or leaving an `async with`/`async for` via `break`, or a cancelled request), `GeneratorExit` lands at the wrapper's `yield` and the wrapper exits — but `async for` does not close the iterator it was reading from. The provider stream is dropped, not closed, and the HTTP response under it stays open until the garbage collector's finalizer runs, at some later point on some loop.

For anthropic that stream is the `async with client.messages.stream(...)` block, for openai's Responses path it is the SDK's `AsyncStream` returned raw; both close the response promptly on `aclose()`/`close()` — they just never get the call.

The fix is a `finally` on the wrapper that closes the inner iterator: `aclose` for async generators, `close` for SDK streams that only spell it that way (openai's `AsyncStream`). It runs on normal exhaustion too, where both are no-ops. The same idiom already lives in `utils/aio.py` for the sync bridge.

Verified live: start a stream, read one event, `aclose()` the wrapper, then check the SDK response object captured at the provider call:

| | anthropic `messages.stream` response closed | openai `responses.create` stream response closed |
|---|---|---|
| before | no | no |
| after | yes | yes |

The test wraps two provider streams — an async generator and an SDK-style object with `close()` only — reads one item from each, closes the wrapper, and asserts the inner one closed. It fails on main.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of streaming responses by ensuring underlying streams are closed after completion, cancellation, or errors.
  * Added support for both synchronous and asynchronous stream cleanup.
  * Cleanup failures no longer interrupt the original streaming operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->