### PR TITLE
fix(providers): preserve typed safety refusals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "pydantic>2,<3",
   "openai>=2.18.0",
   "openresponses-types>=2.4.0,<3",
-  "anthropic>=0.83.0",
+  "anthropic>=0.119.0",
   "rich",
   "httpx",
   "typing_extensions>=4.5.0",
@@ -49,11 +49,11 @@ vertexai = [
 ]
 
 vertexaianthropic = [
-  "anthropic[vertex]>=0.83.0",
+  "anthropic[vertex]>=0.119.0",
 ]
 
 azureanthropic = [
-  "anthropic>=0.83.0",
+  "anthropic>=0.119.0",
 ]
 
 huggingface = [

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -8,9 +8,11 @@ from anthropic.types import (
     ContentBlockStartEvent,
     ContentBlockStopEvent,
     Message,
+    MessageDeltaEvent,
     MessageStopEvent,
 )
 from anthropic.types.model_info import ModelInfo as AnthropicModelInfo
+from pydantic import BaseModel
 
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.logging import logger
@@ -31,6 +33,7 @@ from any_llm.types.model import Model
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 DEFAULT_MAX_TOKENS = 8192
+_ANTHROPIC_CONTENT_FILTER_REFUSAL = "Response blocked by Anthropic content filtering."
 # OpenAI has no counterpart for the "stop_sequence" and "pause_turn" stop reasons, so those
 # fall through to the "stop" default. "refusal" (a safety stop) and
 # "model_context_window_exceeded" (the model ran out of context rather than out of max_tokens)
@@ -51,6 +54,14 @@ REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
     "xhigh": "xhigh",
     "max": "max",
 }
+
+
+def _refusal_stop_details(value: object) -> dict[str, Any] | None:
+    """Return typed Anthropic refusal details when the installed SDK exposes them."""
+    stop_details = getattr(value, "stop_details", None)
+    if isinstance(stop_details, BaseModel):
+        return stop_details.model_dump(mode="json", exclude_none=True)
+    return None
 
 
 def _is_tool_call(message: dict[str, Any]) -> bool:
@@ -275,13 +286,20 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
             delta = {"extra_content": {"anthropic": {"signature": chunk.delta.signature}}}
 
     elif isinstance(chunk, ContentBlockStopEvent):
-        if hasattr(chunk, "content_block") and chunk.content_block.type == "tool_use":
-            finish_reason = "tool_calls"
-        else:
-            finish_reason = None
+        finish_reason = None
+
+    elif isinstance(chunk, MessageDeltaEvent):
+        stop_reason = chunk.delta.stop_reason
+        finish_reason = (
+            ANTHROPIC_STOP_REASON_TO_FINISH_REASON.get(stop_reason, "stop") if stop_reason is not None else None
+        )
+        if finish_reason == "content_filter":
+            delta = {"refusal": _ANTHROPIC_CONTENT_FILTER_REFUSAL}
+        if stop_details := _refusal_stop_details(chunk.delta):
+            delta["extra_content"] = {"anthropic": {"stop_details": stop_details}}
 
     elif isinstance(chunk, MessageStopEvent):
-        finish_reason = "stop"
+        finish_reason = None
         if hasattr(chunk, "message") and chunk.message.usage:
             anthropic_usage = chunk.message.usage
             cache_read = anthropic_usage.cache_read_input_tokens or 0
@@ -349,12 +367,19 @@ def _convert_response(response: Message) -> ChatCompletion:
             # which is what the streaming converter already does for the same block types.
             logger.warning("Skipping unsupported Anthropic content block type: %s", content_block.type)
 
+    anthropic_extra_content: dict[str, Any] = {}
+    if thinking_signature:
+        anthropic_extra_content["signature"] = thinking_signature
+    if stop_details := _refusal_stop_details(response):
+        anthropic_extra_content["stop_details"] = stop_details
+
     message = ChatCompletionMessage(
         role="assistant",
         content="".join(content_parts),
+        refusal=_ANTHROPIC_CONTENT_FILTER_REFUSAL if finish_reason == "content_filter" else None,
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         tool_calls=tool_calls or None,
-        extra_content={"anthropic": {"signature": thinking_signature}} if thinking_signature else None,
+        extra_content={"anthropic": anthropic_extra_content} if anthropic_extra_content else None,
     )
 
     cache_read = response.usage.cache_read_input_tokens or 0

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -31,6 +31,18 @@ from any_llm.types.model import Model
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
 DEFAULT_MAX_TOKENS = 8192
+# OpenAI has no counterpart for the "stop_sequence" and "pause_turn" stop reasons, so those
+# fall through to the "stop" default. "refusal" (a safety stop) and
+# "model_context_window_exceeded" (the model ran out of context rather than out of max_tokens)
+# do have one, and without it a refused or truncated answer looks like a normal completion.
+# See https://docs.claude.com/en/docs/build-with-claude/handling-stop-reasons
+ANTHROPIC_STOP_REASON_TO_FINISH_REASON = {
+    "end_turn": "stop",
+    "max_tokens": "length",
+    "model_context_window_exceeded": "length",
+    "tool_use": "tool_calls",
+    "refusal": "content_filter",
+}
 REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
     "minimal": "low",
     "low": "low",
@@ -297,8 +309,7 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
 def _convert_response(response: Message) -> ChatCompletion:
     """Convert Anthropic Message to OpenAI ChatCompletion format."""
     finish_reason_raw = response.stop_reason or "end_turn"
-    finish_reason_map = {"end_turn": "stop", "max_tokens": "length", "tool_use": "tool_calls"}
-    finish_reason = finish_reason_map.get(finish_reason_raw, "stop")
+    finish_reason = ANTHROPIC_STOP_REASON_TO_FINISH_REASON.get(finish_reason_raw, "stop")
 
     content_parts: list[str] = []
     tool_calls: list[ChatCompletionMessageFunctionToolCall | ChatCompletionMessageToolCall] = []

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -238,6 +238,7 @@ class GoogleProvider(AnyLLM):
             message = ChatCompletionMessage(
                 role="assistant",
                 content=message_dict.get("content"),
+                refusal=message_dict.get("refusal"),
                 tool_calls=tool_calls,
                 reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
                 extra_content=message_dict.get("extra_content"),

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -30,6 +30,7 @@ from any_llm.types.completion import (
 from any_llm.types.model import Model
 
 _INLINE_SIZE_LIMIT = 20 * 1024 * 1024
+_GEMINI_CONTENT_FILTER_REFUSAL = "Response blocked by Gemini content filtering."
 
 
 def _has_json_schema_refs(schema: Any) -> bool:
@@ -404,6 +405,16 @@ def _resolve_finish_reason(
     return mapped_finish_reason
 
 
+def _prompt_was_blocked(response: types.GenerateContentResponse) -> bool:
+    """Return whether Gemini rejected the prompt before producing a candidate."""
+    prompt_feedback = response.prompt_feedback
+    return (
+        prompt_feedback is not None
+        and isinstance(prompt_feedback.block_reason, types.BlockedReason)
+        and prompt_feedback.block_reason is not types.BlockedReason.BLOCKED_REASON_UNSPECIFIED
+    )
+
+
 def _convert_response_to_response_dict(response: types.GenerateContentResponse) -> dict[str, Any]:
     """Convert a Gemini GenerateContentResponse into an OpenAI-shaped completion dict."""
     response_dict = {
@@ -466,11 +477,27 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                         "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
                         "extra_content": message_extra_content,
+                        "refusal": _GEMINI_CONTENT_FILTER_REFUSAL if mapped_finish_reason == "content_filter" else None,
                     },
                     "finish_reason": _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list)) or "stop",
                     "index": 0,
                 }
             )
+    elif _prompt_was_blocked(response):
+        choices.append(
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning": None,
+                    "tool_calls": None,
+                    "extra_content": None,
+                    "refusal": _GEMINI_CONTENT_FILTER_REFUSAL,
+                },
+                "finish_reason": "content_filter",
+                "index": 0,
+            }
+        )
 
     response_dict["choices"] = choices
 
@@ -517,8 +544,7 @@ def _create_openai_chunk_from_google_chunk(
             than restarting at 0 for every chunk.
     """
 
-    assert response.candidates
-    candidate = response.candidates[0]
+    candidate = response.candidates[0] if response.candidates else None
 
     if tool_call_counter is None:
         tool_call_counter = [0]
@@ -530,7 +556,7 @@ def _create_openai_chunk_from_google_chunk(
 
     # Content can be absent on terminal chunks, e.g. when the response is truncated or
     # filtered before any part is produced; the finish reason must still be surfaced.
-    parts = candidate.content.parts if candidate.content else None
+    parts = candidate.content.parts if candidate and candidate.content else None
 
     for part in parts or []:
         if part.thought:
@@ -565,11 +591,16 @@ def _create_openai_chunk_from_google_chunk(
             message_extra_content = _thought_signature_extra_content(part) or message_extra_content
 
     # Unmapped reasons stay None so non-final chunks are not forced to a terminal reason.
-    finish_reason = _resolve_finish_reason(_map_finish_reason(candidate.finish_reason), bool(tool_calls_list))
+    mapped_finish_reason = _map_finish_reason(candidate.finish_reason) if candidate else None
+    prompt_was_blocked = _prompt_was_blocked(response)
+    finish_reason = (
+        "content_filter" if prompt_was_blocked else _resolve_finish_reason(mapped_finish_reason, bool(tool_calls_list))
+    )
 
     delta = ChoiceDelta(
         content=content or None,
         role="assistant",
+        refusal=_GEMINI_CONTENT_FILTER_REFUSAL if finish_reason == "content_filter" else None,
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         tool_calls=tool_calls_list or None,
         extra_content=message_extra_content,

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -10,6 +10,7 @@ import pytest
 from anthropic import transform_schema
 from anthropic.types import Message
 from anthropic.types.model_info import ModelInfo
+from anthropic.types.stop_reason import StopReason
 from pydantic import BaseModel
 
 from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
@@ -1096,6 +1097,66 @@ def test_non_streaming_response_preserves_multiple_tool_calls() -> None:
     assert isinstance(result.choices[0].message.tool_calls[1], ChatCompletionMessageFunctionToolCall)
     assert result.choices[0].message.tool_calls[1].function is not None
     assert result.choices[0].message.tool_calls[1].function.name == "get_time"
+
+
+@pytest.mark.parametrize("stop_reason", get_args(StopReason))
+def test_non_streaming_response_maps_every_anthropic_stop_reason(stop_reason: StopReason) -> None:
+    """Every stop reason the API can return needs an explicit OpenAI finish_reason.
+
+    An unmapped one falls back to "stop", which tells callers the model answered normally
+    when it actually refused or ran out of context.
+    """
+    from anthropic.types import Message, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    expected_finish_reasons: dict[str, str] = {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "pause_turn": "stop",
+        "max_tokens": "length",
+        "model_context_window_exceeded": "length",
+        "tool_use": "tool_calls",
+        "refusal": "content_filter",
+    }
+    assert stop_reason in expected_finish_reasons, (
+        f"New Anthropic stop reason {stop_reason!r} needs a finish_reason mapping."
+    )
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason=stop_reason,
+        content=[TextBlock(type="text", text="Hello")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == expected_finish_reasons[stop_reason]
+
+
+def test_non_streaming_response_without_stop_reason_finishes_as_stop() -> None:
+    """A response with no stop_reason at all still needs a valid finish_reason."""
+    from anthropic.types import Message, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        model="claude-3-haiku",
+        stop_reason=None,
+        content=[TextBlock(type="text", text="Hello")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == "stop"
 
 
 def test_non_streaming_response_preserves_thinking_signature() -> None:

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -930,6 +930,7 @@ def test_streaming_chunk_includes_cache_tokens_in_usage() -> None:
     assert result.usage.total_tokens == expected_total_tokens
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 13332
+    assert result.choices[0].finish_reason is None
 
 
 @pytest.mark.asyncio
@@ -999,6 +1000,7 @@ def test_streaming_chunk_without_cache_tokens() -> None:
     assert result.usage.completion_tokens == 50
     assert result.usage.total_tokens == 150
     assert result.usage.prompt_tokens_details is None
+    assert result.choices[0].finish_reason is None
 
 
 def test_streaming_tool_chunks_preserve_parallel_tool_index() -> None:
@@ -1136,6 +1138,9 @@ def test_non_streaming_response_maps_every_anthropic_stop_reason(stop_reason: St
     result = _convert_response(response)
 
     assert result.choices[0].finish_reason == expected_finish_reasons[stop_reason]
+    assert result.choices[0].message.refusal == (
+        "Response blocked by Anthropic content filtering." if stop_reason == "refusal" else None
+    )
 
 
 def test_non_streaming_response_without_stop_reason_finishes_as_stop() -> None:
@@ -1157,6 +1162,130 @@ def test_non_streaming_response_without_stop_reason_finishes_as_stop() -> None:
     result = _convert_response(response)
 
     assert result.choices[0].finish_reason == "stop"
+    assert result.choices[0].message.refusal is None
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected_finish_reason", "expected_refusal"),
+    [
+        ("end_turn", "stop", None),
+        ("max_tokens", "length", None),
+        ("stop_sequence", "stop", None),
+        ("pause_turn", "stop", None),
+        ("tool_use", "tool_calls", None),
+        ("model_context_window_exceeded", "length", None),
+        ("refusal", "content_filter", "Response blocked by Anthropic content filtering."),
+        (None, None, None),
+    ],
+)
+def test_streaming_message_delta_preserves_terminal_reason(
+    stop_reason: StopReason | None, expected_finish_reason: str | None, expected_refusal: str | None
+) -> None:
+    from anthropic.types import MessageDeltaEvent, MessageDeltaUsage
+    from anthropic.types.raw_message_delta_event import Delta
+
+    from any_llm.providers.anthropic.utils import _create_openai_chunk_from_anthropic_chunk
+
+    chunk = MessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason=stop_reason, stop_sequence=None),
+        usage=MessageDeltaUsage(output_tokens=5),
+    )
+
+    result = _create_openai_chunk_from_anthropic_chunk(chunk, "claude-sonnet-4-5")
+
+    assert result.choices[0].finish_reason == expected_finish_reason
+    assert result.choices[0].delta.refusal == expected_refusal
+
+
+def test_non_streaming_refusal_preserves_stop_details() -> None:
+    from anthropic.types import Message, RefusalStopDetails, TextBlock, Usage
+
+    from any_llm.providers.anthropic.utils import _convert_response
+
+    response = Message(
+        id="msg_refusal",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-4-5",
+        stop_reason="refusal",
+        stop_details=RefusalStopDetails(type="refusal", category="bio", explanation="Request declined."),
+        content=[TextBlock(type="text", text="Request declined.")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+
+    result = _convert_response(response)
+
+    assert result.choices[0].message.extra_content == {
+        "anthropic": {
+            "stop_details": {
+                "type": "refusal",
+                "category": "bio",
+                "explanation": "Request declined.",
+            }
+        }
+    }
+
+
+def test_streaming_refusal_preserves_stop_details() -> None:
+    from anthropic.types import MessageDeltaEvent, MessageDeltaUsage, RefusalStopDetails
+    from anthropic.types.raw_message_delta_event import Delta
+
+    from any_llm.providers.anthropic.utils import _create_openai_chunk_from_anthropic_chunk
+
+    chunk = MessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(
+            stop_reason="refusal",
+            stop_sequence=None,
+            stop_details=RefusalStopDetails(type="refusal", category="bio", explanation="Request declined."),
+        ),
+        usage=MessageDeltaUsage(output_tokens=5),
+    )
+
+    result = _create_openai_chunk_from_anthropic_chunk(chunk, "claude-sonnet-4-5")
+
+    assert result.choices[0].delta.extra_content == {
+        "anthropic": {
+            "stop_details": {
+                "type": "refusal",
+                "category": "bio",
+                "explanation": "Request declined.",
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected_finish_reason"),
+    [("end_turn", "stop"), ("tool_use", "tool_calls"), ("refusal", "content_filter")],
+)
+def test_stream_sequence_has_one_terminal_reason(stop_reason: StopReason, expected_finish_reason: str) -> None:
+    from anthropic.types import (
+        ContentBlockStopEvent,
+        MessageDeltaEvent,
+        MessageDeltaUsage,
+        MessageStopEvent,
+    )
+    from anthropic.types.raw_message_delta_event import Delta
+
+    from any_llm.providers.anthropic.utils import _create_openai_chunk_from_anthropic_chunk
+
+    events = [
+        ContentBlockStopEvent(type="content_block_stop", index=0),
+        MessageDeltaEvent(
+            type="message_delta",
+            delta=Delta(stop_reason=stop_reason, stop_sequence=None),
+            usage=MessageDeltaUsage(output_tokens=1),
+        ),
+        MessageStopEvent(type="message_stop"),
+    ]
+
+    results = [_create_openai_chunk_from_anthropic_chunk(event, "claude-sonnet-4-5") for event in events]
+
+    assert [choice.finish_reason for result in results for choice in result.choices if choice.finish_reason] == [
+        expected_finish_reason
+    ]
 
 
 def test_non_streaming_response_preserves_thinking_signature() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -67,6 +67,13 @@ def _make_gemini_response(
     )
 
 
+def _make_gemini_prompt_block(block_reason: types.BlockedReason) -> types.GenerateContentResponse:
+    return types.GenerateContentResponse(
+        candidates=None,
+        prompt_feedback=types.GenerateContentResponsePromptFeedback(block_reason=block_reason),
+    )
+
+
 @contextmanager
 def mock_gemini_provider():  # type: ignore[no-untyped-def]
     with (
@@ -828,6 +835,9 @@ def test_convert_response_maps_finish_reason(
     choice = response_dict["choices"][0]
     assert choice["finish_reason"] == expected_finish_reason
     assert choice["message"]["content"] == "Hello"
+    assert choice["message"]["refusal"] == (
+        "Response blocked by Gemini content filtering." if expected_finish_reason == "content_filter" else None
+    )
 
 
 @pytest.mark.parametrize(
@@ -944,6 +954,44 @@ def test_convert_response_emits_choice_for_filtered_response_without_content() -
     choice = response_dict["choices"][0]
     assert choice["finish_reason"] == "content_filter"
     assert choice["message"]["content"] is None
+    assert choice["message"]["refusal"] == "Response blocked by Gemini content filtering."
+
+
+@pytest.mark.parametrize(
+    "block_reason",
+    [reason for reason in types.BlockedReason if reason is not types.BlockedReason.BLOCKED_REASON_UNSPECIFIED],
+)
+def test_convert_response_maps_prompt_block_to_content_filter(block_reason: types.BlockedReason) -> None:
+    response_dict = _convert_response_to_response_dict(_make_gemini_prompt_block(block_reason))
+
+    assert len(response_dict["choices"]) == 1
+    choice = response_dict["choices"][0]
+    assert choice["finish_reason"] == "content_filter"
+    assert choice["message"]["content"] is None
+    assert choice["message"]["refusal"] == "Response blocked by Gemini content filtering."
+
+
+def test_convert_response_does_not_filter_unspecified_prompt_feedback() -> None:
+    response_dict = _convert_response_to_response_dict(
+        _make_gemini_prompt_block(types.BlockedReason.BLOCKED_REASON_UNSPECIFIED)
+    )
+
+    assert response_dict["choices"] == []
+
+
+def test_convert_response_without_candidate_or_prompt_feedback_has_no_choices() -> None:
+    response_dict = _convert_response_to_response_dict(types.GenerateContentResponse(candidates=None))
+
+    assert response_dict["choices"] == []
+
+
+def test_google_provider_preserves_prompt_block_as_refusal() -> None:
+    response_dict = _convert_response_to_response_dict(_make_gemini_prompt_block(types.BlockedReason.SAFETY))
+
+    result = GoogleProvider._convert_completion_response((response_dict, "gemini-3.5-flash"))
+
+    assert result.choices[0].finish_reason == "content_filter"
+    assert result.choices[0].message.refusal == "Response blocked by Gemini content filtering."
 
 
 def test_convert_response_without_content_and_terminal_reason_has_no_choices() -> None:
@@ -2657,6 +2705,38 @@ def test_streaming_chunk_emits_finish_reason_for_filtered_chunk_without_content(
 
     assert chunk.choices[0].finish_reason == "content_filter"
     assert chunk.choices[0].delta.content is None
+    assert chunk.choices[0].delta.refusal == "Response blocked by Gemini content filtering."
+
+
+def test_streaming_chunk_maps_prompt_block_to_refusal() -> None:
+    chunk = _create_openai_chunk_from_google_chunk(_make_gemini_prompt_block(types.BlockedReason.SAFETY))
+
+    assert chunk.choices[0].finish_reason == "content_filter"
+    assert chunk.choices[0].delta.content is None
+    assert chunk.choices[0].delta.refusal == "Response blocked by Gemini content filtering."
+
+
+def test_streaming_prompt_block_has_one_terminal_refusal() -> None:
+    responses = [
+        types.GenerateContentResponse(candidates=None),
+        _make_gemini_prompt_block(types.BlockedReason.SAFETY),
+    ]
+
+    chunks = [_create_openai_chunk_from_google_chunk(response) for response in responses]
+
+    assert [choice.finish_reason for chunk in chunks for choice in chunk.choices if choice.finish_reason] == [
+        "content_filter"
+    ]
+    assert [choice.delta.refusal for chunk in chunks for choice in chunk.choices if choice.delta.refusal] == [
+        "Response blocked by Gemini content filtering."
+    ]
+
+
+def test_streaming_chunk_without_candidate_or_prompt_block_remains_nonterminal() -> None:
+    chunk = _create_openai_chunk_from_google_chunk(types.GenerateContentResponse(candidates=None))
+
+    assert chunk.choices[0].finish_reason is None
+    assert chunk.choices[0].delta.refusal is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Preserve provider-typed safety refusals through the existing OpenAI-compatible completion contract so downstream agent runtimes can terminate blocked work without parsing refusal prose.

- Anthropic `stop_reason="refusal"` maps to `finish_reason="content_filter"` in non-streaming and streaming responses, with `message.refusal` / `delta.refusal` populated.
- Anthropic `stop_details` remains available under existing `extra_content.anthropic.stop_details`; ordinary model-written refusals remain ordinary text.
- Anthropic terminal reasons now come from `message_delta`, so the official `content_block_stop -> message_delta -> message_stop` sequence emits exactly one terminal marker.
- Gemini candidate content-filter reasons now populate `message.refusal` / `delta.refusal` in addition to the already-normalized `content_filter` finish reason.
- Gemini prompt blocks with no candidates now become a typed content-filter choice rather than an empty completion or streaming assertion.
- Empty unblocked Gemini chunks remain nonterminal; ordinary answers, reasoning, and tool calls are unchanged.

This incorporates the original commit from #1306 unchanged, preserving its author and co-author attribution, and completes its streaming path. It also builds on the merged Gemini candidate mapping from #1202.

A deterministic live safety-filter test would require committing prohibited prompts and would be inherently unstable as provider classifiers change. The safety paths therefore use official Anthropic and Google SDK response objects with their documented enums. Real-key integration tests verify that normal responses still work through both changed providers.

## PR Type

- 🐛 Bug Fix

## Relevant issues

- Extends and supersedes #1306 while preserving its original commit attribution.
- Complements the Gemini candidate finish-reason work in #1202.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (no user-facing API changed; provider metadata uses existing fields)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## Verification

- `uv run pre-commit run --all-files --verbose`
- `uv run pytest -q --reruns 0 tests/unit`: 2,289 passed, 67 optional-provider skips
- Changed provider suites: 292 passed
- Real-key integration, `gemini-3-flash-preview` and `claude-haiku-4-5`:
  - async non-streaming completion
  - async streaming completion
  - 4 passed; normal responses returned one `stop` and no refusal
- Cross-repository consumer smoke: Gemini prompt-block and Anthropic refusal fixtures crossed `AnyLLMModel` in streamed and non-streamed modes and became the consumer's typed terminal safety outcome.
- Independent Standards re-review: no findings.
- Independent Spec re-review against the official provider schemas: no findings.

## AI Usage Information

- AI Model used: GPT-5 Codex
- AI Developer Tool used: Codex
- Any other info you'd like to share: The implementation was iterated under human direction, tested against official SDK response types, live normal provider calls, and independently reviewed along separate Standards and Spec axes.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer content-filter refusal details to Anthropic and Gemini responses.
  * Added support for Gemini prompt-block refusals, including streamed responses.
  * Preserved Anthropic stop details alongside thinking information.
  * Added consistent mapping of provider stop reasons to standard finish reasons.

* **Bug Fixes**
  * Improved consistency of streaming finish reasons.
  * Prevented duplicate finish reasons in streamed Anthropic responses.
  * Ensured filtered responses are represented correctly when no candidate is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
