### PR TITLE
fix(providers): keep the assistant text when the turn also calls a tool

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -176,6 +176,10 @@ def _convert_messages_for_anthropic(messages: list[dict[str, Any]]) -> tuple[str
                 content_blocks: list[dict[str, Any]] = []
                 if thinking_block := _build_anthropic_thinking_block(message):
                     content_blocks.append(thinking_block)
+                # The model's own text belongs in its turn, between the thinking and the tool_use blocks.
+                content = message.get("content")
+                if isinstance(content, str) and content:
+                    content_blocks.append({"type": "text", "text": content})
                 for tool_call in message["tool_calls"]:
                     content_blocks.append(
                         {

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -271,8 +271,21 @@ def _convert_messages(
                         logger.debug("Skipping unsupported Gemini content block type: %s", content.get("type"))
             formatted_messages.append(types.Content(role="user", parts=parts))
         elif message["role"] == "assistant":
+            parts = []
+            # The model's own text belongs in its turn, ahead of any function calls it made.
+            content = message.get("content")
+            has_text = isinstance(content, str) and content
+            if has_text or not message.get("tool_calls"):
+                parts.append(
+                    types.Part(
+                        text=content,
+                        # The SDK field is typed bytes but its validator decodes a base64 str.
+                        thought_signature=cast(
+                            "bytes | None", _extract_google_thought_signature(message, provider_name)
+                        ),
+                    )
+                )
             if message.get("tool_calls"):
-                parts = []
                 for i, tool_call in enumerate(message["tool_calls"]):
                     function_call = tool_call["function"]
                     if tool_call_id := tool_call.get("id"):
@@ -300,16 +313,6 @@ def _convert_messages(
                             thought_signature=cast("bytes | None", thought_signature),
                         )
                     )
-            else:
-                parts = [
-                    types.Part(
-                        text=message["content"],
-                        # The SDK field is typed bytes but its validator decodes a base64 str.
-                        thought_signature=cast(
-                            "bytes | None", _extract_google_thought_signature(message, provider_name)
-                        ),
-                    )
-                ]
 
             formatted_messages.append(types.Content(role="model", parts=parts))
         elif message["role"] == "tool":
@@ -473,7 +476,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                 {
                     "message": {
                         "role": "assistant",
-                        "content": None if tool_calls_list else text_content,
+                        "content": text_content,
                         "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
                         "extra_content": message_extra_content,

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1543,6 +1543,17 @@ def test_convert_messages_tool_call_turn_without_text_emits_only_tool_use(conten
     assert [block["type"] for block in converted[0]["content"]] == ["tool_use"]
 
 
+def test_convert_messages_keeps_text_when_tool_calls_is_empty() -> None:
+    """An assistant turn with text and an empty tool_calls list keeps its text instead of sending content: []."""
+    from any_llm.providers.anthropic.utils import _convert_messages_for_anthropic
+
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": "I will check the weather.", "tool_calls": []}]
+
+    _, converted = _convert_messages_for_anthropic(messages)
+
+    assert converted[0]["content"] == [{"type": "text", "text": "I will check the weather."}]
+
+
 def test_convert_messages_replays_thinking_block_with_text() -> None:
     """A plain-text assistant message that carries a thinking signature should also replay it.
 

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1496,6 +1496,53 @@ def test_convert_messages_replays_thinking_block_with_tool_call() -> None:
     }
 
 
+def test_convert_messages_replays_assistant_text_between_thinking_and_tool_use() -> None:
+    """A turn that thought, spoke and then called a tool replays in that order, as Claude produced it."""
+    from any_llm.providers.anthropic.utils import _convert_messages_for_anthropic
+
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Tell me your plan, then get the weather."},
+        {
+            "role": "assistant",
+            "content": "I will look up the weather in Paris.",
+            "reasoning": "The user wants a plan first.",
+            "extra_content": {"anthropic": {"signature": "sig-12345"}},
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                }
+            ],
+        },
+    ]
+
+    _, converted = _convert_messages_for_anthropic(messages)
+
+    assert [block["type"] for block in converted[1]["content"]] == ["thinking", "text", "tool_use"]
+    assert converted[1]["content"][1] == {"type": "text", "text": "I will look up the weather in Paris."}
+
+
+@pytest.mark.parametrize("content", [None, ""])
+def test_convert_messages_tool_call_turn_without_text_emits_only_tool_use(content: str | None) -> None:
+    """No empty text block is fabricated for a tool-call turn with nothing to say (Anthropic rejects them)."""
+    from any_llm.providers.anthropic.utils import _convert_messages_for_anthropic
+
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": "toolu_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+            ],
+        },
+    ]
+
+    _, converted = _convert_messages_for_anthropic(messages)
+
+    assert [block["type"] for block in converted[0]["content"]] == ["tool_use"]
+
+
 def test_convert_messages_replays_thinking_block_with_text() -> None:
     """A plain-text assistant message that carries a thinking signature should also replay it.
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -929,6 +929,24 @@ def test_convert_response_accumulates_multiple_text_parts() -> None:
     assert message["reasoning"] is None
 
 
+def test_convert_response_keeps_text_alongside_function_call() -> None:
+    """A turn that speaks and then calls a tool reports both, as the streaming converter already does."""
+    response = _make_gemini_response(
+        [
+            types.Part(text="I will look up the weather in Paris."),
+            types.Part(function_call=types.FunctionCall(name="get_weather", args={"location": "Paris"})),
+        ],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    message = response_dict["choices"][0]["message"]
+    assert message["content"] == "I will look up the weather in Paris."
+    assert [tool_call["function"]["name"] for tool_call in message["tool_calls"]] == ["get_weather"]
+    assert response_dict["choices"][0]["finish_reason"] == "tool_calls"
+
+
 def test_convert_response_skips_parts_without_text_or_function_call() -> None:
     """A candidate can mix in parts that carry neither text nor a tool call, e.g. inline image
     data; those must not disturb the accumulated text."""
@@ -2047,6 +2065,103 @@ def test_convert_messages_invalid_base64_raises_invalid_request() -> None:
 
     with pytest.raises(InvalidRequestError, match="invalid base64"):
         _convert_messages(messages)
+
+
+def test_convert_messages_replays_assistant_text_ahead_of_its_tool_calls() -> None:
+    """A turn that spoke and then called a tool replays as [text, function_call], signatures on their own parts."""
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Tell me your plan, then get the weather."},
+        {
+            "role": "assistant",
+            "content": "I will look up the weather in Paris.",
+            "extra_content": {"google": {"thought_signature": "dGV4dA=="}},
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"location": "Paris"}'},
+                    "extra_content": {"google": {"thought_signature": "Y2FsbA=="}},
+                }
+            ],
+        },
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert [part.text for part in parts] == ["I will look up the weather in Paris.", None]
+    assert parts[0].function_call is None
+    assert parts[0].thought_signature == b"text"
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "get_weather"
+    assert parts[1].thought_signature == b"call"
+
+
+@pytest.mark.parametrize("content", [None, "", [{"type": "text", "text": "ignored"}]])
+def test_convert_messages_tool_call_turn_without_text_emits_only_function_calls(content: Any) -> None:
+    """Only a non-empty string adds a text part to a tool-call turn; the first call keeps the skip sentinel."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+            ],
+        },
+    ]
+
+    formatted_messages, _ = _convert_messages(messages)
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert parts[0].thought_signature is not None
+
+
+def test_convert_messages_tool_call_turn_rejects_an_undecodable_text_signature() -> None:
+    """The text part of a tool-call turn goes through the same signature check as a text-only turn."""
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": "I will look up the weather.",
+            "extra_content": {"google": {"thought_signature": 12345}},
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+            ],
+        },
+    ]
+
+    with pytest.raises(InvalidRequestError, match="thought_signature"):
+        _convert_messages(messages)
+
+
+def test_convert_messages_round_trips_a_text_and_tool_call_turn() -> None:
+    """Response -> ChatCompletionMessage -> dump (as acompletion replays it) -> model turn keeps text and both signatures."""
+    response = _make_gemini_response(
+        [
+            types.Part(text="I will look up the weather in Paris.", thought_signature=b"text-sig"),
+            types.Part(
+                function_call=types.FunctionCall(name="get_weather", args={"location": "Paris"}),
+                thought_signature=b"call-sig",
+            ),
+        ],
+        types.FinishReason.STOP,
+    )
+    message = ChatCompletionMessage.model_validate(
+        _convert_response_to_response_dict(response)["choices"][0]["message"]
+    )
+    replayed = message.model_dump(exclude_none=True, exclude={"reasoning"})
+
+    formatted_messages, _ = _convert_messages([{"role": "user", "content": "Plan, then weather?"}, replayed])
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert [part.text for part in parts] == ["I will look up the weather in Paris.", None]
+    assert parts[0].thought_signature == b"text-sig"
+    assert parts[1].function_call is not None
+    assert parts[1].thought_signature == b"call-sig"
 
 
 def test_convert_messages_without_thought_signature_uses_skip_sentinel() -> None:


### PR DESCRIPTION
## Description

When a model writes a sentence and then calls a tool in the same turn, any-llm loses the sentence on Gemini and Anthropic. Two seams, same shape:

- `gemini/utils.py::_convert_response_to_response_dict` set `content` to `None` whenever the response carried a function call, so the text part never reached the caller (the streaming converter already kept it). `_convert_messages` then rebuilt a tool-call turn from `tool_calls` alone, so even a caller who had the text could not replay it.
- `anthropic/utils.py::_convert_messages_for_anthropic` built the tool-call turn from the thinking block plus the `tool_use` blocks and never read `content`.

The model cannot see that it already announced its plan, so it announces it again instead of answering. No API error, so nothing in the suite noticed. Bedrock's converter already does this right (`bedrock/utils.py:377`, text before `toolUse`), so the fix follows that shape. Gemini reports `content` and `tool_calls` together and replays the text `Part` ahead of the function-call parts; a message-level `thought_signature` rides on that part, which covers the limitation noted on #1320 for the only shape Gemini 3 has been seen to produce (a non-empty text part). Anthropic inserts the text block between thinking and `tool_use`. Only a non-empty string adds a part or block: tool-call turns with `content` `None` or `""` still emit only call parts, so no empty text is ever sent, and list-shaped assistant content keeps today's behaviour on both providers. A side effect on Anthropic: an assistant turn with text and `tool_calls: []` used to produce `content: []`, which the API rejects; it now carries its text.

Live, through `acompletion`, prompt "Before calling any tool, write one sentence telling me your plan. Then get the weather in Paris.", tool result fed back:

| model | before: turn 1 `content` / turn 2 | after: turn 1 `content` / turn 2 |
|---|---|---|
| gemini-3.1-pro-preview | `None` / "I will use the weather tool to find the current weather conditions in Paris. The current..." | "I will use the weather API tool to..." / "The current weather in Paris is 18°C and cloudy." |
| gemini-3-flash-preview | `None` / "OK. The weather in Paris is currently 18°C and cloudy." | "I will call the weather tool to..." / "The current weather in Paris is 18°C and cloudy." |
| claude-sonnet-5 | text / "I'll check the current weather conditions in Paris for you using the weather tool. The we..." | text / "The weather in Paris is currently 18°C and cloudy." |
| claude-haiku-4-5 | text / "My plan is to call the get_weather function with Paris as the city parameter. The weather..." | text / "The weather in Paris is currently 18°C and cloudy." |

Streamed first turns, accumulated and replayed, behave the same on both providers. `tests/integration` for gemini and anthropic on this branch: 50 passed, 13 skipped, both agent-loop tests included. Unit tests: the response keeps text next to a function call; Gemini replays `[text, function_call]` with each signature on its own part and round-trips response -> `ChatCompletionMessage` -> dump -> model turn; a malformed message-level signature on a tool-call turn is rejected like a text-only one; Anthropic replays `[thinking, text, tool_use]`; tool-call turns with `None`/`""` content still emit only call parts. The positive tests fail on main, the negative ones pin what must not change.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Follow-up to #1320 (signed text part beside a function call). None open.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Fable 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved assistant text alongside tool calls for Anthropic and Gemini.
  * Gemini responses now retain text content and finish reasons when function calls are present.
  * Prevented empty text blocks from being emitted for tool-only assistant turns.
* **Tests**
  * Added coverage for text and tool-call ordering, signatures, absent content, and response conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->