### PR TITLE
Add MiniMax image generation support

### DIFF
--- a/src/any_llm/providers/minimax/minimax.py
+++ b/src/any_llm/providers/minimax/minimax.py
@@ -1,6 +1,8 @@
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+import httpx
 from openai._streaming import AsyncStream
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
@@ -10,6 +12,7 @@ from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.openai.xml_reasoning import XMLReasoningOpenAIProvider, wrap_chunks_with_xml_reasoning
 from any_llm.providers.openai.xml_reasoning_utils import convert_chat_completion_with_xml_reasoning
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+from any_llm.types.image import ImageGenerationParams, ImagesResponse
 
 
 class MinimaxProvider(XMLReasoningOpenAIProvider):
@@ -17,13 +20,42 @@ class MinimaxProvider(XMLReasoningOpenAIProvider):
     ENV_API_KEY_NAME = "MINIMAX_API_KEY"
     ENV_API_BASE_NAME = "MINIMAX_API_BASE"
     PROVIDER_NAME = "minimax"
-    PROVIDER_DOCUMENTATION_URL = "https://www.minimax.io/platform_overview"
+    PROVIDER_DOCUMENTATION_URL = "https://platform.minimax.io/docs"
 
     SUPPORTS_COMPLETION_PDF = False
     SUPPORTS_COMPLETION_REASONING = True
     SUPPORTS_COMPLETION_IMAGE = False
+    SUPPORTS_IMAGE_GENERATION = True
     SUPPORTS_LIST_MODELS = False
     SUPPORTS_EMBEDDING = False
+
+    @override
+    async def _aimage_generation(self, params: ImageGenerationParams, **kwargs: Any) -> ImagesResponse:
+        """Call MiniMax's native image endpoint and normalize its response."""
+        api_kwargs = params.to_api_kwargs()
+        api_kwargs.update(kwargs)
+        response_format = api_kwargs.get("response_format")
+        if response_format == "b64_json":
+            api_kwargs["response_format"] = "base64"
+
+        endpoint = f"{str(self.client.base_url).rstrip('/')}/image_generation"
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                endpoint,
+                headers={"Authorization": f"Bearer {self.client.api_key}"},
+                json={"model": params.model_id, "prompt": params.prompt, **api_kwargs},
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        base_resp = payload.get("base_resp") or {}
+        if str(base_resp.get("status_code", 0)) not in ("0", "None"):
+            raise RuntimeError(base_resp.get("status_msg", "MiniMax image generation failed"))
+
+        image_data = payload.get("data") or {}
+        images = [{"url": url} for url in image_data.get("image_urls", [])]
+        images.extend({"b64_json": value} for value in image_data.get("image_base64", []))
+        return ImagesResponse.model_validate({"created": int(time.time()), "data": images})
 
     @staticmethod
     @override

--- a/src/any_llm/types/image.py
+++ b/src/any_llm/types/image.py
@@ -20,6 +20,12 @@ class ImageGenerationParams(BaseModel):
     style: str | None = None
     response_format: Literal["url", "b64_json"] | None = None
     user: str | None = None
+    subject_reference: list[str] | None = None
+    aspect_ratio: str | None = None
+    width: int | None = None
+    height: int | None = None
+    seed: int | None = None
+    prompt_optimizer: bool | None = None
 
     def to_api_kwargs(self) -> dict[str, Any]:
         """Convert to kwargs for the provider API call, excluding None values."""

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -19,6 +19,7 @@ from any_llm import AnyLLM
 from any_llm.exceptions import UnsupportedParameterError
 from any_llm.providers.minimax.minimax import MinimaxProvider
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+from any_llm.types.image import ImageGenerationParams
 
 if TYPE_CHECKING:
     from openai._streaming import AsyncStream
@@ -44,6 +45,7 @@ def test_provider_basics() -> None:
     assert p.SUPPORTS_COMPLETION_REASONING is True
     assert p.SUPPORTS_EMBEDDING is False
     assert p.SUPPORTS_COMPLETION_IMAGE is False
+    assert p.SUPPORTS_IMAGE_GENERATION is True
     assert p.SUPPORTS_COMPLETION_PDF is False
     assert p.SUPPORTS_LIST_MODELS is False
 
@@ -91,10 +93,47 @@ def test_provider_metadata() -> None:
     metadata = MinimaxProvider.get_provider_metadata()
     assert metadata.name == "minimax"
     assert metadata.env_key == "MINIMAX_API_KEY"
-    assert metadata.doc_url == "https://www.minimax.io/platform_overview"
+    assert metadata.doc_url == "https://platform.minimax.io/docs"
     assert metadata.completion is True
     assert metadata.embedding is False
     assert metadata.image is False
+    assert metadata.image_generation is True
+
+
+@pytest.mark.asyncio
+async def test_image_generation_uses_native_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"data": {"image_urls": ["https://img.example/image.png"]}, "base_resp": {"status_code": 0}}
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.request: dict[str, object] | None = None
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: object) -> FakeResponse:
+            self.request = {"url": url, **kwargs}
+            return FakeResponse()
+
+    client = FakeClient()
+    monkeypatch.setattr("any_llm.providers.minimax.minimax.httpx.AsyncClient", lambda: client)
+    provider = MinimaxProvider(api_key="sk-test")
+    result = await provider._aimage_generation(
+        ImageGenerationParams(model_id="image-01", prompt="a cat", aspect_ratio="16:9")
+    )
+
+    assert result.data[0].url == "https://img.example/image.png"
+    assert client.request is not None
+    assert client.request["url"] == "https://api.minimax.io/v1/image_generation"
+    assert client.request["json"] == {"model": "image-01", "prompt": "a cat", "aspect_ratio": "16:9"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -167,6 +167,7 @@ def test_supports_image_generation_only_on_expected_providers() -> None:
         LLMProvider.AZUREOPENAI,
         LLMProvider.NEOSANTARA,
         LLMProvider.OTARI,
+        LLMProvider.MINIMAX,
     }
 
     for provider_enum in expected_supported:


### PR DESCRIPTION
Reason: MinimaxProvider exposes image generation through the MiniMax image endpoint.

This adds the native MiniMax image-generation request and response adapter, including URL and base64 output normalization, status handling, regional API-base support, and documented request parameters. Provider image-generation metadata and unit coverage are updated accordingly.

Checks: `PYTHONPATH=src /home/jianglisu/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/unit/providers/test_minimax_provider.py tests/unit/test_image_generation.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image-generation support for the MiniMax provider.
  * Added options for subject references, aspect ratio, image dimensions, random seed and prompt optimisation.
  * Image-generation results now support both returned image URLs and base64-encoded images.

* **Documentation**
  * Updated the MiniMax documentation link.

* **Tests**
  * Added coverage for MiniMax image generation and its supported configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->