### PR TITLE
fix(gemini): name tool results from the tool_call they answer

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -198,6 +198,7 @@ def _convert_messages(
     """Convert messages to Google GenAI format."""
     formatted_messages = []
     system_instruction = None
+    tool_names: dict[str, str] = {}  # tool_call id -> function name, for tool results that carry no name
 
     for message in messages:
         if message["role"] == "system":
@@ -225,6 +226,7 @@ def _convert_messages(
                 parts = []
                 for i, tool_call in enumerate(message["tool_calls"]):
                     function_call = tool_call["function"]
+                    tool_names[tool_call.get("id", "")] = function_call["name"]
                     args = json.loads(function_call["arguments"]) if function_call["arguments"] else {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)
@@ -251,16 +253,13 @@ def _convert_messages(
 
             formatted_messages.append(types.Content(role="model", parts=parts))
         elif message["role"] == "tool":
+            name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
             try:
                 content_json = json.loads(message["content"])
-                part = types.Part.from_function_response(
-                    name=message.get("name", "unknown"), response=_normalize_tool_response(content_json)
-                )
+                part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content_json))
                 formatted_messages.append(types.Content(role="function", parts=[part]))
             except json.JSONDecodeError:
-                part = types.Part.from_function_response(
-                    name=message.get("name", "unknown"), response={"result": message["content"]}
-                )
+                part = types.Part.from_function_response(name=name, response={"result": message["content"]})
                 formatted_messages.append(types.Content(role="function", parts=[part]))
 
     return formatted_messages, system_instruction

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -226,7 +226,8 @@ def _convert_messages(
                 parts = []
                 for i, tool_call in enumerate(message["tool_calls"]):
                     function_call = tool_call["function"]
-                    tool_names[tool_call.get("id", "")] = function_call["name"]
+                    if tool_call_id := tool_call.get("id"):
+                        tool_names[tool_call_id] = function_call["name"]
                     args = json.loads(function_call["arguments"]) if function_call["arguments"] else {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1570,6 +1570,12 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
         },
         {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
         {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"type": "function", "function": {"name": "no_id", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "{}"},  # neither side carries an id: nothing to resolve
     ]
 
     formatted_messages, _ = _convert_messages(messages)
@@ -1580,7 +1586,7 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
             assert content.parts is not None
             assert content.parts[0].function_response is not None
             names.append(content.parts[0].function_response.name)
-    assert names == ["get_population", "get_temperature"]
+    assert names == ["get_population", "get_temperature", "unknown"]
 
 
 def test_convert_messages_with_base64_image() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1556,6 +1556,33 @@ def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     assert assistant_message.parts[0].thought_signature == original_bytes
 
 
+def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
+    """OpenAI tool messages carry no name: resolve it from the assistant's tool_calls by id, in any order."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Temperature and population of Toronto?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_temperature", "arguments": "{}"}},
+                {"id": "call_2", "type": "function", "function": {"name": "get_population", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
+        {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    names = []
+    for content in formatted_messages:
+        if content.role == "function":
+            assert content.parts is not None
+            assert content.parts[0].function_response is not None
+            names.append(content.parts[0].function_response.name)
+    assert names == ["get_population", "get_temperature"]
+
+
 def test_convert_messages_with_base64_image() -> None:
     image_b64 = base64.b64encode(TEST_IMAGE_BYTES).decode("utf-8")
     messages = [

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1556,6 +1556,16 @@ def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     assert assistant_message.parts[0].thought_signature == original_bytes
 
 
+def _function_response_names(contents: list[types.Content]) -> list[str | None]:
+    names = []
+    for content in contents:
+        if content.role == "function":
+            assert content.parts is not None
+            assert content.parts[0].function_response is not None
+            names.append(content.parts[0].function_response.name)
+    return names
+
+
 def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
     """OpenAI tool messages carry no name: resolve it from the assistant's tool_calls by id, in any order."""
     messages: list[dict[str, Any]] = [
@@ -1570,23 +1580,31 @@ def test_convert_messages_resolves_tool_result_name_from_tool_call_id() -> None:
         },
         {"role": "tool", "tool_call_id": "call_2", "content": '{"value": 2794356}'},
         {"role": "tool", "tool_call_id": "call_1", "content": "8 degrees"},
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    assert _function_response_names(formatted_messages) == ["get_population", "get_temperature"]
+
+
+def test_convert_messages_tool_result_name_explicit_wins_else_unknown() -> None:
+    messages: list[dict[str, Any]] = [
         {
             "role": "assistant",
             "content": None,
-            "tool_calls": [{"type": "function", "function": {"name": "no_id", "arguments": "{}"}}],
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+                {"type": "function", "function": {"name": "no_id", "arguments": "{}"}},
+            ],
         },
+        {"role": "tool", "tool_call_id": "call_1", "name": "explicit_name", "content": "{}"},
+        {"role": "tool", "tool_call_id": "call_9", "content": "{}"},  # an id no tool_call carries
         {"role": "tool", "content": "{}"},  # neither side carries an id: nothing to resolve
     ]
 
     formatted_messages, _ = _convert_messages(messages)
 
-    names = []
-    for content in formatted_messages:
-        if content.role == "function":
-            assert content.parts is not None
-            assert content.parts[0].function_response is not None
-            names.append(content.parts[0].function_response.name)
-    assert names == ["get_population", "get_temperature", "unknown"]
+    assert _function_response_names(formatted_messages) == ["explicit_name", "unknown", "unknown"]
 
 
 def test_convert_messages_with_base64_image() -> None:


### PR DESCRIPTION
## Description

`_convert_messages` in `providers/gemini/utils.py` names each gemini `function_response` from `message["name"]` and falls back to `"unknown"`. OpenAI's tool message has no `name`: its keys are `role`, `content`, `tool_call_id` (`ChatCompletionToolMessageParam`). The Messages bridge emits that same shape (`utils/messages_compat.py`, `tool_result` → `{"role": "tool", "tool_call_id": ...}`). So every standard tool loop, through `completion()` or `messages()`, reached gemini with `name="unknown"` on every function response. The integration agent-loop test only avoids it by adding a `name` key by hand.

Gemini accepts the unnamed response, so nothing errors. But with `name="unknown"` on every response the model can only match results to calls by position. The OpenAI contract lets a caller return tool results in any order because `tool_call_id` disambiguates; gemini then attributes them to the wrong calls.

The fix records `tool_call id → function name` while walking the assistant's `tool_calls` and uses it for tool messages that carry no `name`. It lives in `_convert_messages` because that is the one place that sees both the calls and the results, for `completion()`, `messages()` and the batch converter alike. An explicit `name` still wins. A call without an id is not recorded, so a tool message whose id matches nothing, or that has no id, still gets `"unknown"`.

Live check: two tools, `get_red_code` and `get_blue_code`, both returning `{"code": n}`, called in parallel, results fed back in reverse call order with no `name` on the tool messages. Names that went out were captured by spying on `generate_content`. Same run through `completion()` and through the bridged `messages()` path, 3 trials each:

| | names sent | gemini-2.5-flash | gemini-3-flash-preview |
|---|---|---|---|
| before | `unknown, unknown` | 0/3 completion, 0/3 messages: every answer swapped (`red=9026, blue=4173`) | 0/3 completion, 0/3 messages: every answer swapped |
| after | `get_blue_code, get_red_code` | 4/4 completion (2 trials skipped: model called one tool at a time), 3/3 messages | 3/3 completion, 3/3 messages |

Two unit tests: one feeds two results in reversed order without names, one JSON and one plain string, and asserts the resolved names (fails on main); the other pins the fallbacks, explicit `name` wins and an unmatched or missing id stays `"unknown"`.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Gemini function responses when tool messages provide only a tool-call ID.
  - Preserved explicitly provided function names and used a safe fallback when no matching name is available.
  - Ensured function-response names remain correct regardless of tool-call ordering or response format.

- **Tests**
  - Added coverage for name resolution, precedence rules, unmatched tool-call IDs, and missing names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->