### PR TITLE
fix(streaming): close the provider stream when the wrapped stream is closed

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -49,7 +49,7 @@ from any_llm.types.responses import (
     ResponsesParams,
     ResponseStreamEvent,
 )
-from any_llm.utils.aio import async_coro_to_sync_iter, async_iter_to_sync_iter, run_async_in_sync
+from any_llm.utils.aio import aclose_quietly, async_coro_to_sync_iter, async_iter_to_sync_iter, run_async_in_sync
 from any_llm.utils.exception_handler import handle_exceptions
 from any_llm.utils.structured_output import (
     build_parsed_message,
@@ -1067,6 +1067,9 @@ class AnyLLM(ABC):
                 if state.started:
                     yield usage_delta(None)
                 raise
+            finally:
+                await aclose_quietly(result)
+
             # Emit the closing events after the full stream is consumed so trailing-chunk usage is included.
             if state.started:
                 for stop_event in close_open_blocks(state):

--- a/src/any_llm/utils/aio.py
+++ b/src/any_llm/utils/aio.py
@@ -1,4 +1,4 @@
-"""Utilities for running async code in sync contexts."""
+"""Utilities for running async code in sync contexts and for closing async iterators cleanly."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import contextvars
+import inspect
 import os
 import queue
 import threading
@@ -17,6 +18,21 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterator
 
 RUNNER_THREAD_NAME = "any-llm-async-runner"
+
+
+async def aclose_quietly(async_iter: object) -> None:
+    """Close an async iterator if it knows how; a failing close is suppressed so it never replaces the stream's own outcome.
+
+    ``async for`` never closes its source, so every generator that loops over a provider stream
+    must do this on the way out or a caller's ``aclose()`` stops at the outer layer. Async
+    generators spell it ``aclose()``; SDK streams spell it ``close()``, sometimes synchronous.
+    """
+    close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            maybe_awaitable = close()
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
 
 
 def _start_loop_thread(name: str) -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
@@ -272,12 +288,7 @@ def _async_source_to_sync_iter(
                         break
                     output_queue.put(item)
             finally:
-                aclose = getattr(async_iter, "aclose", None)
-                if callable(aclose):
-                    with contextlib.suppress(Exception):
-                        maybe_awaitable = aclose()
-                        if asyncio.iscoroutine(maybe_awaitable):
-                            await maybe_awaitable
+                await aclose_quietly(async_iter)
         except asyncio.CancelledError:
             pass
         except Exception as exc:

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import contextlib
 import functools
-import inspect
 import os
 import re
 import warnings
@@ -23,6 +21,7 @@ from any_llm.exceptions import (
     RateLimitError,
     UpstreamProviderError,
 )
+from any_llm.utils.aio import aclose_quietly
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -341,14 +340,7 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                 except Exception as e:
                     _handle_exception(e, provider_name)
                 finally:
-                    # async for never closes its source, so without this the caller's aclose() would stop
-                    # here and leave the provider stream to the GC. SDK streams spell the method close().
-                    close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
-                    if callable(close):
-                        with contextlib.suppress(Exception):  # cleanup never outranks the stream's own error
-                            maybe_awaitable = close()
-                            if inspect.isawaitable(maybe_awaitable):
-                                await maybe_awaitable
+                    await aclose_quietly(async_iter)
 
             @functools.wraps(func)
             async def streaming_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -338,6 +338,11 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                         yield item
                 except Exception as e:
                     _handle_exception(e, provider_name)
+                finally:
+                    # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
+                    close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
+                    if close is not None:
+                        await close()
 
             @functools.wraps(func)
             async def streaming_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -341,7 +341,8 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                 except Exception as e:
                     _handle_exception(e, provider_name)
                 finally:
-                    # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
+                    # async for never closes its source, so without this the caller's aclose() would stop
+                    # here and leave the provider stream to the GC. SDK streams spell the method close().
                     close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
                     if callable(close):
                         with contextlib.suppress(Exception):  # cleanup never outranks the stream's own error

--- a/src/any_llm/utils/exception_handler.py
+++ b/src/any_llm/utils/exception_handler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import functools
+import inspect
 import os
 import re
 import warnings
@@ -341,8 +343,11 @@ def handle_exceptions(*, wrap_streaming: bool = False) -> Callable[[F], F]:
                 finally:
                     # reach the provider stream so its HTTP response closes now, not at GC (SDK streams spell it close)
                     close = getattr(async_iter, "aclose", None) or getattr(async_iter, "close", None)
-                    if close is not None:
-                        await close()
+                    if callable(close):
+                        with contextlib.suppress(Exception):  # cleanup never outranks the stream's own error
+                            maybe_awaitable = close()
+                            if inspect.isawaitable(maybe_awaitable):
+                                await maybe_awaitable
 
             @functools.wraps(func)
             async def streaming_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/src/any_llm/utils/reasoning.py
+++ b/src/any_llm/utils/reasoning.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator, Callable
 from typing import Any, Literal, TypeVar
 
 from any_llm.constants import REASONING_FIELD_NAMES
+from any_llm.utils.aio import aclose_quietly
 
 T = TypeVar("T")
 
@@ -77,76 +78,79 @@ async def process_streaming_reasoning_chunks(
     held_chunks: list[T] = []
     last_chunk_was_yielded = False
 
-    async for original_chunk in chunks:
-        content = get_content(original_chunk)
+    try:
+        async for original_chunk in chunks:
+            content = get_content(original_chunk)
 
-        if not content:
+            if not content:
+                if is_terminal(original_chunk) and (buffer or reasoning_buffer):
+                    held_chunks.append(original_chunk)
+                else:
+                    yield original_chunk
+                continue
+
+            last_chunk = original_chunk
+            last_chunk_was_yielded = False
+            buffer += content
+            content_parts = []
+            reasoning_parts = []
+
+            while buffer:
+                if current_tag is None:
+                    tag_info = find_reasoning_tag(buffer, opening=True)
+                    if tag_info:
+                        tag_start, tag_name = tag_info
+                        if tag_start > 0:
+                            content_parts.append(buffer[:tag_start])
+                        tag_full = f"<{tag_name}>"
+                        buffer = buffer[tag_start + len(tag_full) :]
+                        current_tag = tag_name
+                    else:
+                        partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="opening")
+                        if partial_len:
+                            if partial_len < len(buffer):
+                                content_parts.append(buffer[:-partial_len])
+                            buffer = buffer[len(buffer) - partial_len :]
+                            break
+                        content_parts.append(buffer)
+                        buffer = ""
+                else:
+                    tag_close = f"</{current_tag}>"
+                    tag_end = buffer.find(tag_close)
+                    if tag_end != -1:
+                        reasoning_parts.append(reasoning_buffer + buffer[:tag_end])
+                        reasoning_buffer = ""
+                        buffer = buffer[tag_end + len(tag_close) :]
+                        current_tag = None
+                    else:
+                        partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="closing")
+                        if partial_len:
+                            reasoning_buffer += buffer[: len(buffer) - partial_len]
+                            buffer = buffer[len(buffer) - partial_len :]
+                            break
+                        reasoning_buffer += buffer
+                        buffer = ""
+
             if is_terminal(original_chunk) and (buffer or reasoning_buffer):
-                held_chunks.append(original_chunk)
-            else:
-                yield original_chunk
-            continue
+                terminal_chunk = original_chunk
+                terminal_content_parts.extend(content_parts)
+                terminal_reasoning_parts.extend(reasoning_parts)
+                continue
 
-        last_chunk = original_chunk
-        last_chunk_was_yielded = False
-        buffer += content
-        content_parts = []
-        reasoning_parts = []
-
-        while buffer:
-            if current_tag is None:
-                tag_info = find_reasoning_tag(buffer, opening=True)
-                if tag_info:
-                    tag_start, tag_name = tag_info
-                    if tag_start > 0:
-                        content_parts.append(buffer[:tag_start])
-                    tag_full = f"<{tag_name}>"
-                    buffer = buffer[tag_start + len(tag_full) :]
-                    current_tag = tag_name
-                else:
-                    partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="opening")
-                    if partial_len:
-                        if partial_len < len(buffer):
-                            content_parts.append(buffer[:-partial_len])
-                        buffer = buffer[len(buffer) - partial_len :]
-                        break
-                    content_parts.append(buffer)
-                    buffer = ""
-            else:
-                tag_close = f"</{current_tag}>"
-                tag_end = buffer.find(tag_close)
-                if tag_end != -1:
-                    reasoning_parts.append(reasoning_buffer + buffer[:tag_end])
-                    reasoning_buffer = ""
-                    buffer = buffer[tag_end + len(tag_close) :]
-                    current_tag = None
-                else:
-                    partial_len = partial_reasoning_tag_suffix_len(buffer, tag_kind="closing")
-                    if partial_len:
-                        reasoning_buffer += buffer[: len(buffer) - partial_len]
-                        buffer = buffer[len(buffer) - partial_len :]
-                        break
-                    reasoning_buffer += buffer
-                    buffer = ""
-
-        if is_terminal(original_chunk) and (buffer or reasoning_buffer):
-            terminal_chunk = original_chunk
-            terminal_content_parts.extend(content_parts)
-            terminal_reasoning_parts.extend(reasoning_parts)
-            continue
-
-        if content_parts or reasoning_parts:
-            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
-            modified_chunk = set_content(modified_chunk, "".join(content_parts) if content_parts else None)
-            if reasoning_parts:
-                modified_chunk = set_reasoning(modified_chunk, "".join(reasoning_parts))
-            yield modified_chunk
-            last_chunk_was_yielded = True
-        elif not buffer:
-            modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
-            modified_chunk = set_content(modified_chunk, None)
-            yield modified_chunk
-            last_chunk_was_yielded = True
+            if content_parts or reasoning_parts:
+                modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+                modified_chunk = set_content(modified_chunk, "".join(content_parts) if content_parts else None)
+                if reasoning_parts:
+                    modified_chunk = set_reasoning(modified_chunk, "".join(reasoning_parts))
+                yield modified_chunk
+                last_chunk_was_yielded = True
+            elif not buffer:
+                modified_chunk = original_chunk.model_copy(deep=True)  # type: ignore[attr-defined]
+                modified_chunk = set_content(modified_chunk, None)
+                yield modified_chunk
+                last_chunk_was_yielded = True
+    finally:
+        await aclose_quietly(chunks)
 
     if terminal_chunk is not None:
         final_chunk = terminal_chunk.model_copy(deep=True)  # type: ignore[attr-defined]

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -650,6 +650,7 @@ async def test_a_failing_close_never_outranks_the_stream_outcome() -> None:
 
     sdk_stream = _SdkStream(close_error=RuntimeError(_CLOSE_ERROR))
     assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
+    assert sdk_stream.close_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -521,6 +521,21 @@ class _SdkStream:
         self.closed = True
 
 
+_STREAM_ERROR = "stream broke"
+_CLOSE_ERROR = "close broke"
+
+
+class _SyncCloseStream:
+    """An iterable whose close() is synchronous and fails."""
+
+    async def __aiter__(self) -> Any:
+        yield 1
+        raise ValueError(_STREAM_ERROR)
+
+    def close(self) -> None:
+        raise RuntimeError(_CLOSE_ERROR)
+
+
 class _Provider:
     PROVIDER_NAME = "test"
 
@@ -543,6 +558,17 @@ class _Provider:
     async def stream_sdk(self) -> Any:
         return self.sdk_stream
 
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_sync_close(self) -> Any:
+        return _SyncCloseStream()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_plain(self) -> Any:
+        async def generate() -> Any:
+            yield 1
+
+        return generate().__aiter__()
+
 
 @pytest.mark.asyncio
 async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
@@ -558,3 +584,18 @@ async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
     await wrapped.__anext__()
     await wrapped.aclose()
     assert provider.sdk_stream.closed
+
+
+@pytest.mark.asyncio
+async def test_provider_stream_closes_on_exhaustion_and_iteration_errors() -> None:
+    """Cleanup runs on every exit: exhaustion, an iteration error (still surfaced), a sync closer that fails."""
+    provider = _Provider()
+
+    assert [item async for item in await provider.stream_generator()] == [0, 1, 2]
+    assert provider.generator_closed
+
+    with pytest.raises(ValueError, match=_STREAM_ERROR):  # the stream's error wins over the failing closer
+        async for _ in await provider.stream_sync_close():
+            pass
+
+    assert [item async for item in await provider.stream_plain()] == [1]  # no close method at all is fine

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -517,12 +517,14 @@ class _SdkStream:
     """An SDK stream like openai's AsyncStream: iterable, closed through an async close(), no aclose()."""
 
     def __init__(self, *, hang: bool = False, close_error: Exception | None = None) -> None:
+        """Optionally hang after the first item, and optionally fail on close()."""
         self.hang = hang
         self.hanging = asyncio.Event()
         self.close_error = close_error
         self.close_calls = 0
 
     async def __aiter__(self) -> AsyncIterator[int]:
+        """Yield 0, 1, 2 — parking after 0 when asked to hang."""
         yield 0
         if self.hang:
             self.hanging.set()
@@ -531,6 +533,7 @@ class _SdkStream:
         yield 2
 
     async def close(self) -> None:
+        """Count the call, then raise the configured error if any."""
         self.close_calls += 1
         if self.close_error is not None:
             raise self.close_error
@@ -540,44 +543,44 @@ class _SyncCloseStream:
     """A stream that fails after its first item and spells its close synchronously."""
 
     def __init__(self, *, close_error: Exception | None = None) -> None:
+        """Optionally fail on close()."""
         self.close_error = close_error
         self.closed = False
 
     async def __aiter__(self) -> AsyncIterator[int]:
+        """Yield one item, then fail."""
         yield 1
         raise ProviderError(_STREAM_ERROR)
 
     def close(self) -> None:
+        """Mark closed, then raise the configured error if any."""
         self.closed = True
         if self.close_error is not None:
             raise self.close_error
 
 
-class _PlainIterator:
-    """An async iterator with neither aclose() nor close()."""
+class _PlainIterable:
+    """An async iterable with neither aclose() nor close()."""
 
-    def __init__(self) -> None:
-        self.items = iter([1, 2])
-
-    def __aiter__(self) -> AsyncIterator[int]:
-        return self
-
-    async def __anext__(self) -> int:
-        try:
-            return next(self.items)
-        except StopIteration:
-            raise StopAsyncIteration from None
+    async def __aiter__(self) -> AsyncIterator[int]:
+        """Yield 1, 2."""
+        yield 1
+        yield 2
 
 
 class _Provider:
+    """A provider whose stream() hands back whatever source it is given, wrapped by handle_exceptions."""
+
     PROVIDER_NAME = "test"
 
     @handle_exceptions(wrap_streaming=True)
     async def stream(self, source: Any) -> Any:
+        """Return the source stream; the decorator wraps it."""
         return source
 
 
 async def _wrapped(source: Any) -> Any:
+    """The source as callers receive it: inside _wrap_async_iterator."""
     return await _Provider().stream(source)
 
 
@@ -587,6 +590,7 @@ async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
     closed: list[str] = []
 
     async def generate() -> AsyncIterator[int]:
+        """Record when the generator is closed."""
         try:
             yield 0
             yield 1
@@ -608,6 +612,7 @@ async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
 
 @pytest.mark.asyncio
 async def test_provider_stream_closes_after_exhaustion() -> None:
+    """Reading a stream to the end closes the SDK stream beneath it."""
     sdk_stream = _SdkStream()
     assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
     assert sdk_stream.close_calls == 1
@@ -620,6 +625,7 @@ async def test_provider_stream_closes_when_the_consumer_is_cancelled() -> None:
     wrapped = await _wrapped(sdk_stream)
 
     async def consume() -> None:
+        """Iterate until cancelled."""
         async for _ in wrapped:
             pass
 
@@ -655,4 +661,5 @@ async def test_a_failing_close_never_outranks_the_stream_outcome() -> None:
 
 @pytest.mark.asyncio
 async def test_iterator_without_a_close_method_is_left_alone() -> None:
-    assert [item async for item in await _wrapped(_PlainIterator())] == [1, 2]
+    """A source with neither aclose() nor close() streams through untouched."""
+    assert [item async for item in await _wrapped(_PlainIterable())] == [1, 2]

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -21,6 +21,7 @@ from any_llm.utils.exception_handler import (
     _STATUS_ERROR_CLASSES,
     _handle_exception,
     convert_exception,
+    handle_exceptions,
 )
 
 
@@ -504,3 +505,56 @@ def test_status_free_failures_still_use_the_message_patterns() -> None:
     status classifies exactly as it did before."""
     assert type(convert_exception(Exception("Rate limit reached"), "openai")) is RateLimitError
     assert type(convert_exception(TimeoutError("request timed out"), "openai")) is ProviderError
+
+
+class _SdkStream:
+    """An SDK stream like openai's AsyncStream: iterable, closed via close(), no aclose()."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def __aiter__(self) -> Any:
+        for item in range(3):
+            yield item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Provider:
+    PROVIDER_NAME = "test"
+
+    def __init__(self) -> None:
+        self.generator_closed = False
+        self.sdk_stream = _SdkStream()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_generator(self) -> Any:
+        async def generate() -> Any:
+            try:
+                for item in range(3):
+                    yield item
+            finally:
+                self.generator_closed = True
+
+        return generate()
+
+    @handle_exceptions(wrap_streaming=True)
+    async def stream_sdk(self) -> Any:
+        return self.sdk_stream
+
+
+@pytest.mark.asyncio
+async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
+    """A caller's aclose() must reach the provider stream, whether it spells it aclose or close."""
+    provider = _Provider()
+
+    wrapped = await provider.stream_generator()
+    await wrapped.__anext__()
+    await wrapped.aclose()
+    assert provider.generator_closed
+
+    wrapped = await provider.stream_sdk()
+    await wrapped.__anext__()
+    await wrapped.aclose()
+    assert provider.sdk_stream.closed

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -524,7 +524,7 @@ class _SdkStream:
         self.close_calls = 0
 
     async def __aiter__(self) -> AsyncIterator[int]:
-        """Yield 0, 1, 2 — parking after 0 when asked to hang."""
+        """Yield 0, 1, 2, parking after 0 when asked to hang."""
         yield 0
         if self.hang:
             self.hanging.set()

--- a/tests/unit/test_exception_handler.py
+++ b/tests/unit/test_exception_handler.py
@@ -1,3 +1,5 @@
+import asyncio
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
@@ -507,95 +509,149 @@ def test_status_free_failures_still_use_the_message_patterns() -> None:
     assert type(convert_exception(TimeoutError("request timed out"), "openai")) is ProviderError
 
 
-class _SdkStream:
-    """An SDK stream like openai's AsyncStream: iterable, closed via close(), no aclose()."""
-
-    def __init__(self) -> None:
-        self.closed = False
-
-    async def __aiter__(self) -> Any:
-        for item in range(3):
-            yield item
-
-    async def close(self) -> None:
-        self.closed = True
-
-
 _STREAM_ERROR = "stream broke"
 _CLOSE_ERROR = "close broke"
 
 
-class _SyncCloseStream:
-    """An iterable whose close() is synchronous and fails."""
+class _SdkStream:
+    """An SDK stream like openai's AsyncStream: iterable, closed through an async close(), no aclose()."""
 
-    async def __aiter__(self) -> Any:
+    def __init__(self, *, hang: bool = False, close_error: Exception | None = None) -> None:
+        self.hang = hang
+        self.hanging = asyncio.Event()
+        self.close_error = close_error
+        self.close_calls = 0
+
+    async def __aiter__(self) -> AsyncIterator[int]:
+        yield 0
+        if self.hang:
+            self.hanging.set()
+            await asyncio.Event().wait()
         yield 1
-        raise ValueError(_STREAM_ERROR)
+        yield 2
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _SyncCloseStream:
+    """A stream that fails after its first item and spells its close synchronously."""
+
+    def __init__(self, *, close_error: Exception | None = None) -> None:
+        self.close_error = close_error
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[int]:
+        yield 1
+        raise ProviderError(_STREAM_ERROR)
 
     def close(self) -> None:
-        raise RuntimeError(_CLOSE_ERROR)
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _PlainIterator:
+    """An async iterator with neither aclose() nor close()."""
+
+    def __init__(self) -> None:
+        self.items = iter([1, 2])
+
+    def __aiter__(self) -> AsyncIterator[int]:
+        return self
+
+    async def __anext__(self) -> int:
+        try:
+            return next(self.items)
+        except StopIteration:
+            raise StopAsyncIteration from None
 
 
 class _Provider:
     PROVIDER_NAME = "test"
 
-    def __init__(self) -> None:
-        self.generator_closed = False
-        self.sdk_stream = _SdkStream()
-
     @handle_exceptions(wrap_streaming=True)
-    async def stream_generator(self) -> Any:
-        async def generate() -> Any:
-            try:
-                for item in range(3):
-                    yield item
-            finally:
-                self.generator_closed = True
+    async def stream(self, source: Any) -> Any:
+        return source
 
-        return generate()
 
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_sdk(self) -> Any:
-        return self.sdk_stream
-
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_sync_close(self) -> Any:
-        return _SyncCloseStream()
-
-    @handle_exceptions(wrap_streaming=True)
-    async def stream_plain(self) -> Any:
-        async def generate() -> Any:
-            yield 1
-
-        return generate().__aiter__()
+async def _wrapped(source: Any) -> Any:
+    return await _Provider().stream(source)
 
 
 @pytest.mark.asyncio
 async def test_closing_the_wrapped_stream_closes_the_provider_stream() -> None:
-    """A caller's aclose() must reach the provider stream, whether it spells it aclose or close."""
-    provider = _Provider()
+    """A caller's aclose() reaches the provider stream, whether it spells it aclose or close, exactly once."""
+    closed: list[str] = []
 
-    wrapped = await provider.stream_generator()
+    async def generate() -> AsyncIterator[int]:
+        try:
+            yield 0
+            yield 1
+        finally:
+            closed.append("generator")
+
+    wrapped = await _wrapped(generate())
     await wrapped.__anext__()
     await wrapped.aclose()
-    assert provider.generator_closed
+    assert closed == ["generator"]
 
-    wrapped = await provider.stream_sdk()
+    sdk_stream = _SdkStream()
+    wrapped = await _wrapped(sdk_stream)
     await wrapped.__anext__()
     await wrapped.aclose()
-    assert provider.sdk_stream.closed
+    await wrapped.aclose()
+    assert sdk_stream.close_calls == 1
 
 
 @pytest.mark.asyncio
-async def test_provider_stream_closes_on_exhaustion_and_iteration_errors() -> None:
-    """Cleanup runs on every exit: exhaustion, an iteration error (still surfaced), a sync closer that fails."""
-    provider = _Provider()
+async def test_provider_stream_closes_after_exhaustion() -> None:
+    sdk_stream = _SdkStream()
+    assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
+    assert sdk_stream.close_calls == 1
 
-    assert [item async for item in await provider.stream_generator()] == [0, 1, 2]
-    assert provider.generator_closed
 
-    with pytest.raises(ValueError, match=_STREAM_ERROR):  # the stream's error wins over the failing closer
-        async for _ in await provider.stream_sync_close():
+@pytest.mark.asyncio
+async def test_provider_stream_closes_when_the_consumer_is_cancelled() -> None:
+    """Cancellation lands inside the provider stream; the wrapper still closes it on the way out."""
+    sdk_stream = _SdkStream(hang=True)
+    wrapped = await _wrapped(sdk_stream)
+
+    async def consume() -> None:
+        async for _ in wrapped:
             pass
 
-    assert [item async for item in await provider.stream_plain()] == [1]  # no close method at all is fine
+    task = asyncio.create_task(consume())
+    await sdk_stream.hanging.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sdk_stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_iteration_error_surfaces_after_a_sync_close() -> None:
+    """The failing stream is still closed, without awaiting its sync close(), and its error is what the caller sees."""
+    stream = _SyncCloseStream()
+    with pytest.raises(ProviderError, match=_STREAM_ERROR):
+        async for _ in await _wrapped(stream):
+            pass
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_a_failing_close_never_outranks_the_stream_outcome() -> None:
+    """A close() that raises changes nothing: the stream's own error wins, and a clean run stays clean."""
+    with pytest.raises(ProviderError, match=_STREAM_ERROR):
+        async for _ in await _wrapped(_SyncCloseStream(close_error=RuntimeError(_CLOSE_ERROR))):
+            pass
+
+    sdk_stream = _SdkStream(close_error=RuntimeError(_CLOSE_ERROR))
+    assert [item async for item in await _wrapped(sdk_stream)] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_iterator_without_a_close_method_is_left_alone() -> None:
+    assert [item async for item in await _wrapped(_PlainIterator())] == [1, 2]

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -869,6 +869,71 @@ async def test_default_amessages_streaming() -> None:
 
 
 @pytest.mark.asyncio
+async def test_default_amessages_streaming_aclose_closes_the_provider_stream() -> None:
+    """Closing the bridged event stream early must close the completion stream it wraps, not leave it to the GC."""
+    closed = False
+
+    async def provider_stream() -> Any:
+        nonlocal closed
+        try:
+            for text in ("Hello", " world", " again"):
+                yield ChatCompletionChunk(
+                    id="chunk",
+                    model="gpt-4",
+                    created=0,
+                    object="chat.completion.chunk",
+                    choices=[ChunkChoice(index=0, delta=ChoiceDelta(content=text), finish_reason=None)],
+                )
+        finally:
+            closed = True
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=provider_stream())
+    params = MessagesParams(model="gpt-4", messages=[{"role": "user", "content": "Hello"}], max_tokens=100, stream=True)
+
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert isinstance(result, AsyncGenerator)
+    await anext(result)
+    assert not closed
+    await result.aclose()
+
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_default_amessages_streaming_closes_the_provider_stream_when_it_fails() -> None:
+    """A provider stream that raises mid-way is still closed, and its error is the one the caller sees."""
+    closed = False
+
+    async def failing_stream() -> Any:
+        nonlocal closed
+        try:
+            yield ChatCompletionChunk(
+                id="chunk",
+                model="gpt-4",
+                created=0,
+                object="chat.completion.chunk",
+                choices=[ChunkChoice(index=0, delta=ChoiceDelta(content="Hello"), finish_reason=None)],
+            )
+            msg = "provider went away"
+            raise RuntimeError(msg)
+        finally:
+            closed = True
+
+    mock_provider = Mock()
+    mock_provider._acompletion = AsyncMock(return_value=failing_stream())
+    params = MessagesParams(model="gpt-4", messages=[{"role": "user", "content": "Hello"}], max_tokens=100, stream=True)
+
+    result = await AnyLLM._amessages(mock_provider, params)
+    assert isinstance(result, AsyncGenerator)
+    with pytest.raises(RuntimeError, match="provider went away"):
+        async for _ in result:
+            pass
+
+    assert closed
+
+
+@pytest.mark.asyncio
 async def test_default_amessages_streaming_requests_include_usage() -> None:
     """Streaming through the bridge must ask the backend for usage, otherwise
     OpenAI-compatible providers emit no usage-only chunk and the trailing-chunk

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import pytest
 
-from any_llm.utils.aio import _get_runner_loop, _runner, async_iter_to_sync_iter, run_async_in_sync
+from any_llm.utils.aio import _get_runner_loop, _runner, aclose_quietly, async_iter_to_sync_iter, run_async_in_sync
 
 
 def test_run_async_in_sync_fails_with_background_task_state() -> None:
@@ -344,6 +344,71 @@ def test_run_async_in_sync_disallows_running_loop_when_requested() -> None:
         coro.close()
 
     asyncio.run(call_from_async_context())
+
+
+class _Closable:
+    """A stream double whose close method is chosen per test: aclose, close, sync or async, or failing."""
+
+    def __init__(self, *, aclose: bool = False, close: bool = False, sync: bool = False, fail: bool = False) -> None:
+        self.calls: list[str] = []
+
+        async def _aclose() -> None:
+            self.calls.append("aclose")
+
+        def _close_sync() -> None:
+            self.calls.append("close")
+            if fail:
+                msg = "close failed"
+                raise RuntimeError(msg)
+
+        async def _close_async() -> None:
+            self.calls.append("close")
+            if fail:
+                msg = "close failed"
+                raise RuntimeError(msg)
+
+        if aclose:
+            self.aclose = _aclose
+        if close:
+            self.close = _close_sync if sync else _close_async
+
+
+@pytest.mark.asyncio
+async def test_aclose_quietly_prefers_aclose_over_close() -> None:
+    """An async generator style aclose() wins when both spellings exist."""
+    stream = _Closable(aclose=True, close=True)
+
+    await aclose_quietly(stream)
+
+    assert stream.calls == ["aclose"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False])
+async def test_aclose_quietly_calls_close_sync_or_async(sync: bool) -> None:
+    """SDK streams spell it close(); both the sync and the awaitable form run exactly once."""
+    stream = _Closable(close=True, sync=sync)
+
+    await aclose_quietly(stream)
+
+    assert stream.calls == ["close"]
+
+
+@pytest.mark.asyncio
+async def test_aclose_quietly_ignores_an_iterator_without_close() -> None:
+    """A plain iterable with nothing to close is left alone."""
+    await aclose_quietly(object())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False])
+async def test_aclose_quietly_suppresses_a_failing_close(sync: bool) -> None:
+    """A close that raises is swallowed so it can never replace the stream's own outcome."""
+    stream = _Closable(close=True, sync=sync, fail=True)
+
+    await aclose_quietly(stream)
+
+    assert stream.calls == ["close"]
 
 
 def test_async_iter_to_sync_iter_preserves_contextvars() -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -354,6 +354,9 @@ class _Closable:
 
         async def _aclose() -> None:
             self.calls.append("aclose")
+            if fail:
+                msg = "close failed"
+                raise RuntimeError(msg)
 
         def _close_sync() -> None:
             self.calls.append("close")
@@ -409,6 +412,16 @@ async def test_aclose_quietly_suppresses_a_failing_close(sync: bool) -> None:
     await aclose_quietly(stream)
 
     assert stream.calls == ["close"]
+
+
+@pytest.mark.asyncio
+async def test_aclose_quietly_suppresses_a_failing_aclose() -> None:
+    """The preferred aclose() gets the same treatment: its error is swallowed and it runs once."""
+    stream = _Closable(aclose=True, fail=True)
+
+    await aclose_quietly(stream)
+
+    assert stream.calls == ["aclose"]
 
 
 def test_async_iter_to_sync_iter_preserves_contextvars() -> None:

--- a/tests/unit/test_xml_reasoning.py
+++ b/tests/unit/test_xml_reasoning.py
@@ -359,6 +359,49 @@ async def test_wrap_chunks_preserves_metadata_order_around_partial_tag() -> None
 
 
 @pytest.mark.asyncio
+async def test_wrap_chunks_aclose_closes_the_source() -> None:
+    """Closing the wrapped stream early must close the chunk source underneath it."""
+    closed = False
+
+    async def source() -> AsyncIterator[ChatCompletionChunk]:
+        nonlocal closed
+        try:
+            for text in ("one", "two", "three"):
+                yield _make_chunk(text)
+        finally:
+            closed = True
+
+    wrapped = wrap_chunks_with_xml_reasoning(source())
+    await anext(wrapped)
+    assert not closed
+    await wrapped.aclose()  # type: ignore[attr-defined]
+
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_wrap_chunks_closes_the_source_on_exhaustion_before_the_flush() -> None:
+    """Running the source dry closes it, and the held reasoning still flushes afterwards."""
+    closed = False
+
+    async def source() -> AsyncIterator[ChatCompletionChunk]:
+        nonlocal closed
+        try:
+            yield _make_chunk("<think>unterminated reasoning")
+        finally:
+            closed = True
+
+    wrapped = wrap_chunks_with_xml_reasoning(source())
+    first = await anext(wrapped)
+    flushed = [chunk async for chunk in wrapped]
+
+    assert closed
+    assert first.choices[0].delta.content is None
+    assert len(flushed) == 1
+    assert flushed[0].choices[0].delta.reasoning is not None
+
+
+@pytest.mark.asyncio
 async def test_wrap_chunks_empty_stream_yields_nothing() -> None:
     """No chunks in means no chunks out, including no flush chunk."""
     result = await _collect_chunks(wrap_chunks_with_xml_reasoning(_async_iter_chunks([])))


### PR DESCRIPTION
## Description

Every stream any-llm returns from `acompletion`, `amessages` and `aresponses` is the `_wrap_async_iterator` generator from `handle_exceptions(wrap_streaming=True)`. It sits around the provider's own iterator so mid-stream errors get converted. When the wrapper exits early (the caller's `await it.aclose()` or `contextlib.aclosing`, the sync API's bridge, a cancelled task), `async for` never closes the iterator it was reading. The provider stream is dropped, not closed, and whatever it holds open waits for the garbage collector: asyncio's async-generator finalizer a few loop ticks later at best, or a cyclic GC pass when the SDK object sits in a reference cycle (openai's `AsyncStream` does).

The fix is one helper, `aclose_quietly()` in `utils/aio.py`, called from a `finally` in every shared generator that loops over a provider stream: the wrapper, `AnyLLM._amessages`'s `convert_stream()` (the Messages-over-Completions bridge every provider without a native Messages API goes through), `process_streaming_reasoning_chunks()` (the XML-reasoning providers), and the sync bridge's own consumer. It closes the source as `aclose()` for async generators or `close()` for SDK streams that only spell it that way (openai's `AsyncStream`, which `_aresponses` returns raw; `_acompletion` is typed `AsyncIterator`, so `contextlib.aclosing` would not fit), awaits the result only when there is one, and suppresses a failing close so it never replaces the stream's own outcome. The sync bridge previously handled `aclose()` alone and awaited only coroutines; it now shares the helper. The close runs on every exit: explicit `aclose()`, exhaustion, an iteration error, a cancellation that lands inside the generator. On an iterator that already finished it is a no-op. Closing a generator before its first `__anext__()` cannot reach its body; that limitation predates this change and holds for every layer, so it stays out of scope.

What this buys depends on what the wrapped iterator owns. Where it owns the HTTP response, the response now closes inside the caller's `aclose()`: anthropic's `_amessages`/`_acompletion` generators (`async with client.messages.stream(...)`) and openai's `_aresponses` (the SDK `AsyncStream` returned raw). Where a provider generator only loops over an SDK stream (`async for chunk in response: yield ...`, which is openai's `_acompletion` and most other providers), the generator is now closed, but its own `async for` has the same gap one level down, so the SDK stream still waits for GC. With this round every shared, non-provider generator closes its source (`grep "async for" src/any_llm` outside `providers/` is exactly these four sites); the per-provider `chunk_iterator()` layer is the remaining follow-up.

Live check: read one event, `await it.aclose()`, then read the SDK's httpx/aiohttp response and the client's connection pool, holding only weak references so the check itself keeps nothing alive.

| path | before | after |
|---|---|---|
| anthropic `amessages` (`async with messages.stream`) | response open, pool `ACTIVE` at `aclose()` and one tick later; closed about 0.3s later by the async-generator finalizer | closed, pool released, at `aclose()` |
| openai `aresponses` (raw `AsyncStream`) | open, pool `ACTIVE` until a cyclic `gc.collect()` | closed, pool released, at `aclose()` |
| bridged `amessages` (any provider without a native Messages API) | `convert_stream()` dropped the completion stream on `aclose()` | completion stream closed inside `aclose()` (unit-tested; the SDK layer below it is the provider follow-up) |
| openai `acompletion` (provider generator over `AsyncStream`) | open, pool `ACTIVE` until `gc.collect()` | unchanged, provider-level follow-up |
| gemini `acompletion` (provider generator over the genai generator) | open, aiohttp connection acquired until `gc.collect()` | unchanged, provider-level follow-up |

The sync API closes the wrapper when the caller stops iterating, so `completion(stream=True)` with `break` gets the same behaviour through the bridge.

Tests: `aclose()` reaches an async generator and an SDK-style `close()`, once even when the wrapper is closed twice; the SDK-style stream is closed after exhaustion, after a cancelled consumer, and after an iteration error whose sync `close()` is not awaited; a failing `close()` never replaces the stream's error or a clean run; an iterator with no close method is left alone. Closing the bridged `amessages` event stream early closes the completion stream under it, and closing the XML-reasoning wrapper closes its chunk source; both fail without the new `finally` blocks. A provider stream that fails mid-bridge is still closed with its error intact, the reasoning source is closed on exhaustion before the held flush, and `aclose_quietly()` has its own tests for `aclose()` over `close()`, sync and awaitable `close()`, no close method, and a failing close. The first four wrapper tests fail on main.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses and reasoning streams now close reliably after completion, cancellation, early termination, or errors.
  * Supports synchronous and asynchronous stream cleanup while safely suppressing cleanup failures.
  * Provider errors continue to propagate correctly while streams are closed safely.

* **Tests**
  * Added coverage for stream bridging, reasoning output preservation, cancellation, iteration errors, different close methods, failed cleanup, and streams without cleanup support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
