### PR TITLE
fix(gemini): preserve inline data response parts

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -241,6 +241,7 @@ class GoogleProvider(AnyLLM):
                 refusal=message_dict.get("refusal"),
                 tool_calls=tool_calls,
                 reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
+                images=message_dict.get("images"),
                 extra_content=message_dict.get("extra_content"),
             )
             from typing import Literal

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -452,6 +452,8 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         parts = candidate.content.parts if candidate.content else None
 
         for part in parts or []:
+            if image := _inline_data_image(part):
+                images.append(image)
             if getattr(part, "thought", None):
                 reasoning = (reasoning or "") + (part.text or "")
             elif function_call := getattr(part, "function_call", None):
@@ -475,8 +477,6 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
 
                 tool_calls_list.append(tool_call_dict)
             else:
-                if image := _inline_data_image(part):
-                    images.append(image)
                 if part.text:
                     text_content = (text_content or "") + part.text
                 message_extra_content = _thought_signature_extra_content(part) or message_extra_content
@@ -577,6 +577,8 @@ def _create_openai_chunk_from_google_chunk(
     parts = candidate.content.parts if candidate and candidate.content else None
 
     for part in parts or []:
+        if image := _inline_data_image(part):
+            images.append(image)
         if part.thought:
             reasoning_content += part.text or ""
         elif function_call := part.function_call:
@@ -605,8 +607,6 @@ def _create_openai_chunk_from_google_chunk(
                 )
             )
         else:
-            if image := _inline_data_image(part):
-                images.append(image)
             content += part.text or ""  # the signed final part may carry empty text
             message_extra_content = _thought_signature_extra_content(part) or message_extra_content
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -368,11 +368,7 @@ def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
 def _inline_data_image(part: types.Part) -> dict[str, Any] | None:
     """Build an OpenAI-compatible image content item from Gemini inline data."""
     inline_data = part.inline_data
-    if (
-        inline_data is None
-        or not isinstance(inline_data.data, bytes)
-        or not isinstance(inline_data.mime_type, str)
-    ):
+    if inline_data is None or not isinstance(inline_data.data, bytes) or not isinstance(inline_data.mime_type, str):
         return None
     return {
         "type": "image_url",

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -368,7 +368,11 @@ def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
 def _inline_data_image(part: types.Part) -> dict[str, Any] | None:
     """Build an OpenAI-compatible image content item from Gemini inline data."""
     inline_data = part.inline_data
-    if inline_data is None or inline_data.data is None or inline_data.mime_type is None:
+    if (
+        inline_data is None
+        or not isinstance(inline_data.data, bytes)
+        or not isinstance(inline_data.mime_type, str)
+    ):
         return None
     return {
         "type": "image_url",

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -365,6 +365,19 @@ def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
     return None
 
 
+def _inline_data_image(part: types.Part) -> dict[str, Any] | None:
+    """Build an OpenAI-compatible image content item from Gemini inline data."""
+    inline_data = part.inline_data
+    if inline_data is None or inline_data.data is None or inline_data.mime_type is None:
+        return None
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": f"data:{inline_data.mime_type};base64,{base64.b64encode(inline_data.data).decode('ascii')}"
+        },
+    }
+
+
 _FINISH_REASON_MAP: dict[types.FinishReason, Literal["stop", "length", "content_filter"]] = {
     types.FinishReason.STOP: "stop",
     types.FinishReason.MAX_TOKENS: "length",
@@ -432,6 +445,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         reasoning = None
         tool_calls_list: list[dict[str, Any]] = []
         text_content = None
+        images: list[dict[str, Any]] = []
         # Gemini 3 signs the last non-function-call part of a text answer. It rides message.extra_content,
         # the same spelling Google's OpenAI-compatible endpoint uses.
         message_extra_content = None
@@ -461,6 +475,8 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
 
                 tool_calls_list.append(tool_call_dict)
             else:
+                if image := _inline_data_image(part):
+                    images.append(image)
                 if part.text:
                     text_content = (text_content or "") + part.text
                 message_extra_content = _thought_signature_extra_content(part) or message_extra_content
@@ -468,7 +484,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
         # Truncated or filtered responses produce a choice even without content or tool
         # calls, e.g. a thinking model that spent the whole max_output_tokens budget on
         # reasoning, so callers see the terminal reason instead of an empty choices list.
-        if tool_calls_list or text_content or mapped_finish_reason in ("length", "content_filter"):
+        if tool_calls_list or text_content or images or mapped_finish_reason in ("length", "content_filter"):
             choices.append(
                 {
                     "message": {
@@ -476,6 +492,7 @@ def _convert_response_to_response_dict(response: types.GenerateContentResponse) 
                         "content": None if tool_calls_list else text_content,
                         "reasoning": reasoning or None,
                         "tool_calls": tool_calls_list or None,
+                        "images": images or None,
                         "extra_content": message_extra_content,
                         "refusal": _GEMINI_CONTENT_FILTER_REFUSAL if mapped_finish_reason == "content_filter" else None,
                     },
@@ -553,6 +570,7 @@ def _create_openai_chunk_from_google_chunk(
     reasoning_content = ""
     tool_calls_list: list[ChoiceDeltaToolCall] = []
     message_extra_content = None
+    images: list[dict[str, Any]] = []
 
     # Content can be absent on terminal chunks, e.g. when the response is truncated or
     # filtered before any part is produced; the finish reason must still be surfaced.
@@ -587,6 +605,8 @@ def _create_openai_chunk_from_google_chunk(
                 )
             )
         else:
+            if image := _inline_data_image(part):
+                images.append(image)
             content += part.text or ""  # the signed final part may carry empty text
             message_extra_content = _thought_signature_extra_content(part) or message_extra_content
 
@@ -603,6 +623,7 @@ def _create_openai_chunk_from_google_chunk(
         refusal=_GEMINI_CONTENT_FILTER_REFUSAL if finish_reason == "content_filter" else None,
         reasoning=Reasoning(content=reasoning_content) if reasoning_content else None,
         tool_calls=tool_calls_list or None,
+        images=images or None,
         extra_content=message_extra_content,
     )
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -368,7 +368,13 @@ def _thought_signature_extra_content(part: types.Part) -> dict[str, Any] | None:
 def _inline_data_image(part: types.Part) -> dict[str, Any] | None:
     """Build an OpenAI-compatible image content item from Gemini inline data."""
     inline_data = part.inline_data
-    if inline_data is None or not isinstance(inline_data.data, bytes) or not isinstance(inline_data.mime_type, str):
+    if (
+        inline_data is None
+        or not isinstance(inline_data.data, bytes)
+        or not inline_data.data
+        or not isinstance(inline_data.mime_type, str)
+        or not inline_data.mime_type
+    ):
         return None
     return {
         "type": "image_url",

--- a/src/any_llm/types/completion.py
+++ b/src/any_llm/types/completion.py
@@ -77,6 +77,7 @@ class ChatCompletionMessage(OpenAIChatCompletionMessage):
     tool_calls: list[ChatCompletionMessageToolCall] | None = None  # type: ignore[assignment]
     reasoning: Reasoning | None = None
     annotations: list[dict[str, Any]] | None = None  # type: ignore[assignment]
+    images: list[dict[str, Any]] | None = None
     extra_content: dict[str, Any] | None = None
     """Provider-specific metadata that needs to be preserved across multi-turn conversations.
 
@@ -126,6 +127,7 @@ class ChoiceDeltaToolCall(OpenAIChoiceDeltaToolCall):
 class ChoiceDelta(OpenAIChoiceDelta):
     reasoning: Reasoning | None = None
     tool_calls: list[ChoiceDeltaToolCall] | None = None  # type: ignore[assignment]
+    images: list[dict[str, Any]] | None = None
     extra_content: dict[str, Any] | None = None
     """Streaming counterpart of ``ChatCompletionMessage.extra_content``.
 

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -7,12 +7,12 @@ from dataclasses import dataclass
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import httpx as standard_httpx
+import httpx
 
 try:
     import httpx2
 except ImportError:
-    httpx = standard_httpx
+    pass
 else:
     httpx = httpx2
 

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import httpx
+try:
+    import httpx2 as httpx
+except ImportError:
+    import httpx
+
 import pytest
 from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usage
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -8,14 +8,6 @@ from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
-
-try:
-    import httpx2
-except ImportError:
-    pass
-else:
-    httpx = httpx2
-
 import pytest
 from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usage
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -7,10 +7,14 @@ from dataclasses import dataclass
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import httpx as standard_httpx
+
 try:
-    import httpx2 as httpx
+    import httpx2
 except ImportError:
-    import httpx
+    httpx = standard_httpx
+else:
+    httpx = httpx2
 
 import pytest
 from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usage

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -975,6 +975,31 @@ def test_convert_streaming_response_preserves_inline_data() -> None:
     assert chunk.model_dump()["choices"][0]["delta"]["images"] == chunk.choices[0].delta.images
 
 
+def test_convert_response_preserves_thought_inline_data() -> None:
+    response = _make_gemini_response(
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"), thought=True)],
+        types.FinishReason.STOP,
+    )
+
+    message = ChatCompletion.model_validate(_convert_response_to_response_dict(response)).choices[0].message
+
+    assert message.reasoning is None
+    assert message.images == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+
+
+def test_convert_streaming_response_preserves_thought_inline_data() -> None:
+    response = _make_gemini_response(
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"), thought=True)],
+        types.FinishReason.STOP,
+    )
+
+    chunk = _create_openai_chunk_from_google_chunk(response)
+
+    assert chunk.choices[0].delta.images == [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
+    ]
+
+
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:
     response_dict = _convert_response_to_response_dict(_make_gemini_response(None, types.FinishReason.SAFETY))
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -39,6 +39,13 @@ from any_llm.types.completion import (
 
 TEST_IMAGE_BYTES = b"test-image-bytes"
 TEST_PDF_BYTES = b"%PDF-1.4\ntest"
+TEST_PNG_BYTES = b"\x89PNG\r\n\x1a\n"
+TEST_WAV_BYTES = (
+    b"RIFF\x24\x00\x00\x00WAVE"
+    b"fmt \x10\x00\x00\x00\x01\x00\x01\x00"
+    b"\x44\xac\x00\x00\x88\x58\x01\x00\x02\x00\x10\x00"
+    b"data\x00\x00\x00\x00"
+)
 
 
 class StructuredAnswer(BaseModel):
@@ -933,7 +940,7 @@ def test_convert_response_accumulates_multiple_text_parts() -> None:
 def test_convert_response_preserves_inline_data_alongside_text() -> None:
     response = _make_gemini_response(
         [
-            types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG")),
+            types.Part(inline_data=types.Blob(mime_type="image/png", data=TEST_PNG_BYTES)),
             types.Part(text="Described."),
         ],
         types.FinishReason.STOP,
@@ -944,27 +951,37 @@ def test_convert_response_preserves_inline_data_alongside_text() -> None:
     message = response_dict["choices"][0]["message"]
     assert message["content"] == "Described."
     assert message["tool_calls"] is None
-    assert message["images"] == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+    assert message["images"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(TEST_PNG_BYTES).decode('ascii')}"},
+        }
+    ]
     assert ChatCompletionMessage.model_validate(message).images == message["images"]
 
 
 def test_convert_completion_response_preserves_public_images() -> None:
     response_dict = _convert_response_to_response_dict(
         _make_gemini_response(
-            [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))],
+            [types.Part(inline_data=types.Blob(mime_type="image/png", data=TEST_PNG_BYTES))],
             types.FinishReason.STOP,
         )
     )
 
     completion = GoogleProvider._convert_completion_response((response_dict, "test-model"))
     message = completion.choices[0].message
-    assert message.images == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+    assert message.images == [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(TEST_PNG_BYTES).decode('ascii')}"},
+        }
+    ]
     assert completion.model_dump()["choices"][0]["message"]["images"] == message.images
 
 
 def test_convert_response_emits_choice_for_image_only_response() -> None:
     response = _make_gemini_response(
-        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))],
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=TEST_PNG_BYTES))],
         types.FinishReason.STOP,
     )
 
@@ -976,21 +993,24 @@ def test_convert_response_emits_choice_for_image_only_response() -> None:
 
 def test_convert_streaming_response_preserves_inline_data() -> None:
     response = _make_gemini_response(
-        [types.Part(inline_data=types.Blob(mime_type="audio/wav", data=b"RIFF"))],
+        [types.Part(inline_data=types.Blob(mime_type="audio/wav", data=TEST_WAV_BYTES))],
         types.FinishReason.STOP,
     )
 
     chunk = _create_openai_chunk_from_google_chunk(response)
 
     assert chunk.choices[0].delta.images == [
-        {"type": "image_url", "image_url": {"url": "data:audio/wav;base64,UklGRg=="}}
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:audio/wav;base64,{base64.b64encode(TEST_WAV_BYTES).decode('ascii')}"},
+        }
     ]
     assert chunk.model_dump()["choices"][0]["delta"]["images"] == chunk.choices[0].delta.images
 
 
 def test_convert_response_preserves_thought_inline_data() -> None:
     response = _make_gemini_response(
-        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"), thought=True)],
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=TEST_PNG_BYTES), thought=True)],
         types.FinishReason.STOP,
     )
 
@@ -999,19 +1019,27 @@ def test_convert_response_preserves_thought_inline_data() -> None:
     )
 
     assert message.reasoning is None
-    assert message.images == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+    assert message.images == [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(TEST_PNG_BYTES).decode('ascii')}"},
+        }
+    ]
 
 
 def test_convert_streaming_response_preserves_thought_inline_data() -> None:
     response = _make_gemini_response(
-        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"), thought=True)],
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=TEST_PNG_BYTES), thought=True)],
         types.FinishReason.STOP,
     )
 
     chunk = _create_openai_chunk_from_google_chunk(response)
 
     assert chunk.choices[0].delta.images == [
-        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(TEST_PNG_BYTES).decode('ascii')}"},
+        }
     ]
 
 

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -943,10 +943,8 @@ def test_convert_response_preserves_inline_data_alongside_text() -> None:
     message = response_dict["choices"][0]["message"]
     assert message["content"] == "Described."
     assert message["tool_calls"] is None
-    assert message["images"] == [
-        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
-    ]
-    assert ChatCompletion.model_validate(response_dict).choices[0].message.images == message["images"]
+    assert message["images"] == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+    assert ChatCompletionMessage.model_validate(message).images == message["images"]
 
 
 def test_convert_response_emits_choice_for_image_only_response() -> None:
@@ -981,7 +979,9 @@ def test_convert_response_preserves_thought_inline_data() -> None:
         types.FinishReason.STOP,
     )
 
-    message = ChatCompletion.model_validate(_convert_response_to_response_dict(response)).choices[0].message
+    message = ChatCompletionMessage.model_validate(
+        _convert_response_to_response_dict(response)["choices"][0]["message"]
+    )
 
     assert message.reasoning is None
     assert message.images == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -929,9 +929,7 @@ def test_convert_response_accumulates_multiple_text_parts() -> None:
     assert message["reasoning"] is None
 
 
-def test_convert_response_skips_parts_without_text_or_function_call() -> None:
-    """A candidate can mix in parts that carry neither text nor a tool call, e.g. inline image
-    data; those must not disturb the accumulated text."""
+def test_convert_response_preserves_inline_data_alongside_text() -> None:
     response = _make_gemini_response(
         [
             types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG")),
@@ -945,6 +943,34 @@ def test_convert_response_skips_parts_without_text_or_function_call() -> None:
     message = response_dict["choices"][0]["message"]
     assert message["content"] == "Described."
     assert message["tool_calls"] is None
+    assert message["images"] == [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
+    ]
+
+
+def test_convert_response_emits_choice_for_image_only_response() -> None:
+    response = _make_gemini_response(
+        [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))],
+        types.FinishReason.STOP,
+    )
+
+    response_dict = _convert_response_to_response_dict(response)
+
+    assert response_dict["choices"][0]["finish_reason"] == "stop"
+    assert response_dict["choices"][0]["message"]["images"]
+
+
+def test_convert_streaming_response_preserves_inline_data() -> None:
+    response = _make_gemini_response(
+        [types.Part(inline_data=types.Blob(mime_type="audio/wav", data=b"RIFF"))],
+        types.FinishReason.STOP,
+    )
+
+    chunk = _create_openai_chunk_from_google_chunk(response)
+
+    assert chunk.choices[0].delta.images == [
+        {"type": "image_url", "image_url": {"url": "data:audio/wav;base64,UklGRg=="}}
+    ]
 
 
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -946,6 +946,7 @@ def test_convert_response_preserves_inline_data_alongside_text() -> None:
     assert message["images"] == [
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
     ]
+    assert ChatCompletion.model_validate(response_dict).choices[0].message.images == message["images"]
 
 
 def test_convert_response_emits_choice_for_image_only_response() -> None:
@@ -971,6 +972,7 @@ def test_convert_streaming_response_preserves_inline_data() -> None:
     assert chunk.choices[0].delta.images == [
         {"type": "image_url", "image_url": {"url": "data:audio/wav;base64,UklGRg=="}}
     ]
+    assert chunk.model_dump()["choices"][0]["delta"]["images"] == chunk.choices[0].delta.images
 
 
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -948,6 +948,20 @@ def test_convert_response_preserves_inline_data_alongside_text() -> None:
     assert ChatCompletionMessage.model_validate(message).images == message["images"]
 
 
+def test_convert_completion_response_preserves_public_images() -> None:
+    response_dict = _convert_response_to_response_dict(
+        _make_gemini_response(
+            [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))],
+            types.FinishReason.STOP,
+        )
+    )
+
+    completion = GoogleProvider._convert_completion_response((response_dict, "test-model"))
+    message = completion.choices[0].message
+    assert message.images == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}]
+    assert completion.model_dump()["choices"][0]["message"]["images"] == message.images
+
+
 def test_convert_response_emits_choice_for_image_only_response() -> None:
     response = _make_gemini_response(
         [types.Part(inline_data=types.Blob(mime_type="image/png", data=b"\x89PNG"))],

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -23,6 +23,7 @@ from any_llm.providers.gemini.utils import (
     _convert_tool_spec,
     _create_openai_chunk_from_google_chunk,
     _has_additional_properties,
+    _inline_data_image,
     _map_finish_reason,
 )
 from any_llm.types.completion import (
@@ -998,6 +999,19 @@ def test_convert_streaming_response_preserves_thought_inline_data() -> None:
     assert chunk.choices[0].delta.images == [
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw=="}}
     ]
+
+
+@pytest.mark.parametrize(
+    "inline_data",
+    [
+        types.Blob(mime_type="", data=b"image-bytes"),
+        types.Blob(mime_type="image/png", data=b""),
+    ],
+)
+def test_inline_data_image_ignores_incomplete_data(inline_data: types.Blob) -> None:
+    part = types.Part(inline_data=inline_data)
+
+    assert _inline_data_image(part) is None
 
 
 def test_convert_response_emits_choice_for_filtered_response_without_content() -> None:


### PR DESCRIPTION
## Description

Preserve Gemini `inline_data` response parts as OpenAI-compatible image items for both non-streaming and streaming responses, including media-only and thought-marked parts. The conversion now ignores incomplete mock/provider parts instead of attempting to base64-encode non-byte values.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1295

## Root cause and scope

Gemini response conversion only handled text, thought, and function-call parts. `inline_data` was silently discarded, and media-only candidates produced no choice. The fix adds the `images` response fields, converts inline bytes to data URLs in both paths, and preserves existing text/tool/finish-reason behavior. The type guard keeps text-only fixtures and incomplete provider parts out of the media conversion path.

## Validation

- Added unit coverage for mixed text + media, media-only, streaming media, and thought-marked media.
- `uv run --extra gemini pytest tests/unit/providers/test_gemini_provider.py -q --reruns 0 --timeout=20` — **182 passed**.
- `uv run --extra gemini pytest tests/unit/providers/test_gemini_provider.py -q --reruns 0 --timeout=20 -k "inline_data or image_only"` — **5 passed, 177 deselected**.
- Ruff lint and format checks on changed files — passed.
- `python -m compileall` on changed Python files — passed.
- `git diff --check` — passed.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info: implementation and validation were reviewed against the current source and reviewer feedback.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gemini responses now support inline images alongside text, reasoning, tool calls and thought signatures.
  - Images are provided as OpenAI-compatible base64 data URLs in regular and streaming responses.
  - Image information is available in chat messages and streaming response updates.
  - Image-only responses are supported.

- **Bug Fixes**
  - Incomplete inline image data is safely ignored during response conversion.
  - Inline images now remain available when returned alongside other response content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->