### PR TITLE
fix(gemini): accept parsed tool arguments and results

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -275,7 +275,8 @@ def _convert_messages(
                     function_call = tool_call["function"]
                     if tool_call_id := tool_call.get("id"):
                         tool_names[tool_call_id] = function_call["name"]
-                    args = json.loads(function_call["arguments"]) if function_call["arguments"] else {}
+                    arguments = function_call["arguments"]
+                    args = json.loads(arguments) if isinstance(arguments, str) and arguments else arguments or {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)
                     # SDK accepts base64 string or bytes
@@ -307,13 +308,14 @@ def _convert_messages(
             formatted_messages.append(types.Content(role="model", parts=parts))
         elif message["role"] == "tool":
             name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
-            try:
-                content_json = json.loads(message["content"])
-                part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content_json))
-                formatted_messages.append(types.Content(role="function", parts=[part]))
-            except json.JSONDecodeError:
-                part = types.Part.from_function_response(name=name, response={"result": message["content"]})
-                formatted_messages.append(types.Content(role="function", parts=[part]))
+            content = message["content"]
+            if isinstance(content, str):
+                try:
+                    content = json.loads(content)
+                except json.JSONDecodeError:
+                    pass
+            part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content))
+            formatted_messages.append(types.Content(role="function", parts=[part]))
 
     return formatted_messages, system_instruction
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import json
 import mimetypes
+from contextlib import suppress
 from time import time
 from typing import Any, Literal, cast
 
@@ -275,7 +276,7 @@ def _convert_messages(
                     function_call = tool_call["function"]
                     if tool_call_id := tool_call.get("id"):
                         tool_names[tool_call_id] = function_call["name"]
-                    arguments = function_call["arguments"]
+                    arguments = function_call.get("arguments")
                     args = json.loads(arguments) if isinstance(arguments, str) and arguments else arguments or {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)
@@ -310,10 +311,8 @@ def _convert_messages(
             name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
             content = message["content"]
             if isinstance(content, str):
-                try:
+                with suppress(json.JSONDecodeError):
                     content = json.loads(content)
-                except json.JSONDecodeError:
-                    pass
             part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content))
             formatted_messages.append(types.Content(role="function", parts=[part]))
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -315,7 +315,7 @@ def _convert_messages(
             name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
             content = message["content"]
             if isinstance(content, (str, bytes, bytearray)):
-                with suppress(json.JSONDecodeError):
+                with suppress(json.JSONDecodeError, UnicodeDecodeError):
                     content = json.loads(content)
             part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content))
             formatted_messages.append(types.Content(role="function", parts=[part]))

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -277,7 +277,11 @@ def _convert_messages(
                     if tool_call_id := tool_call.get("id"):
                         tool_names[tool_call_id] = function_call["name"]
                     arguments = function_call.get("arguments")
-                    args = json.loads(arguments) if isinstance(arguments, str) and arguments else arguments or {}
+                    args = (
+                        json.loads(arguments)
+                        if isinstance(arguments, (str, bytes, bytearray)) and arguments
+                        else arguments or {}
+                    )
 
                     # Extract thought_signature if present (OpenAI compatibility format)
                     # SDK accepts base64 string or bytes
@@ -310,7 +314,7 @@ def _convert_messages(
         elif message["role"] == "tool":
             name = message.get("name") or tool_names.get(message.get("tool_call_id", ""), "unknown")
             content = message["content"]
-            if isinstance(content, str):
+            if isinstance(content, (str, bytes, bytearray)):
                 with suppress(json.JSONDecodeError):
                     content = json.loads(content)
             part = types.Part.from_function_response(name=name, response=_normalize_tool_response(content))

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1740,6 +1740,8 @@ def test_convert_messages_tool_call_without_a_signature_keeps_the_skip_sentinel(
     ("function", "expected_args"),
     [
         ({"name": "get_weather", "arguments": '{"location": "Paris"}'}, {"location": "Paris"}),
+        ({"name": "get_weather", "arguments": b'{"location": "Paris"}'}, {"location": "Paris"}),
+        ({"name": "get_weather", "arguments": bytearray(b'{"location": "Paris"}')}, {"location": "Paris"}),
         ({"name": "get_weather", "arguments": {"location": "Paris"}}, {"location": "Paris"}),
         ({"name": "get_weather"}, {}),
         ({"name": "get_weather", "arguments": None}, {}),
@@ -2063,6 +2065,8 @@ def test_convert_messages_parallel_tool_calls_only_first_gets_skip_sentinel() ->
     ("tool_content", "expected_response"),
     [
         ('{"temp": "20C"}', {"temp": "20C"}),
+        (b'{"temp": "20C"}', {"temp": "20C"}),
+        (bytearray(b'{"temp": "20C"}'), {"temp": "20C"}),
         ({"temp": "20C"}, {"temp": "20C"}),
         ("[]", {"result": []}),
         ([], {"result": []}),

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -2067,6 +2067,8 @@ def test_convert_messages_parallel_tool_calls_only_first_gets_skip_sentinel() ->
         ('{"temp": "20C"}', {"temp": "20C"}),
         (b'{"temp": "20C"}', {"temp": "20C"}),
         (bytearray(b'{"temp": "20C"}'), {"temp": "20C"}),
+        (b"\xff", {"result": b"\xff"}),
+        (bytearray(b"\xff"), {"result": bytearray(b"\xff")}),
         ({"temp": "20C"}, {"temp": "20C"}),
         ("[]", {"result": []}),
         ([], {"result": []}),

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1736,8 +1736,19 @@ def test_convert_messages_tool_call_without_a_signature_keeps_the_skip_sentinel(
     assert part_json["thought_signature"] == "skip_thought_signature_validator"
 
 
-@pytest.mark.parametrize("arguments", ['{"location": "Paris"}', {"location": "Paris"}])
-def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(arguments: Any) -> None:
+@pytest.mark.parametrize(
+    ("function", "expected_args"),
+    [
+        ({"name": "get_weather", "arguments": '{"location": "Paris"}'}, {"location": "Paris"}),
+        ({"name": "get_weather", "arguments": {"location": "Paris"}}, {"location": "Paris"}),
+        ({"name": "get_weather"}, {}),
+        ({"name": "get_weather", "arguments": None}, {}),
+        ({"name": "get_weather", "arguments": ""}, {}),
+    ],
+)
+def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(
+    function: dict[str, Any], expected_args: dict[str, Any]
+) -> None:
     messages: list[dict[str, Any]] = [
         {
             "role": "assistant",
@@ -1746,7 +1757,7 @@ def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(arguments: 
                 {
                     "id": "call_1",
                     "type": "function",
-                    "function": {"name": "get_weather", "arguments": arguments},
+                    "function": function,
                 }
             ],
         }
@@ -1757,7 +1768,7 @@ def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(arguments: 
     assert formatted_messages[0].parts is not None
     function_call = formatted_messages[0].parts[0].function_call
     assert function_call is not None
-    assert function_call.args == {"location": "Paris"}
+    assert function_call.args == expected_args
 
 
 def test_convert_messages_with_thought_signature_in_extra_content() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -1736,6 +1736,30 @@ def test_convert_messages_tool_call_without_a_signature_keeps_the_skip_sentinel(
     assert part_json["thought_signature"] == "skip_thought_signature_validator"
 
 
+@pytest.mark.parametrize("arguments", ['{"location": "Paris"}', {"location": "Paris"}])
+def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(arguments: Any) -> None:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": arguments},
+                }
+            ],
+        }
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    assert formatted_messages[0].parts is not None
+    function_call = formatted_messages[0].parts[0].function_call
+    assert function_call is not None
+    assert function_call.args == {"location": "Paris"}
+
+
 def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     # Use valid base64 that round-trips correctly
     original_bytes = b"test-signature-bytes"
@@ -2028,12 +2052,16 @@ def test_convert_messages_parallel_tool_calls_only_first_gets_skip_sentinel() ->
     ("tool_content", "expected_response"),
     [
         ('{"temp": "20C"}', {"temp": "20C"}),
+        ({"temp": "20C"}, {"temp": "20C"}),
         ("[]", {"result": []}),
+        ([], {"result": []}),
+        ([{"type": "text", "text": "ok"}], {"result": [{"type": "text", "text": "ok"}]}),
         ("1", {"result": 1}),
+        ("not JSON", {"result": "not JSON"}),
     ],
 )
-def test_convert_messages_tool_response_normalizes_non_objects(
-    tool_content: str, expected_response: dict[str, Any]
+def test_convert_messages_tool_response_accepts_json_or_parsed_content(
+    tool_content: Any, expected_response: dict[str, Any]
 ) -> None:
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "What is the weather?"},


### PR DESCRIPTION
## Description

Gemini message conversion called `json.loads` for tool arguments and tool-result content even when callers had already parsed those values. Non-empty dictionaries and lists therefore raised `TypeError` before a request could be sent.

This change only decodes string values. Parsed assistant arguments are reused, and parsed tool-result mappings/lists continue through the existing response normalization. JSON strings and the non-JSON string fallback keep their previous output.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1321

## Validation

- `pytest -q tests/unit/providers/test_gemini_provider.py --reruns 0` -> `184 passed`
- `pytest -q tests/unit --reruns 0` -> `2259 passed, 69 skipped`
- `pre-commit run --all-files --verbose` -> passed, including Ruff, Ruff format, mypy, and codespell

The conversion is credential-free and fails before any Gemini request on the old code, so no live provider call was needed for reproduction. The repository integration workflow can provide the live provider check.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable; this restores accepted input handling without a public API change)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex desktop
- Any other info you'd like to share: The agent independently reproduced the issue, implemented the change test-first, and ran the repository's full unit and pre-commit checks.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gemini tool-call handling for structured arguments and JSON-formatted strings.
  - Improved tool-response processing for dictionaries, lists, bytes, bytearrays, valid JSON, and plain text.
  - Preserved non-JSON response content instead of rejecting or incorrectly transforming it.
  - Handled missing, null, and empty tool-call arguments consistently.

- **Tests**
  - Added coverage for supported tool-call argument and tool-response formats, including parsed and encoded content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->