### PR TITLE
fix(gemini): carry the text-part thought_signature across turns

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -250,6 +250,7 @@ class GoogleProvider(AnyLLM):
                 content=message_dict.get("content"),
                 tool_calls=cast("list[ChatCompletionMessageToolCallType] | None", tool_calls),
                 reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
+                extra_content=message_dict.get("extra_content"),
             )
             from typing import Literal
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -364,7 +364,9 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         reasoning = None
         tool_calls_list: list[dict[str, Any]] = []
         text_content = None
-        message_extra_content = None  # gemini 3 signs the last text part too; it rides the message, like anthropic's
+        # Gemini 3 signs the last non-function-call part of a text answer. It rides message.extra_content,
+        # the same spelling Google's OpenAI-compatible endpoint uses.
+        message_extra_content = None
         parts = candidate.content.parts if candidate.content else None
 
         for part in parts or []:

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -364,7 +364,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         reasoning = None
         tool_calls_list: list[dict[str, Any]] = []
         text_content = None
-        extra_content = None  # gemini 3 signs the last text part too; it rides the message, like anthropic's
+        message_extra_content = None  # gemini 3 signs the last text part too; it rides the message, like anthropic's
         parts = candidate.content.parts if candidate.content else None
 
         for part in parts or []:
@@ -391,9 +391,9 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
 
                 tool_calls_list.append(tool_call_dict)
             else:
-                if part_text := getattr(part, "text", None):
-                    text_content = (text_content or "") + part_text
-                extra_content = _thought_signature_extra_content(part) or extra_content
+                if part.text:
+                    text_content = (text_content or "") + part.text
+                message_extra_content = _thought_signature_extra_content(part) or message_extra_content
 
         # Truncated or filtered responses produce a choice even without content or tool
         # calls, e.g. a thinking model that spent the whole max_output_tokens budget on
@@ -406,7 +406,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                         "content": None if tool_calls_list else text_content,
                         "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
-                        "extra_content": extra_content,
+                        "extra_content": message_extra_content,
                     },
                     "finish_reason": _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list)) or "stop",
                     "index": 0,
@@ -467,7 +467,7 @@ def _create_openai_chunk_from_google_chunk(
     content = ""
     reasoning_content = ""
     tool_calls_list: list[ChoiceDeltaToolCall] = []
-    extra_content = None
+    message_extra_content = None
 
     # Content can be absent on terminal chunks, e.g. when the response is truncated or
     # filtered before any part is produced; the finish reason must still be surfaced.
@@ -503,7 +503,7 @@ def _create_openai_chunk_from_google_chunk(
             )
         else:
             content += part.text or ""  # the signed final part may carry empty text
-            extra_content = _thought_signature_extra_content(part) or extra_content
+            message_extra_content = _thought_signature_extra_content(part) or message_extra_content
 
     # Unmapped reasons stay None so non-final chunks are not forced to a terminal reason.
     finish_reason = _resolve_finish_reason(_map_finish_reason(candidate.finish_reason), bool(tool_calls_list))
@@ -513,7 +513,7 @@ def _create_openai_chunk_from_google_chunk(
         role="assistant",
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         tool_calls=tool_calls_list or None,
-        extra_content=extra_content,
+        extra_content=message_extra_content,
     )
 
     choice = ChunkChoice(

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -247,7 +247,8 @@ def _convert_messages(
                         )
                     )
             else:
-                parts = [types.Part.from_text(text=message["content"])]
+                signature = ((message.get("extra_content") or {}).get("google") or {}).get("thought_signature")
+                parts = [types.Part(text=message["content"], thought_signature=signature)]
 
             formatted_messages.append(types.Content(role="model", parts=parts))
         elif message["role"] == "tool":
@@ -363,6 +364,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         reasoning = None
         tool_calls_list: list[dict[str, Any]] = []
         text_content = None
+        extra_content = None  # gemini 3 signs the last text part too; it rides the message, like anthropic's
         parts = candidate.content.parts if candidate.content else None
 
         for part in parts or []:
@@ -388,8 +390,10 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                     tool_call_dict["extra_content"] = extra_content
 
                 tool_calls_list.append(tool_call_dict)
-            elif part_text := getattr(part, "text", None):
-                text_content = (text_content or "") + part_text
+            else:
+                if part_text := getattr(part, "text", None):
+                    text_content = (text_content or "") + part_text
+                extra_content = _thought_signature_extra_content(part) or extra_content
 
         # Truncated or filtered responses produce a choice even without content or tool
         # calls, e.g. a thinking model that spent the whole max_output_tokens budget on
@@ -402,6 +406,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                         "content": None if tool_calls_list else text_content,
                         "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
+                        "extra_content": extra_content,
                     },
                     "finish_reason": _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list)) or "stop",
                     "index": 0,
@@ -462,6 +467,7 @@ def _create_openai_chunk_from_google_chunk(
     content = ""
     reasoning_content = ""
     tool_calls_list: list[ChoiceDeltaToolCall] = []
+    extra_content = None
 
     # Content can be absent on terminal chunks, e.g. when the response is truncated or
     # filtered before any part is produced; the finish reason must still be surfaced.
@@ -495,8 +501,9 @@ def _create_openai_chunk_from_google_chunk(
                     extra_content=extra_content,
                 )
             )
-        elif part.text:
-            content += part.text
+        else:
+            content += part.text or ""  # the signed final part may carry empty text
+            extra_content = _thought_signature_extra_content(part) or extra_content
 
     # Unmapped reasons stay None so non-final chunks are not forced to a terminal reason.
     finish_reason = _resolve_finish_reason(_map_finish_reason(candidate.finish_reason), bool(tool_calls_list))
@@ -506,6 +513,7 @@ def _create_openai_chunk_from_google_chunk(
         role="assistant",
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         tool_calls=tool_calls_list or None,
+        extra_content=extra_content,
     )
 
     choice = ChunkChoice(

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1248,6 +1248,7 @@ def test_streaming_completion_with_tool_call_preserves_thought_signature() -> No
     tool_call = chunk.choices[0].delta.tool_calls[0]
     assert tool_call.extra_content is not None
     assert tool_call.extra_content["google"]["thought_signature"] == base64.b64encode(original_bytes).decode("utf-8")
+    assert chunk.choices[0].delta.extra_content is None  # signature stays on the tool call
 
 
 def test_streaming_completion_with_tool_call_no_thought_signature() -> None:
@@ -1491,6 +1492,7 @@ def test_convert_response_preserves_thought_signature() -> None:
     assert tool_calls[0]["extra_content"]["google"]["thought_signature"] == base64.b64encode(
         b"test-signature-bytes"
     ).decode("utf-8")
+    assert response_dict["choices"][0]["message"]["extra_content"] is None  # signature stays on the tool call
 
 
 def test_convert_response_no_thought_signature() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1492,7 +1492,7 @@ def test_convert_response_preserves_thought_signature() -> None:
     assert tool_calls[0]["extra_content"]["google"]["thought_signature"] == base64.b64encode(
         b"test-signature-bytes"
     ).decode("utf-8")
-    assert response_dict["choices"][0]["message"]["extra_content"] is None  # signature stays on the tool call
+    assert response_dict["choices"][0]["message"].get("extra_content") is None  # signature stays on the tool call
 
 
 def test_convert_response_no_thought_signature() -> None:
@@ -1532,42 +1532,53 @@ def test_convert_response_text_part_thought_signature_rides_the_message() -> Non
     mock_response.candidates[0].content = Mock()
     mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.usage_metadata = None
-    thought, text = Mock(), Mock()
-    thought.thought, thought.text, thought.function_call, thought.thought_signature = True, "let me think", None, None
-    text.thought, text.text, text.function_call, text.thought_signature = None, "42", None, b"test-signature-bytes"
-    mock_response.candidates[0].content.parts = [thought, text]
+
+    mock_thought = Mock()
+    mock_thought.thought = True
+    mock_thought.text = "let me think"
+    mock_thought.function_call = None
+    mock_thought.thought_signature = None
+
+    mock_text = Mock()
+    mock_text.thought = None
+    mock_text.text = "42"
+    mock_text.function_call = None
+    mock_text.thought_signature = b"test-signature-bytes"
+
+    mock_response.candidates[0].content.parts = [mock_thought, mock_text]
 
     message = _convert_response_to_response_dict(mock_response)["choices"][0]["message"]
 
     assert message["content"] == "42"
     assert message["extra_content"] == {
-        "google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode()}
+        "google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode("utf-8")}
     }
 
 
 def test_streaming_text_part_thought_signature_rides_the_delta() -> None:
     """The signed final part arrives with empty text on the last chunk; the delta must still carry it."""
-    from any_llm.providers.gemini.utils import _create_openai_chunk_from_google_chunk
-
     mock_response = Mock()
     mock_response.candidates = [Mock()]
     mock_response.candidates[0].content = Mock()
     mock_response.candidates[0].finish_reason = types.FinishReason.STOP
     mock_response.model_version = "gemini-3-flash-preview"
     mock_response.usage_metadata = None
-    signed = Mock()
-    signed.thought, signed.text, signed.function_call, signed.thought_signature = (
-        None,
-        "",
-        None,
-        b"test-signature-bytes",
-    )
-    mock_response.candidates[0].content.parts = [signed]
+
+    mock_part = Mock()
+    mock_part.thought = None
+    mock_part.text = ""
+    mock_part.function_call = None
+    mock_part.thought_signature = b"test-signature-bytes"
+
+    mock_response.candidates[0].content.parts = [mock_part]
 
     delta = _create_openai_chunk_from_google_chunk(mock_response).choices[0].delta
 
     assert delta.content is None
-    assert delta.extra_content == {"google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode()}}
+    assert delta.tool_calls is None
+    assert delta.extra_content == {
+        "google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode("utf-8")}
+    }
 
 
 def test_convert_messages_text_turn_replays_thought_signature() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1523,6 +1523,66 @@ def test_convert_response_no_thought_signature() -> None:
     assert "extra_content" not in tool_calls[0] or tool_calls[0].get("extra_content") is None
 
 
+def test_convert_response_text_part_thought_signature_rides_the_message() -> None:
+    """Gemini 3 signs the final text part of a text-only answer; it lands on message.extra_content."""
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.usage_metadata = None
+    thought, text = Mock(), Mock()
+    thought.thought, thought.text, thought.function_call, thought.thought_signature = True, "let me think", None, None
+    text.thought, text.text, text.function_call, text.thought_signature = None, "42", None, b"test-signature-bytes"
+    mock_response.candidates[0].content.parts = [thought, text]
+
+    message = _convert_response_to_response_dict(mock_response)["choices"][0]["message"]
+
+    assert message["content"] == "42"
+    assert message["extra_content"] == {
+        "google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode()}
+    }
+
+
+def test_streaming_text_part_thought_signature_rides_the_delta() -> None:
+    """The signed final part arrives with empty text on the last chunk; the delta must still carry it."""
+    from any_llm.providers.gemini.utils import _create_openai_chunk_from_google_chunk
+
+    mock_response = Mock()
+    mock_response.candidates = [Mock()]
+    mock_response.candidates[0].content = Mock()
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.model_version = "gemini-3-flash-preview"
+    mock_response.usage_metadata = None
+    signed = Mock()
+    signed.thought, signed.text, signed.function_call, signed.thought_signature = (
+        None,
+        "",
+        None,
+        b"test-signature-bytes",
+    )
+    mock_response.candidates[0].content.parts = [signed]
+
+    delta = _create_openai_chunk_from_google_chunk(mock_response).choices[0].delta
+
+    assert delta.content is None
+    assert delta.extra_content == {"google": {"thought_signature": base64.b64encode(b"test-signature-bytes").decode()}}
+
+
+def test_convert_messages_text_turn_replays_thought_signature() -> None:
+    """A text-only assistant turn carrying extra_content replays its signature on the text part."""
+    base64_signature = base64.b64encode(b"test-signature-bytes").decode("utf-8")
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "How many sheep?"},
+        {"role": "assistant", "content": "42", "extra_content": {"google": {"thought_signature": base64_signature}}},
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    assert formatted_messages[1].parts is not None
+    assert formatted_messages[1].parts[0].text == "42"
+    assert formatted_messages[1].parts[0].thought_signature == b"test-signature-bytes"
+
+
 def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     # Use valid base64 that round-trips correctly
     original_bytes = b"test-signature-bytes"


### PR DESCRIPTION
## Description

#1153 carries gemini's `thought_signature` on function calls. Gemini 3 also signs text: a text-only answer comes back with the signature on its final text part, and Google's guidance for that case is to return it on the next turn — recommended for reasoning quality, not enforced (no 400 if omitted, unlike function calls). Both gemini converters read the signature only inside the `function_call` branch, so a text turn's signature was dropped on the way out and, having nowhere to live on the message, never replayed.

Live on `gemini-3-flash-preview` and `gemini-3.1-pro-preview` (raw SDK): a reasoning question returns `[thought part, text part]` with the signature on the text part; `gemini-2.5-flash` signs nothing. On a stream both models deliver the signature on the last chunk in a part with **empty text** — the case Google's docs call out — which the streaming converter's `elif part.text:` skipped outright.

The fix mirrors what the anthropic converter already does for its signature: the text-part signature rides `message.extra_content` (`{"google": {"thought_signature": ...}}`) on the non-streaming message and `delta.extra_content` on the chunk that carries it, and `_convert_messages` attaches it back to the text `Part` when a text-only assistant turn is replayed. Function-call signatures keep riding the tool call as before. `_thought_signature_extra_content` is reused, so both spellings stay in sync.

Verified through `acompletion` on `gemini-3-flash-preview`:

| | `message.extra_content` | replayed text `Part.thought_signature` | stream: chunks with `delta.extra_content` |
|---|---|---|---|
| before | `None` | `None` | 0 |
| after | `{"google": {"thought_signature": ...}}` | the returned signature | 1 (the last chunk) |

Tests: a signed text part lands on `message.extra_content`; a signed empty-text part on a stream lands on `delta.extra_content`; a text-only assistant turn carrying `extra_content` replays its signature. All three fail on main.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Extends #1153 to text turns; related to the open RFC #1053.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Gemini completion responses now preserve thought-signature metadata.
  - Thought signatures are retained in both standard and streaming responses.
  - Assistant responses can replay preserved signatures in subsequent Gemini messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->