### PR TITLE
Refactor/portkey native sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,9 @@ nebius = []
 neosantara = []
 openai = []
 openrouter = []
-portkey = []
+portkey = [
+  "portkey-ai>=2.3.4"
+]
 qiniu = []
 requesty = []
 sambanova = []

--- a/src/any_llm/providers/portkey/portkey.py
+++ b/src/any_llm/providers/portkey/portkey.py
@@ -210,7 +210,7 @@ class PortkeyProvider(AnyLLM):
         **kwargs: Any,
     ) -> ModerationResponse:
         include_raw = kwargs.pop("include_raw", False)
-        model_name = model or "omni-moderation-latest"
+        model_name = model or "text-moderation-latest"
 
         raw = await self.client.moderations.create(
             model=model_name,

--- a/src/any_llm/providers/portkey/portkey.py
+++ b/src/any_llm/providers/portkey/portkey.py
@@ -1,19 +1,43 @@
-from typing import Any
+from __future__ import annotations
 
-from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
-from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
+from typing import TYPE_CHECKING, Any, cast
+
 from typing_extensions import override
 
-from any_llm.providers.openai.xml_reasoning import XMLReasoningOpenAIProvider
-from any_llm.providers.openai.xml_reasoning_utils import (
-    convert_chat_completion_chunk_with_xml_reasoning,
-    convert_chat_completion_with_xml_reasoning,
+from any_llm.any_llm import AnyLLM
+from any_llm.providers.openai.utils import (
+    _convert_moderation_response_from_openai,
+    _normalize_openai_dict_response,
+)
+from any_llm.providers.openai.xml_reasoning import (
+    wrap_chunks_with_xml_reasoning,
 )
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+from any_llm.types.model import Model
+from any_llm.utils.reasoning import normalize_reasoning_from_provider_fields_and_xml_tags
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
+MISSING_PACKAGES_ERROR = None
+try:
+    from portkey_ai import AsyncPortkey
+except ImportError as e:
+    MISSING_PACKAGES_ERROR = e
 
-class PortkeyProvider(XMLReasoningOpenAIProvider):
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from portkey_ai.api_resources.types.chat_complete_type import (
+        ChatCompletions as PortkeyChatCompletions,
+    )
+    from portkey_ai.api_resources.types.models_type import (
+        ModelList as PortkeyModelList,
+    )
+
+    from any_llm.types.completion import CreateEmbeddingResponse
+    from any_llm.types.moderation import ModerationResponse
+
+
+class PortkeyProvider(AnyLLM):
     """Portkey provider for accessing 200+ LLMs through Portkey's AI Gateway."""
 
     API_BASE = "https://api.portkey.ai/v1"
@@ -22,45 +46,181 @@ class PortkeyProvider(XMLReasoningOpenAIProvider):
     PROVIDER_NAME = "portkey"
     PROVIDER_DOCUMENTATION_URL = "https://portkey.ai/docs"
 
+    TIMEOUT_SUPPORT = "native"
+    MISSING_PACKAGES_ERROR = MISSING_PACKAGES_ERROR
+
+    SUPPORTS_MODERATION = True
+
     SUPPORTS_COMPLETION_STREAMING = True
     SUPPORTS_COMPLETION = True
     SUPPORTS_RESPONSES = False
     SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_COMPLETION_IMAGE = True
+    SUPPORTS_COMPLETION_PDF = True
     SUPPORTS_EMBEDDING = False
     SUPPORTS_LIST_MODELS = True
+    SUPPORTS_BATCH = False
 
     _DEFAULT_REASONING_EFFORT = None
+
+    client: AsyncPortkey
+
+    @override
+    def _init_client(self, api_key: str | None = None, api_base: str | None = None, **kwargs: Any) -> None:
+        self.client = AsyncPortkey(
+            base_url=api_base or self.API_BASE,
+            api_key=api_key,
+            **kwargs,
+        )
 
     @staticmethod
     @override
     def _convert_completion_response(response: Any) -> ChatCompletion:
-        if isinstance(response, OpenAIChatCompletion):
-            return convert_chat_completion_with_xml_reasoning(response)
-        if isinstance(response, ChatCompletion):
-            return response
-        return ChatCompletion.model_validate(response)
+
+        response_dict = _normalize_openai_dict_response(response.model_dump())
+
+        choices = response_dict.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                message = choice.get("message") if isinstance(choice, dict) else None
+                if isinstance(message, dict):
+                    normalize_reasoning_from_provider_fields_and_xml_tags(message)
+
+                delta = choice.get("delta") if isinstance(choice, dict) else None
+                if isinstance(delta, dict):
+                    normalize_reasoning_from_provider_fields_and_xml_tags(delta)
+
+        return ChatCompletion.model_validate(response_dict)
 
     @staticmethod
     @override
     def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
-        if isinstance(response, OpenAIChatCompletionChunk):
-            return convert_chat_completion_chunk_with_xml_reasoning(response)
-        if isinstance(response, ChatCompletionChunk):
-            return response
-        return ChatCompletionChunk.model_validate(response)
+        response_dict = _normalize_openai_dict_response(response.model_dump())
+
+        choices = response_dict.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                delta = choice.get("delta") if isinstance(choice, dict) else None
+
+                if isinstance(delta, dict):
+                    normalize_reasoning_from_provider_fields_and_xml_tags(delta)
+
+        response_dict["object"] = "chat.completion.chunk"
+        return ChatCompletionChunk.model_validate(response_dict)
+
+    async def _stream_async_completion(
+        self, params: CompletionParams, **kwargs: Any
+    ) -> AsyncIterator[ChatCompletionChunk]:
+
+        completion_kwargs = self._convert_completion_params(params, **kwargs)
+        stream = cast(
+            "AsyncIterator[Any]",
+            await self.client.chat.completions.create(
+                model=params.model_id,
+                messages=cast("Any", params.messages),
+                stream=True,
+                **completion_kwargs,
+            ),
+        )
+
+        async def chunk_iterator() -> AsyncIterator[ChatCompletionChunk]:
+            async for chunk in stream:
+                yield self._convert_completion_chunk_response(chunk)
+
+        return wrap_chunks_with_xml_reasoning(chunk_iterator())
 
     @staticmethod
     @override
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
-        """Convert CompletionParams to kwargs for OpenAI API."""
-        if is_structured_output_type(params.response_format):
-            params.response_format = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "response_schema",
-                    "schema": get_json_schema(params.response_format),
-                },
-            }
-        converted_params = params.model_dump(exclude_none=True, exclude={"model_id", "messages"})
+        """Convert CompletionParams to kwargs for Portkey SDK."""
+        if params.response_format:
+            if is_structured_output_type(params.response_format):
+                kwargs["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "response_schema",
+                        "schema": get_json_schema(params.response_format),
+                    },
+                }
+            else:
+                kwargs["response_format"] = params.response_format
+
+        converted_params = params.model_dump(
+            exclude_none=True, exclude={"model_id", "messages", "stream", "response_format"}
+        )
         converted_params.update(kwargs)
         return converted_params
+
+    @staticmethod
+    @override
+    def _convert_embedding_params(params: Any, **kwargs: Any) -> dict[str, Any]:
+        """Convert embedding parameters for Portkey."""
+        msg = "Portkey does not support embeddings"
+        raise NotImplementedError(msg)
+
+    @staticmethod
+    @override
+    def _convert_embedding_response(response: Any) -> CreateEmbeddingResponse:
+        """Convert Portkey embedding response to OpenAI format."""
+        msg = "Portkey does not support embeddings"
+        raise NotImplementedError(msg)
+
+    @staticmethod
+    @override
+    def _convert_list_models_response(models_list: PortkeyModelList) -> list[Model]:
+
+        data = models_list.data or []
+
+        return [Model.model_validate(model.model_dump()) for model in data]
+
+    @override
+    async def _acompletion(
+        self, params: CompletionParams, **kwargs: Any
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+
+        if params.reasoning_effort == "auto":
+            params.reasoning_effort = self._DEFAULT_REASONING_EFFORT
+
+        completion_kwargs = self._convert_completion_params(params, **kwargs)
+
+        if params.stream:
+            return await self._stream_async_completion(
+                params,
+                **kwargs,
+            )
+        response = cast(
+            "PortkeyChatCompletions",
+            await self.client.chat.completions.create(
+                model=params.model_id,
+                messages=cast("Any", params.messages),
+                **completion_kwargs,
+            ),
+        )
+
+        return self._convert_completion_response(response)
+
+    @override
+    async def _alist_models(self, **kwargs: Any) -> Sequence[Model]:
+        models_list = await self.client.models.list(**kwargs)
+        return self._convert_list_models_response(models_list)
+
+    @override
+    async def _amoderation(
+        self,
+        model: str,
+        input: str | list[str] | list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModerationResponse:
+        include_raw = kwargs.pop("include_raw", False)
+        model_name = model or "omni-moderation-latest"
+
+        raw = await self.client.moderations.create(
+            model=model_name,
+            input=cast("Any", input),
+            **kwargs,
+        )
+
+        return _convert_moderation_response_from_openai(
+            raw,
+            include_raw=include_raw,
+        )

--- a/src/any_llm/providers/portkey/portkey.py
+++ b/src/any_llm/providers/portkey/portkey.py
@@ -7,7 +7,6 @@ from typing_extensions import override
 from any_llm.any_llm import AnyLLM
 from any_llm.providers.openai.utils import (
     _convert_moderation_response_from_openai,
-    _normalize_openai_dict_response,
 )
 from any_llm.providers.openai.xml_reasoning import (
     wrap_chunks_with_xml_reasoning,
@@ -76,8 +75,7 @@ class PortkeyProvider(AnyLLM):
     @staticmethod
     @override
     def _convert_completion_response(response: Any) -> ChatCompletion:
-
-        response_dict = _normalize_openai_dict_response(response.model_dump())
+        response_dict = response.model_dump()
 
         choices = response_dict.get("choices")
         if isinstance(choices, list):
@@ -95,7 +93,7 @@ class PortkeyProvider(AnyLLM):
     @staticmethod
     @override
     def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
-        response_dict = _normalize_openai_dict_response(response.model_dump())
+        response_dict = response.model_dump()
 
         choices = response_dict.get("choices")
         if isinstance(choices, list):

--- a/tests/unit/providers/test_portkey_provider.py
+++ b/tests/unit/providers/test_portkey_provider.py
@@ -54,27 +54,19 @@ def test_convert_completion_params_with_dataclass_response_format() -> None:
     assert "value" in result["response_format"]["json_schema"]["schema"]["properties"]
 
 
-def test_portkey_convert_completion_response_creates_anyllm_chatcompletion() -> None:
-    """
-    Test that the _convert_completion_response_async converts a portkey ChatCompletion Object
-    into an anyllm ChatCompletion Object
-    """
+def test_convert_completion_params_with_non_structured_response_format() -> None:
 
-    provider = PortkeyProvider(api_key="test")
+    response_format = {"type": "json_object"}
 
-    response = PortkeyChatCompletions(
-        id="test",
-        choices=[],
-        created=123,
-        model="test-model",
-        object="chat.completion",
+    params = CompletionParams(
+        model_id="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        response_format=response_format,
     )
 
-    result = provider._convert_completion_response(response)
+    result = PortkeyProvider._convert_completion_params(params)
 
-    assert isinstance(result, ChatCompletion)
-    assert result.id == "test"
-    assert result.model == "test-model"
+    assert result["response_format"] == response_format
 
 
 @pytest.mark.asyncio
@@ -110,31 +102,14 @@ async def test_acompletion_with_async_portkey() -> None:
     assert result.model == "test-model"
 
 
-def test_portkey_convert_completion_chunk_response_creates_anyllm_chatcompletion() -> None:
-    """
-    Test that the _convert_completion_chunk_response converts a portkey ChatCompletion Object
-    into an anyllm ChatCompletion Object
-    """
+def test_convert_embedding_params_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError, match="Portkey does not support embeddings"):
+        PortkeyProvider._convert_embedding_params(None)
 
-    provider = PortkeyProvider(api_key="test")
 
-    class FakePortkeyChunk:
-        def model_dump(self) -> dict[str, Any]:
-            return {
-                "id": "test",
-                "choices": [],
-                "created": 123,
-                "model": "test-model",
-                "object": "chat.completion.chunk",
-            }
-
-    response = FakePortkeyChunk()
-
-    result = provider._convert_completion_chunk_response(response)
-
-    assert isinstance(result, ChatCompletionChunk)
-    assert result.id == "test"
-    assert result.model == "test-model"
+def test_convert_embedding_response_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError, match="Portkey does not support embeddings"):
+        PortkeyProvider._convert_embedding_response(None)
 
 
 @pytest.mark.asyncio
@@ -253,3 +228,126 @@ async def test_amoderation_with_async_portkey() -> None:
     assert result.results[0].flagged is True
     assert result.results[0].categories["violence"] is True
     assert result.results[0].category_scores["violence"] == 0.95
+
+
+def test_portkey_convert_completion_response_normalizes_reasoning() -> None:
+    provider = PortkeyProvider(api_key="test")
+
+    class FakePortkeyCompletion:
+        def model_dump(self) -> dict[str, Any]:
+            return {
+                "id": "test",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>xml reasoning</think>Final answer",
+                            "reasoning_content": "provider reasoning",
+                        },
+                    }
+                ],
+                "created": 123,
+                "model": "test-model",
+                "object": "chat.completion",
+            }
+
+    result = provider._convert_completion_response(FakePortkeyCompletion())
+
+    assert result.choices[0].message.content == "Final answer"
+    assert result.choices[0].message.reasoning is not None
+    assert result.choices[0].message.reasoning.content == "provider reasoning\nxml reasoning"
+
+
+def test_portkey_convert_completion_chunk_response_normalizes_reasoning() -> None:
+    provider = PortkeyProvider(api_key="test")
+
+    class FakePortkeyChunk:
+        def model_dump(self) -> dict[str, Any]:
+            return {
+                "id": "test",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "<think>xml reasoning</think>Final answer",
+                            "reasoning_content": "provider reasoning",
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+                "created": 123,
+                "model": "test-model",
+                "object": "chat.completion.chunk",
+            }
+
+    result = provider._convert_completion_chunk_response(FakePortkeyChunk())
+
+    assert result.choices[0].delta.content == "Final answer"
+    assert result.choices[0].delta.reasoning is not None
+    assert result.choices[0].delta.reasoning.content == "provider reasoning\nxml reasoning"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_async_chunk_portkey_preserves_reasoning() -> None:
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        class FakePortkeyChunk:
+            def model_dump(self) -> dict[str, Any]:
+                return {
+                    "id": "test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": "<think>xml reasoning</think>Final answer",
+                                "reasoning_content": "provider reasoning",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                    "created": 123,
+                    "model": "test-model",
+                    "object": "chat.completion.chunk",
+                }
+
+        async def fake_stream() -> AsyncIterator[FakePortkeyChunk]:
+            yield FakePortkeyChunk()
+
+        mock_client.chat.completions.create = AsyncMock(return_value=fake_stream())
+
+        provider = PortkeyProvider(api_key="test")
+
+        result = cast(
+            "AsyncIterator[ChatCompletionChunk]",
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="test-model",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    stream=True,
+                )
+            ),
+        )
+
+    chunks = [chunk async for chunk in result]
+
+    assert len(chunks) == 1
+    assert chunks[0].choices[0].delta.content == "Final answer"
+    assert chunks[0].choices[0].delta.reasoning is not None
+    assert chunks[0].choices[0].delta.reasoning.content == "provider reasoning\nxml reasoning"
+
+
+def test_convert_list_models_response_returns_empty_list_when_data_is_none() -> None:
+    response = PortkeyModelList.model_construct(
+        object="list",
+        data=None,
+    )
+
+    result = PortkeyProvider._convert_list_models_response(response)
+
+    assert result == []

--- a/tests/unit/providers/test_portkey_provider.py
+++ b/tests/unit/providers/test_portkey_provider.py
@@ -351,3 +351,29 @@ def test_convert_list_models_response_returns_empty_list_when_data_is_none() -> 
     result = PortkeyProvider._convert_list_models_response(response)
 
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_amoderation_uses_portkey_default_model_when_model_is_empty() -> None:
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        response = PortkeyModerationCreateResponse(
+            id="mod-test",
+            model="text-moderation-latest",
+            results=[],
+        )
+
+        mock_client.moderations.create = AsyncMock(return_value=response)
+
+        provider = PortkeyProvider(api_key="test")
+        await provider._amoderation(
+            model="",
+            input="test input",
+        )
+
+    mock_client.moderations.create.assert_awaited_once_with(
+        model="text-moderation-latest",
+        input="test input",
+    )

--- a/tests/unit/providers/test_portkey_provider.py
+++ b/tests/unit/providers/test_portkey_provider.py
@@ -13,6 +13,18 @@ from portkey_ai.api_resources.types.models_type import (
 from portkey_ai.api_resources.types.models_type import (
     ModelList as PortkeyModelList,
 )
+from portkey_ai.api_resources.types.moderations_type import (
+    Categories as PortkeyCategories,
+)
+from portkey_ai.api_resources.types.moderations_type import (
+    CategoryScores as PortkeyCategoryScores,
+)
+from portkey_ai.api_resources.types.moderations_type import (
+    Moderation as PortkeyModeration,
+)
+from portkey_ai.api_resources.types.moderations_type import (
+    ModerationCreateResponse as PortkeyModerationCreateResponse,
+)
 
 from any_llm.providers.portkey.portkey import PortkeyProvider
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
@@ -203,3 +215,41 @@ async def test_alist_models_with_async_portkey() -> None:
     assert result[0].object == "model"
     assert result[0].created == 123
     assert result[0].owned_by == "test-provider"
+
+
+@pytest.mark.asyncio
+async def test_amoderation_with_async_portkey() -> None:
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        response = PortkeyModerationCreateResponse(
+            id="mod-test",
+            model="test-model",
+            results=[
+                PortkeyModeration(
+                    flagged=True,
+                    categories=PortkeyCategories(
+                        violence=True,
+                    ),
+                    category_scores=PortkeyCategoryScores(
+                        violence=0.95,
+                    ),
+                )
+            ],
+        )
+
+        mock_client.moderations.create = AsyncMock(return_value=response)
+
+        provider = PortkeyProvider(api_key="test")
+        result = await provider._amoderation(
+            model="test-model",
+            input="test input",
+        )
+
+    assert result.id == "mod-test"
+    assert result.model == "test-model"
+    assert len(result.results) == 1
+    assert result.results[0].flagged is True
+    assert result.results[0].categories["violence"] is True
+    assert result.results[0].category_scores["violence"] == 0.95

--- a/tests/unit/providers/test_portkey_provider.py
+++ b/tests/unit/providers/test_portkey_provider.py
@@ -1,7 +1,21 @@
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from portkey_ai.api_resources.types.chat_complete_type import (
+    ChatCompletions as PortkeyChatCompletions,
+)
+from portkey_ai.api_resources.types.models_type import (
+    Model as PortkeyModel,
+)
+from portkey_ai.api_resources.types.models_type import (
+    ModelList as PortkeyModelList,
+)
 
 from any_llm.providers.portkey.portkey import PortkeyProvider
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
 
 
 def test_convert_completion_params_with_dataclass_response_format() -> None:
@@ -26,3 +40,166 @@ def test_convert_completion_params_with_dataclass_response_format() -> None:
     assert "properties" in result["response_format"]["json_schema"]["schema"]
     assert "name" in result["response_format"]["json_schema"]["schema"]["properties"]
     assert "value" in result["response_format"]["json_schema"]["schema"]["properties"]
+
+
+def test_portkey_convert_completion_response_creates_anyllm_chatcompletion() -> None:
+    """
+    Test that the _convert_completion_response_async converts a portkey ChatCompletion Object
+    into an anyllm ChatCompletion Object
+    """
+
+    provider = PortkeyProvider(api_key="test")
+
+    response = PortkeyChatCompletions(
+        id="test",
+        choices=[],
+        created=123,
+        model="test-model",
+        object="chat.completion",
+    )
+
+    result = provider._convert_completion_response(response)
+
+    assert isinstance(result, ChatCompletion)
+    assert result.id == "test"
+    assert result.model == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_async_portkey() -> None:
+    """Test acompletion works with AsyncPortkey Provider"""
+
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        response = PortkeyChatCompletions(
+            id="test",
+            choices=[],
+            created=123,
+            model="test-model",
+            object="chat.completion",
+        )
+
+        mock_client.chat.completions.create = AsyncMock(return_value=response)
+
+        provider = PortkeyProvider(api_key="test")
+
+        result = await provider._acompletion(
+            CompletionParams(
+                model_id="test-model",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+        )
+
+    mock_client.chat.completions.create.assert_called_once()
+    assert isinstance(result, ChatCompletion)
+    assert result.id == "test"
+    assert result.model == "test-model"
+
+
+def test_portkey_convert_completion_chunk_response_creates_anyllm_chatcompletion() -> None:
+    """
+    Test that the _convert_completion_chunk_response converts a portkey ChatCompletion Object
+    into an anyllm ChatCompletion Object
+    """
+
+    provider = PortkeyProvider(api_key="test")
+
+    class FakePortkeyChunk:
+        def model_dump(self) -> dict[str, Any]:
+            return {
+                "id": "test",
+                "choices": [],
+                "created": 123,
+                "model": "test-model",
+                "object": "chat.completion.chunk",
+            }
+
+    response = FakePortkeyChunk()
+
+    result = provider._convert_completion_chunk_response(response)
+
+    assert isinstance(result, ChatCompletionChunk)
+    assert result.id == "test"
+    assert result.model == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_async_chunk_portkey() -> None:
+    """Test acompletion works with AsyncPortkey Provider"""
+
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        class FakePortkeyChunk:
+            def model_dump(self) -> dict[str, Any]:
+                return {
+                    "id": "test",
+                    "choices": [],
+                    "created": 123,
+                    "model": "test-model",
+                    "object": "chat.completion.chunk",
+                }
+
+        async def fake_stream() -> AsyncIterator[FakePortkeyChunk]:
+            yield FakePortkeyChunk()
+
+        mock_client.chat.completions.create = AsyncMock(return_value=fake_stream())
+
+        provider = PortkeyProvider(api_key="test")
+
+        result = cast(
+            "AsyncIterator[ChatCompletionChunk]",
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="test-model",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    stream=True,
+                )
+            ),
+        )
+
+    chunks = []
+
+    async for chunk in result:
+        chunks.append(chunk)
+
+    mock_client.chat.completions.create.assert_called_once()
+    assert len(chunks) == 1
+    assert isinstance(chunks[0], ChatCompletionChunk)
+    assert chunks[0].id == "test"
+    assert chunks[0].model == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_alist_models_with_async_portkey() -> None:
+    """Test that Portkey model responses are converted into any-llm models."""
+
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        response = PortkeyModelList(
+            object="list",
+            data=[
+                PortkeyModel(
+                    id="test-model",
+                    object="model",
+                    created=123,
+                    owned_by="test-provider",
+                )
+            ],
+        )
+
+        mock_client.models.list = AsyncMock(return_value=response)
+
+        provider = PortkeyProvider(api_key="test")
+        result = await provider._alist_models()
+
+    assert len(result) == 1
+    assert result[0].id == "test-model"
+    assert result[0].object == "model"
+    assert result[0].created == 123
+    assert result[0].owned_by == "test-provider"

--- a/tests/unit/providers/test_portkey_provider.py
+++ b/tests/unit/providers/test_portkey_provider.py
@@ -377,3 +377,43 @@ async def test_amoderation_uses_portkey_default_model_when_model_is_empty() -> N
         model="text-moderation-latest",
         input="test input",
     )
+
+
+@pytest.mark.asyncio
+async def test_amoderation_with_include_raw() -> None:
+    with patch("any_llm.providers.portkey.portkey.AsyncPortkey") as mocked_portkey:
+        mock_client = AsyncMock()
+        mocked_portkey.return_value = mock_client
+
+        response = PortkeyModerationCreateResponse(
+            id="mod-test",
+            model="test-model",
+            results=[
+                PortkeyModeration(
+                    flagged=False,
+                    categories=PortkeyCategories(
+                        violence=False,
+                    ),
+                    category_scores=PortkeyCategoryScores(
+                        violence=0.01,
+                    ),
+                )
+            ],
+        )
+
+        mock_client.moderations.create = AsyncMock(return_value=response)
+
+        provider = PortkeyProvider(api_key="test")
+        result = await provider._amoderation(
+            model="test-model",
+            input="test input",
+            include_raw=True,
+        )
+
+    mock_client.moderations.create.assert_awaited_once_with(
+        model="test-model",
+        input="test input",
+    )
+
+    assert response.results is not None
+    assert result.results[0].provider_raw == response.results[0].model_dump()


### PR DESCRIPTION
## Description

Migrate the existing Portkey provider from the OpenAI-compatible client to Portkey's native Python SDK.

This updates PortkeyProvider to use AsyncPortkey directly and explicitly converts Portkey completion, streaming, model-listing, and moderation responses into any-llm types. Existing capability metadata, structured output, reasoning, and timeout behavior are preserved.

Adds portkey-ai>=2.3.4 as the Portkey optional dependency and expands unit coverage for the native SDK paths.

## PR Type

- 💅 Refactor

## Relevant issues
Fixes #524 

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol
- AI Developer Tool used: ChatGPT
- Any other info you'd like to share: AI was used to help investigate the codebase, reason through the SDK migration, debug typing/test failures, and review the implementation. I made and verified the implementation decisions and ran the tests locally.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

This is my first open-source contribution; I'd be happy to hear any feedback on both the implementation and contribution process!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Portkey AI integration for asynchronous chat completions and streaming.
  * Added model listing, content moderation, structured outputs, and consistent response handling.
  * Added support for reasoning content and clearer handling when the optional Portkey package is unavailable.
  * Added explicit handling for unsupported embedding requests.
  * The optional Portkey integration now installs the required Portkey AI package automatically.
* **Tests**
  * Expanded coverage for completions, streaming, model listing, moderation, reasoning content, structured outputs, and unsupported embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->