### PR TITLE
fix(otari): use native messages for structured output

### DIFF
--- a/src/any_llm/providers/otari/otari.py
+++ b/src/any_llm/providers/otari/otari.py
@@ -350,23 +350,18 @@ class OtariProvider(BaseOpenAIProvider):
         config). otari's gateway serves /messages natively, so delegate to the otari
         SDK's ``message()`` to preserve them.
         """
-        if params.output_format is not None:
-            # Structured output is handled by the base Messages<->Completions bridge, which
-            # routes output_format through otari's completion path. A follow-up could adopt
-            # otari's native /messages structured-output support directly.
-            if params.context_management is not None or params.betas:
-                msg = (
-                    "output_format cannot be combined with context_management or betas on otari: "
-                    "structured output routes through the Completions bridge, which drops both. "
-                    "Send them in separate requests until otari's native /messages structured "
-                    "output is adopted."
-                )
-                raise NotImplementedError(msg)
-            return await super()._amessages(params, **kwargs)
-
         api_kwargs = params.model_dump(exclude_none=True)
         api_kwargs.update(kwargs)
         api_kwargs.pop("stream", None)
+
+        if params.output_format is not None:
+            output_config = (
+                {"format": {"type": "json_schema", "schema": get_json_schema(params.output_format)}}
+                if is_structured_output_type(params.output_format)
+                else params.output_format
+            )
+            api_kwargs["output_config"] = output_config
+            api_kwargs.pop("output_format", None)
 
         if params.stream:
             return self._stream_messages_async(**api_kwargs)

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -962,6 +963,49 @@ async def test_otari_amessages_output_format_uses_native_endpoint() -> None:
     call_kwargs = client.message.call_args.kwargs
     assert call_kwargs["output_config"]["format"]["schema"]["title"] == "City"
     assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_output_format_accepts_dataclass_type() -> None:
+    @dataclass
+    class City:
+        city: str
+
+    client = _mock_otari_client()
+    provider = _build_provider(client)
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=100,
+        output_format=City,
+    )
+
+    await provider._amessages(params)
+
+    output_format = client.message.call_args.kwargs["output_config"]["format"]
+    assert output_format["type"] == "json_schema"
+    assert output_format["schema"]["properties"]["city"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_otari_amessages_output_format_forwards_raw_config() -> None:
+    output_config = {"type": "json_schema", "schema": {"type": "object"}}
+    client = _mock_otari_client()
+    provider = _build_provider(client)
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
+
+    params = MessagesParams(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        max_tokens=100,
+        output_format=output_config,
+    )
+
+    await provider._amessages(params)
+
+    assert client.message.call_args.kwargs["output_config"] == output_config
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -991,7 +991,7 @@ async def test_otari_amessages_output_format_accepts_dataclass_type() -> None:
 
 @pytest.mark.asyncio
 async def test_otari_amessages_output_format_forwards_raw_config() -> None:
-    output_config = {"type": "json_schema", "schema": {"type": "object"}}
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
     client = _mock_otari_client()
     provider = _build_provider(client)
     client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)

--- a/tests/unit/providers/test_otari_provider.py
+++ b/tests/unit/providers/test_otari_provider.py
@@ -941,26 +941,13 @@ async def test_otari_amessages_streaming_forwards_anthropic_beta_params() -> Non
 
 
 @pytest.mark.asyncio
-async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
-    """With output_format set, otari delegates to the Completions bridge, not /messages."""
-    completion = ChatCompletion.model_validate(
-        {
-            "id": "chatcmpl-test",
-            "object": "chat.completion",
-            "created": 0,
-            "model": "claude-sonnet-4-5",
-            "choices": [
-                {"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": '{"city": "Paris"}'}}
-            ],
-        }
-    )
-
+async def test_otari_amessages_output_format_uses_native_endpoint() -> None:
     class City(BaseModel):
         city: str
 
     client = _mock_otari_client()
     provider = _build_provider(client)
-    provider._acompletion = AsyncMock(return_value=completion)  # type: ignore[method-assign]
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
 
     params = MessagesParams(
         model="claude-sonnet-4-5",
@@ -972,8 +959,9 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
     result = await provider._amessages(params)
 
     assert isinstance(result, MessageResponse)
-    provider._acompletion.assert_called_once()
-    client.message.assert_not_called()
+    call_kwargs = client.message.call_args.kwargs
+    assert call_kwargs["output_config"]["format"]["schema"]["title"] == "City"
+    assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
 
 
 @pytest.mark.asyncio
@@ -984,15 +972,14 @@ async def test_otari_amessages_output_format_falls_back_to_bridge() -> None:
         {"betas": ["compact-2026-01-12"]},
     ],
 )
-async def test_otari_amessages_output_format_with_beta_params_raises(beta_params: dict[str, Any]) -> None:
-    """output_format routes through the bridge, which cannot carry context_management or betas."""
+async def test_otari_amessages_output_format_with_beta_params_uses_native_endpoint(beta_params: dict[str, Any]) -> None:
 
     class City(BaseModel):
         city: str
 
     client = _mock_otari_client()
     provider = _build_provider(client)
-    provider._acompletion = AsyncMock()  # type: ignore[method-assign]
+    client.message.return_value = SimpleNamespace(data=_message_response_payload(), request_id=None)
 
     params = MessagesParams(
         model="claude-sonnet-4-5",
@@ -1002,11 +989,14 @@ async def test_otari_amessages_output_format_with_beta_params_raises(beta_params
         **beta_params,
     )
 
-    with pytest.raises(NotImplementedError, match="output_format cannot be combined"):
-        await provider._amessages(params)
-
-    provider._acompletion.assert_not_called()
-    client.message.assert_not_called()
+    result = await provider._amessages(params)
+    assert isinstance(result, MessageResponse)
+    call_kwargs = client.message.call_args.kwargs
+    if "context_management" in beta_params:
+        assert call_kwargs["context_management"] == beta_params["context_management"]
+    else:
+        assert call_kwargs["betas"] == beta_params["betas"]
+    assert call_kwargs["output_config"]["format"]["schema"]["title"] == "City"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`OtariProvider._amessages` now sends structured output through Otari's native `/messages` endpoint. Pydantic and dataclass types are converted to `output_config.format` JSON schemas, while raw output configurations pass through unchanged. This preserves `context_management` and `betas` for structured-output requests.

## PR Type

- 🆕 New Feature

## Relevant issues

Fixes #1289

## Root cause and scope

The previous implementation routed `output_format` through the Messages/Completions bridge, which cannot carry Otari/Anthropic-specific `context_management` or `betas`. The changed path is limited to `OtariProvider._amessages`; existing non-structured and streaming behavior remains on the existing native path.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (no user-facing API/documentation change beyond issue #1289)
- [x] I have read and followed the contribution guidelines.
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## Verification

- `uv run --frozen --extra otari pytest -q -rs tests/unit/providers/test_otari_provider.py` — 50 passed
- `uv run --frozen pre-commit run --files src/any_llm/providers/otari/otari.py tests/unit/providers/test_otari_provider.py` — passed
- `uv run --frozen mypy src/any_llm/providers/otari/otari.py` — passed as part of pre-commit
- `git diff --check` — passed

Tests use the repository's mocked Otari client and installed `otari` dependency; no API key or external request is required.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex desktop
- Any other info: implementation and validation were performed in the independent `codex/otari-native-structured-output` branch.

- [x] I am an AI Agent filling out this form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured outputs are now supported through the native messages endpoint.
  * JSON schemas and dataclass-based formats can be used for structured responses.
  * Context management and beta options now work alongside structured outputs.

* **Bug Fixes**
  * Preserved native messages endpoint features when using structured output formats.
  * Improved compatibility for requests combining structured responses with advanced messaging options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->