### PR TITLE
fix(gemini): route tool schemas with type unions through JSON Schema

### DIFF
--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -49,6 +49,24 @@ def _has_json_schema_refs(schema: Any) -> bool:
     return False
 
 
+def _has_type_unions(schema: Any) -> bool:
+    """Return True if *schema* declares a type as a list, e.g. ``["string", "null"]``.
+
+    ``google.genai.types.Schema.type`` is a single ``types.Type`` enum, so the OpenAPI
+    3.0 shape cannot express a union and the API rejects the request. JSON Schema does
+    allow the list form, so such schemas must be routed through
+    ``FunctionDeclaration.parameters_json_schema``, which the SDK forwards to the
+    server as raw JSON Schema.
+    """
+    if isinstance(schema, dict):
+        if isinstance(schema.get("type"), list):
+            return True
+        return any(_has_type_unions(v) for v in schema.values())
+    if isinstance(schema, list):
+        return any(_has_type_unions(v) for v in schema)
+    return False
+
+
 def _has_additional_properties(schema: Any) -> bool:
     """Return True if *schema* sets ``additionalProperties`` anywhere, nested included.
 
@@ -86,7 +104,7 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any], provider_name: str) ->
         function = tool["function"]
         params: dict[str, Any] = function.get("parameters") or {}
 
-        if _has_json_schema_refs(params):
+        if _has_json_schema_refs(params) or _has_type_unions(params):
             function_declarations.append(
                 types.FunctionDeclaration(
                     name=function["name"],

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -344,11 +344,14 @@ def _convert_messages(
                     if tool_call_id := tool_call.get("id"):
                         tool_names[tool_call_id] = function_call["name"]
                     arguments = function_call.get("arguments")
-                    args = (
-                        json.loads(arguments)
-                        if isinstance(arguments, (str, bytes, bytearray)) and arguments
-                        else arguments or {}
-                    )
+                    if isinstance(arguments, (str, bytes, bytearray)) and arguments:
+                        try:
+                            args = json.loads(arguments)
+                        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                            msg = f"Tool call arguments for {function_call['name']!r} must be valid JSON"
+                            raise InvalidRequestError(msg, exc, provider_name) from exc
+                    else:
+                        args = arguments or {}
 
                     # Extract thought_signature if present (OpenAI compatibility format)
                     # SDK accepts base64 string or bytes

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -512,6 +512,7 @@ def test_has_additional_properties(schema: Any, expected: bool) -> None:
         ({"type": "object", "required": ["a", "b"], "properties": {"a": {"type": "string"}}}, False),
         ({"type": "string", "enum": ["a", "b"]}, False),
         ({"anyOf": [{"type": "string"}, {"type": "null"}]}, False),
+        ({"anyOf": [{"type": ["string", "null"]}]}, True),
         ("not-a-schema", False),
     ],
 )

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -23,6 +23,7 @@ from any_llm.providers.gemini.utils import (
     _convert_tool_spec,
     _create_openai_chunk_from_google_chunk,
     _has_additional_properties,
+    _has_type_unions,
     _map_finish_reason,
 )
 from any_llm.types.completion import (
@@ -484,6 +485,105 @@ async def test_completion_with_dataclass_response_format() -> None:
 )
 def test_has_additional_properties(schema: Any, expected: bool) -> None:
     assert _has_additional_properties(schema) is expected
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected"),
+    [
+        ({"type": ["string", "null"]}, True),
+        ({"type": "object", "properties": {"a": {"type": ["string", "null"]}}}, True),
+        # The union that matters in practice sits inside array items, which the
+        # OpenAPI path copies verbatim into types.Schema.
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "object", "properties": {"a": {"type": ["string", "null"]}}},
+                    }
+                },
+            },
+            True,
+        ),
+        # A single-element list is still a list and still unrepresentable.
+        ({"type": ["string"]}, True),
+        # Lists that are not type declarations must not trigger the routing.
+        ({"type": "object", "required": ["a", "b"], "properties": {"a": {"type": "string"}}}, False),
+        ({"type": "string", "enum": ["a", "b"]}, False),
+        ({"anyOf": [{"type": "string"}, {"type": "null"}]}, False),
+        ("not-a-schema", False),
+    ],
+)
+def test_has_type_unions(schema: Any, expected: bool) -> None:
+    assert _has_type_unions(schema) is expected
+
+
+def test_convert_tool_spec_type_union_routes_through_json_schema() -> None:
+    """A nullable field written as ``{"type": ["string", "null"]}`` must not be reshaped.
+
+    ``types.Schema.type`` is a single ``types.Type`` enum, so the OpenAPI path serializes
+    the list into a field that cannot hold it and Gemini answers 400. The union survives
+    only through ``parameters_json_schema``.
+    """
+    raw_params = {
+        "type": "object",
+        "properties": {
+            "candidates": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string"},
+                        "category": {"type": "string", "enum": ["preference", "fact"]},
+                        "valid_from_date": {"type": ["string", "null"]},
+                    },
+                    "required": ["content", "category"],
+                },
+            }
+        },
+        "required": ["candidates"],
+    }
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "submit_candidates",
+                "description": "Submit candidates.",
+                "parameters": raw_params,
+            },
+        }
+    ]
+
+    tools = _convert_tool_spec(openai_tools, "gemini")
+
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.parameters is None
+    assert decl.parameters_json_schema == raw_params
+
+
+def test_convert_tool_spec_without_type_unions_still_uses_openapi_path() -> None:
+    """The reshaping path is unchanged for schemas types.Schema can represent."""
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "echo",
+                "description": "Echo a word.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"word": {"type": "string"}},
+                    "required": ["word"],
+                },
+            },
+        }
+    ]
+
+    tools = _convert_tool_spec(openai_tools, "gemini")
+
+    decl = tools[0].function_declarations[0]  # type: ignore[index]
+    assert decl.parameters_json_schema is None
+    assert decl.parameters is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -2066,6 +2066,38 @@ def test_convert_messages_accepts_json_or_parsed_tool_call_arguments(
     assert function_call.args == expected_args
 
 
+@pytest.mark.parametrize(
+    ("arguments", "expected_exception"),
+    [
+        ("{not-json", json.JSONDecodeError),
+        (b"\xff", UnicodeDecodeError),
+        (bytearray(b"\xff"), UnicodeDecodeError),
+    ],
+)
+def test_convert_messages_rejects_malformed_serialized_tool_call_arguments(
+    arguments: str | bytes | bytearray, expected_exception: type[Exception]
+) -> None:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": arguments},
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(InvalidRequestError, match="must be valid JSON") as exc_info:
+        _convert_messages(messages)
+
+    assert isinstance(exc_info.value.original_exception, expected_exception)
+    assert isinstance(exc_info.value.__cause__, expected_exception)
+
+
 def test_convert_messages_with_thought_signature_in_extra_content() -> None:
     # Use valid base64 that round-trips correctly
     original_bytes = b"test-signature-bytes"


### PR DESCRIPTION
## Why

A tool whose schema marks a field nullable the JSON Schema way —
`{"type": ["string", "null"]}` — cannot be sent to Gemini at all. It fails
locally in `_convert_tool_spec`, before any request goes out:

```
ValidationError: 2 validation errors for Schema
properties.candidates.items.properties.valid_from_date.type
  Input should be 'TYPE_UNSPECIFIED', 'STRING', 'NUMBER', 'INTEGER',
  'BOOLEAN', 'ARRAY', 'OBJECT' or 'NULL'
  [type=enum, input_value=['string', 'null'], input_type=list]
```

`_convert_tool_spec` reshapes a tool's parameters into
`types.Schema(**parameters_dict)` unless the schema carries `$defs`/`$ref`.
Nested schemas are copied verbatim into `items`, so a union inside array items
reaches `Schema`, and `Schema.type` is a single `Type` enum — it cannot hold a
list. The SDK is explicit about the two dialects:

- [`FunctionDeclaration.parameters`](https://github.com/googleapis/python-genai/blob/main/google/genai/types.py)
  is `Optional[Schema]`: *"Describes the parameters to this function in JSON
  Schema Object format. **Reflects the Open API 3.03 Parameter Object.**"*
  OpenAPI 3.0 has no type unions; it spells nullability as `nullable: true`, and
  `Schema.nullable` exists for exactly that.
- [`FunctionDeclaration.parameters_json_schema`](https://github.com/googleapis/python-genai/blob/main/google/genai/types.py)
  is `Optional[Any]`: *"Describes the parameters to the function in JSON Schema
  format. […] This field is mutually exclusive with `parameters`."* JSON Schema
  does allow the list form.

Gemini's function-calling guide says the same thing from the other side —
[*"Only a subset of the OpenAPI schema is supported"*](https://ai.google.dev/gemini-api/docs/function-calling)
for `parameters`.

## What changed

Type unions now take the escape hatch `$defs`/`$ref` already use: route the
schema through `parameters_json_schema` instead of reshaping it. `_has_type_unions`
mirrors the existing `_has_json_schema_refs` and `_has_additional_properties`
detectors. Schemas without unions keep the OpenAPI path untouched.

## Notes

- **Verified against the live Gemini API**, `gemini-3.7-flash`, with a nested
  tool using two `["string", "null"]` fields: `main` raises the `ValidationError`
  above; this branch returns the expected `tool_calls`. Also checked through
  `mozilla-ai/otari`'s `/messages` endpoint, where the same schema currently
  surfaces as `UpstreamProviderError`.
- **`anyOf` is deliberately out of scope.** Pydantic emits that form for optional
  fields, and `Schema.any_of` exists, so it needs mapping rather than routing —
  a separate change. This PR only covers the list-of-types form.
- The `response_format` path is unaffected. Its `types.Schema` branch only
  receives Pydantic-generated schemas, which use `anyOf`, and raw dicts already
  go to `response_json_schema`.
- `tests/unit/providers/test_openai_exceptions.py` fails to collect on `main`
  (missing `httpx2`), unrelated to this change. The rest of `tests/unit` passes:
  2255 passed, 69 skipped.

Found while routing Mozilla.ai Octonous memory-synthesis tool calls through Otari
to Gemini. Investigated and written with Claude Code (Claude Opus 5).

## PR Type

- [ ] 🆕 New Feature
- [x] 🐛 Bug Fix
- [ ] 💅 Refactor
- [ ] 📚 Documentation
- [ ] 🚦 Infrastructure

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The change was investigated and written with Claude Code, then verified against the live Gemini API and the unit test suite.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Gemini tools using JSON Schema type unions, including nested and array-item unions.
  * Preserved existing schema conversion for formats that remain fully representable.
  * Added support for schemas containing references and definitions by retaining their original JSON Schema representation.
  * Improved error reporting when tool-call arguments contain invalid JSON, with a clear request error identifying the affected function.

* **Tests**
  * Added coverage for type unions, nested schemas, enums, `anyOf`, invalid schemas, conversion behaviour, and malformed tool-call arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

