### PR TITLE
fix(xai): preserve tool call IDs in request history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ voyage = [
 ]
 
 xai = [
-  "xai-sdk>=1.0.1",
+  "xai-sdk>=1.6.0",
 ]
 
 sagemaker = [

--- a/src/any_llm/providers/xai/utils.py
+++ b/src/any_llm/providers/xai/utils.py
@@ -1,4 +1,3 @@
-import uuid
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -76,7 +75,7 @@ def _convert_xai_chunk_to_anyllm_chunk(chunk: XaiChunk) -> ChatCompletionChunk:
                 delta_tool_calls_list.append(
                     ChoiceDeltaToolCall(
                         index=idx,
-                        id=str(uuid.uuid4()),
+                        id=tc.id,
                         type="function",
                         function=ChoiceDeltaToolCallFunction(name=func.name, arguments=func.arguments),
                     )

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -17,6 +17,7 @@ try:
     from xai_sdk.chat import Chunk as XaiChunk
     from xai_sdk.chat import Response as XaiResponse
     from xai_sdk.chat import assistant, required_tool, system, tool_result, user
+    from xai_sdk.proto import chat_pb2
 
     from .utils import (
         _convert_models_list,
@@ -187,15 +188,27 @@ class XaiProvider(AnyLLM):
             if message["role"] == "user":
                 xai_messages.append(user(message["content"]))
             elif message["role"] == "assistant":
-                args: list[str] = []
-                if message.get("tool_calls"):
-                    # No idea how to pass tool calls reconstructed in the original protobuf format.
-                    args.extend(str(tool_call) for tool_call in message["tool_calls"])
-                xai_messages.append(assistant(*args, message["content"]))
+                content = message["content"]
+                xai_message = (
+                    assistant(content) if content is not None else chat_pb2.Message(role=chat_pb2.ROLE_ASSISTANT)
+                )
+                for tool_call in message.get("tool_calls") or []:
+                    function = tool_call["function"]
+                    xai_message.tool_calls.append(
+                        chat_pb2.ToolCall(
+                            id=tool_call["id"],
+                            type=chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
+                            function=chat_pb2.FunctionCall(
+                                name=function["name"],
+                                arguments=function["arguments"],
+                            ),
+                        )
+                    )
+                xai_messages.append(xai_message)
             elif message["role"] == "system":
                 xai_messages.append(system(message["content"]))
             elif message["role"] == "tool":
-                xai_messages.append(tool_result(message["content"]))
+                xai_messages.append(tool_result(message["content"], tool_call_id=message.get("tool_call_id")))
         if params.tools is not None:
             kwargs["tools"] = _convert_openai_tools_to_xai_tools(params.tools)
 
@@ -214,15 +227,11 @@ class XaiProvider(AnyLLM):
         # since xAI's parse() only supports Pydantic BaseModel.
         response_format_pb = None
         if params.response_format is not None and dataclasses.is_dataclass(params.response_format):
-            from xai_sdk.proto import chat_pb2
-
             response_format_pb = chat_pb2.ResponseFormat(
                 format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
                 schema=json.dumps(get_json_schema(params.response_format)),
             )
         elif params.response_format is not None and isinstance(params.response_format, dict):
-            from xai_sdk.proto import chat_pb2
-
             rf = params.response_format
             if rf.get("type") == "json_schema":
                 json_schema = rf.get("json_schema", {})

--- a/src/any_llm/providers/xai/xai.py
+++ b/src/any_llm/providers/xai/xai.py
@@ -188,19 +188,22 @@ class XaiProvider(AnyLLM):
             if message["role"] == "user":
                 xai_messages.append(user(message["content"]))
             elif message["role"] == "assistant":
-                content = message["content"]
+                content = message.get("content")
                 xai_message = (
                     assistant(content) if content is not None else chat_pb2.Message(role=chat_pb2.ROLE_ASSISTANT)
                 )
                 for tool_call in message.get("tool_calls") or []:
                     function = tool_call["function"]
+                    arguments = function.get("arguments")
+                    if not isinstance(arguments, str):
+                        arguments = json.dumps(arguments or {})
                     xai_message.tool_calls.append(
                         chat_pb2.ToolCall(
                             id=tool_call["id"],
                             type=chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
                             function=chat_pb2.FunctionCall(
                                 name=function["name"],
-                                arguments=function["arguments"],
+                                arguments=arguments,
                             ),
                         )
                     )

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -224,6 +224,58 @@ async def test_completion_replays_tool_calls_and_reversed_results_by_id() -> Non
 
 
 @pytest.mark.asyncio
+async def test_completion_accepts_assistant_message_without_content_key() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                }
+            ],
+        }
+    ]
+
+    with mock_xai_provider() as (mock_xai, _):
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(CompletionParams(model_id="model", messages=messages))
+
+        xai_message = mock_xai.return_value.chat.create.call_args.kwargs["messages"][0]
+        assert list(xai_message.content) == []
+        assert xai_message.tool_calls[0].id == "call_weather"
+
+
+@pytest.mark.asyncio
+async def test_completion_serializes_parsed_tool_call_arguments() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": {"city": "Paris"}},
+                }
+            ],
+        }
+    ]
+
+    with mock_xai_provider() as (mock_xai, _):
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(CompletionParams(model_id="model", messages=messages))
+
+        xai_message = mock_xai.return_value.chat.create.call_args.kwargs["messages"][0]
+        assert xai_message.tool_calls[0].function.arguments == '{"city": "Paris"}'
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("content", "expected_content"),
     [
@@ -276,6 +328,38 @@ async def test_completion_preserves_assistant_message_without_tool_calls() -> No
         xai_message = mock_xai.return_value.chat.create.call_args.kwargs["messages"][0]
         assert [part.text for part in xai_message.content] == ["Previous answer."]
         assert list(xai_message.tool_calls) == []
+
+
+def test_streaming_response_preserves_tool_call_id() -> None:
+    from xai_sdk.chat import Chunk
+    from xai_sdk.proto import chat_pb2
+
+    from any_llm.providers.xai.utils import _convert_xai_chunk_to_anyllm_chunk
+
+    proto = chat_pb2.GetChatCompletionChunk(
+        id="chunk",
+        model="model",
+        outputs=[
+            chat_pb2.CompletionOutputChunk(
+                index=0,
+                delta=chat_pb2.Delta(
+                    role=chat_pb2.ROLE_ASSISTANT,
+                    tool_calls=[
+                        chat_pb2.ToolCall(
+                            id="call_from_xai",
+                            type=chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
+                            function=chat_pb2.FunctionCall(name="get_weather", arguments='{"city":"Paris"}'),
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+
+    converted = _convert_xai_chunk_to_anyllm_chunk(Chunk(proto, None))
+
+    assert converted.choices[0].delta.tool_calls is not None
+    assert converted.choices[0].delta.tool_calls[0].id == "call_from_xai"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -162,6 +162,123 @@ async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, 
 
 
 @pytest.mark.asyncio
+async def test_completion_replays_tool_calls_and_reversed_results_by_id() -> None:
+    from xai_sdk.proto import chat_pb2
+
+    from any_llm.providers.xai.xai import XaiProvider
+
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Weather in Toronto and Paris?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_toronto",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Toronto"}'},
+                },
+                {
+                    "id": "call_paris",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_paris", "content": '{"temp":30}'},
+        {"role": "tool", "tool_call_id": "call_toronto", "content": '{"temp":-5}'},
+    ]
+
+    with mock_xai_provider() as (mock_xai, _):
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(CompletionParams(model_id="model", messages=messages))
+
+        xai_messages = mock_xai.return_value.chat.create.call_args.kwargs["messages"]
+        assistant_message = xai_messages[1]
+        assert assistant_message.role == chat_pb2.ROLE_ASSISTANT
+        assert list(assistant_message.content) == []
+        assert [
+            (call.id, call.type, call.function.name, call.function.arguments) for call in assistant_message.tool_calls
+        ] == [
+            (
+                "call_toronto",
+                chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
+                "get_weather",
+                '{"city":"Toronto"}',
+            ),
+            (
+                "call_paris",
+                chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
+                "get_weather",
+                '{"city":"Paris"}',
+            ),
+        ]
+
+        tool_messages = xai_messages[2:]
+        assert [message.role for message in tool_messages] == [chat_pb2.ROLE_TOOL, chat_pb2.ROLE_TOOL]
+        assert [message.tool_call_id for message in tool_messages] == ["call_paris", "call_toronto"]
+        assert [[part.text for part in message.content] for message in tool_messages] == [
+            ['{"temp":30}'],
+            ['{"temp":-5}'],
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        (None, []),
+        ("", [""]),
+        ("I will check the weather.", ["I will check the weather."]),
+    ],
+)
+async def test_completion_preserves_assistant_content_with_tool_calls(
+    content: str | None, expected_content: list[str]
+) -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                }
+            ],
+        }
+    ]
+
+    with mock_xai_provider() as (mock_xai, _):
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(CompletionParams(model_id="model", messages=messages))
+
+        xai_message = mock_xai.return_value.chat.create.call_args.kwargs["messages"][0]
+        assert [part.text for part in xai_message.content] == expected_content
+        assert len(xai_message.tool_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_preserves_assistant_message_without_tool_calls() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with mock_xai_provider() as (mock_xai, _):
+        provider = XaiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="model",
+                messages=[{"role": "assistant", "content": "Previous answer."}],
+            )
+        )
+
+        xai_message = mock_xai.return_value.chat.create.call_args.kwargs["messages"][0]
+        assert [part.text for part in xai_message.content] == ["Previous answer."]
+        assert list(xai_message.tool_calls) == []
+
+
+@pytest.mark.asyncio
 async def test_dataclass_response_format_uses_sample_not_parse() -> None:
     """Test that dataclass response_format uses sample() with protobuf schema, not parse()."""
     from dataclasses import dataclass


### PR DESCRIPTION
## Description

`XaiProvider` previously stringified assistant tool calls into text and omitted `tool_call_id` from tool-result messages. That made parallel results depend on position instead of the IDs returned by the model. A tool-calling assistant message with `content=None` also failed locally before a request could be sent.

This change reconstructs each assistant call as a real xAI protobuf `ToolCall`, preserving its ID, client-side tool type, function name, and JSON arguments. Tool results now carry the matching `tool_call_id`. Assistant content remains absent for `None` and is preserved for empty strings and ordinary text; assistant messages without tool calls retain their existing behavior.

The regression test sends two results in reverse call order and verifies that the protobuf messages still associate them by ID.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1323

## Validation

- `uv run pytest -q tests/unit/providers/test_xai_provider.py --reruns 0`: 18 passed
- Full unit suite with local proxy variables removed for the test process: 2258 passed, 69 skipped
- `UV_SYSTEM_PYTHON=0 uv run pre-commit run --all-files --verbose`: passed, including Ruff, Ruff format, mypy, codespell, and nbstripout

The conversion regression and fix are credential-free and were verified against the real protobuf types from `xai-sdk==1.17.0`. I do not have `XAI_API_KEY`, so I did not run or claim a live xAI request. Maintainers, please add the `run-integration-tests` label for the repository's xAI integration coverage.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable; this restores correct provider request conversion without changing the public API)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex desktop
- Any other info you'd like to share: The agent independently rechecked issue ownership and competing PRs, reproduced the defect offline, worked test-first, and ran the repository's full unit and pre-commit checks.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved xAI conversation handling for assistant messages, including preserved content and messages without tool calls.
  * Preserved tool-call identifiers in standard and streaming responses, with accurate tool-result mapping when results arrive in a different order.
  * Improved support for multiple tool calls, structured response formats, and serialised tool-call arguments.

* **Chores**
  * Updated the optional xAI integration to use a newer SDK version.

* **Tests**
  * Added coverage for tool-call reconstruction, content preservation, streaming identifiers, and tool-result mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->