### PR TITLE
fix(mistral): trim reasoning at the opening response tag in the streaming path too

### DIFF
--- a/src/any_llm/providers/mistral/utils.py
+++ b/src/any_llm/providers/mistral/utils.py
@@ -158,6 +158,34 @@ def _extract_mistral_content_and_reasoning(
     return content, reasoning_content, thinking_signature
 
 
+def _split_response_tag_from_reasoning(
+    content: str | None, reasoning_content: str | None
+) -> tuple[str | None, str | None]:
+    """Recover an answer that Mistral wrapped in `<response>` tags inside the thinking trace.
+
+    Some Mistral reasoning models (e.g. Magistral) sometimes return an empty/None content
+    and instead wrap the real answer in `<response>...</response>` inside the reasoning
+    content. When that happens, pull the answer out of the reasoning and trim the reasoning
+    down to what came before the opening tag.
+
+    Used by both the non-streaming and streaming converters so the two paths can't drift
+    apart again the way they did when this was only fixed in one of them (see #1302).
+
+    Note: this only handles the tags landing in a single string. In streaming, if the
+    `<response>` or `</response>` marker itself is split across two chunks, this will not
+    catch it - each chunk's reasoning text is checked independently.
+    """
+    if (
+        content is None
+        and reasoning_content
+        and "<response>" in reasoning_content
+        and "</response>" in reasoning_content
+    ):
+        content = reasoning_content.split("<response>")[1].split("</response>")[0]
+        reasoning_content = reasoning_content.split("<response>")[0]
+    return content, reasoning_content
+
+
 def _create_mistral_completion_from_response(
     response_data: MistralChatCompletionResponse, model: str
 ) -> ChatCompletion:
@@ -208,14 +236,7 @@ def _create_mistral_completion_from_response(
 
         # if the content is none, see if it accidentally ended up in the reasoning content (aka <response>).
         # This is a bug in the mistral provider/model return
-        if (
-            content is None
-            and reasoning_content
-            and "<response>" in reasoning_content
-            and "</response>" in reasoning_content
-        ):
-            content = reasoning_content.split("<response>")[1].split("</response>")[0]
-            reasoning_content = reasoning_content.split("<response>")[0]
+        content, reasoning_content = _split_response_tag_from_reasoning(content, reasoning_content)
 
         message = ChatCompletionMessage(
             role="assistant",
@@ -289,6 +310,11 @@ def _create_openai_chunk_from_mistral_chunk(event: CompletionEvent) -> ChatCompl
                 content = "".join(text_parts) if text_parts else None
             else:
                 content = str(choice.delta.content)
+
+        # Mirrors the non-streaming converter's recovery of an answer that Mistral wrapped
+        # in <response> tags inside the thinking trace (see #1302). This only catches the
+        # case where both tags land in the same chunk; see _split_response_tag_from_reasoning.
+        content, reasoning_content = _split_response_tag_from_reasoning(content, reasoning_content)
 
         role = None
         if choice.delta.role:

--- a/tests/unit/providers/test_mistral_provider.py
+++ b/tests/unit/providers/test_mistral_provider.py
@@ -1351,6 +1351,69 @@ def test_create_openai_chunk_captures_thinking_signature() -> None:
     assert chunk.choices[0].delta.extra_content == {"mistral": {"signature": "sig-abc"}}
 
 
+def test_create_openai_chunk_strips_response_block_from_reasoning() -> None:
+    """Streaming must recover a <response>-wrapped answer the same way non-streaming does.
+
+    #1302 fixed this for `_create_mistral_completion_from_response` but left the streaming
+    converter untouched, so `stream=True` silently returned an empty `delta.content` for the
+    same payload. This is the streaming half of that fix.
+    """
+    pytest.importorskip("mistralai")
+    from mistralai.client.models import TextChunk, ThinkChunk
+
+    from any_llm.providers.mistral.utils import _create_openai_chunk_from_mistral_chunk
+
+    choice = Mock()
+    choice.index = 0
+    choice.delta.content = [
+        ThinkChunk(thinking=[TextChunk(text="Let me work it out.<response>The answer is 42.</response>")])
+    ]
+    choice.delta.role = "assistant"
+    choice.delta.tool_calls = None
+    choice.finish_reason = None
+
+    event = Mock()
+    event.data.id = "chatcmpl-abc"
+    event.data.created = 1_700_000_000
+    event.data.model = "magistral-medium-latest"
+    event.data.choices = [choice]
+    event.data.usage = None
+
+    chunk = _create_openai_chunk_from_mistral_chunk(event)
+
+    assert chunk.choices[0].delta.content == "The answer is 42."
+    assert chunk.choices[0].delta.reasoning is not None
+    assert chunk.choices[0].delta.reasoning.content == "Let me work it out."
+
+
+def test_create_openai_chunk_leaves_plain_reasoning_unchanged() -> None:
+    """Regression: a normal streaming chunk with plain reasoning and no tags is unaffected."""
+    pytest.importorskip("mistralai")
+    from mistralai.client.models import TextChunk, ThinkChunk
+
+    from any_llm.providers.mistral.utils import _create_openai_chunk_from_mistral_chunk
+
+    choice = Mock()
+    choice.index = 0
+    choice.delta.content = [ThinkChunk(thinking=[TextChunk(text="just thinking, nothing special")])]
+    choice.delta.role = "assistant"
+    choice.delta.tool_calls = None
+    choice.finish_reason = None
+
+    event = Mock()
+    event.data.id = "chatcmpl-abc"
+    event.data.created = 1_700_000_000
+    event.data.model = "mistral-medium-3-5"
+    event.data.choices = [choice]
+    event.data.usage = None
+
+    chunk = _create_openai_chunk_from_mistral_chunk(event)
+
+    assert chunk.choices[0].delta.content is None
+    assert chunk.choices[0].delta.reasoning is not None
+    assert chunk.choices[0].delta.reasoning.content == "just thinking, nothing special"
+
+
 @pytest.mark.asyncio
 async def test_timeout_is_translated_to_timeout_ms() -> None:
     """The seconds-based any-llm ``timeout`` must become the SDK's ``timeout_ms``.


### PR DESCRIPTION
## What

#1302 fixed a bug where some Mistral reasoning models (Magistral) sometimes return the real
answer wrapped in `<response>...</response>` inside the reasoning/thinking content instead of
in `content`. That fix only landed in `_create_mistral_completion_from_response` (the
non-streaming converter), `src/any_llm/providers/mistral/utils.py:209-218` on main before this
PR. `_create_openai_chunk_from_mistral_chunk` (the streaming converter, same file, ~256-334)
never got the equivalent change.

## The bug

With `stream=True`, when a `ThinkChunk` delta's thinking text contains the `<response>` markers,
`choice.delta.content` stays `None` for that chunk and the whole answer, tags included, ends up
only in `delta.reasoning.content`. A caller following the standard OpenAI streaming contract
(accumulate `delta.content` across chunks) gets an empty response. No exception, no error - it
just silently returns nothing. The identical request with `stream=False` returns the answer
correctly today (because of #1302), which is what made this easy to miss.

## The fix

Pulled the split/trim logic out of the non-streaming function into a shared
`_split_response_tag_from_reasoning()` helper and call it from both converters. That's the part
that actually matters here - the two converters had this same logic and one of them fell
behind once already; sharing it is what stops that from happening a second time.

## Streaming semantics limitation

Deltas arrive in fragments, so in principle `<response>` or `</response>` could be split across
two separate chunks. This fix only handles the case where a single chunk's reasoning text
contains both the opening and closing tag, mirroring what #1302 already does for a single
non-streaming response body. It does not buffer or reassemble text across chunks to catch a tag
boundary that lands mid-chunk-break. Noting this here rather than silently leaving it unhandled;
happy to follow up with a stateful/buffered version if that's wanted, but wanted to keep this
diff minimal and match #1302's scope.

## Testing

Added to `tests/unit/providers/test_mistral_provider.py`:
- `test_create_openai_chunk_strips_response_block_from_reasoning` - a streaming chunk whose
  thinking text contains `<response>...</response>` yields `delta.content` with the answer and
  `reasoning` trimmed to what came before the opening tag
- `test_create_openai_chunk_leaves_plain_reasoning_unchanged` - regression: a normal streaming
  chunk with plain reasoning and no tags is unaffected

Ran:
- `uv run pytest tests/unit/providers/test_mistral_provider.py -p no:rerunfailures` - 64 passed
  (62 previously existing + 2 new)
- Reverted the source change only (kept the new tests) and reran the two new tests to confirm
  they fail against the old code:
  `test_create_openai_chunk_strips_response_block_from_reasoning` failed with
  `AssertionError: assert None == 'The answer is 42.'` - `delta.content` stayed `None`, matching
  the reported bug exactly. Restored the fix afterward and reran the full file to confirm 64
  passed again.
- `uv run ruff check` / `uv run ruff format --check` on both changed files - clean
- `uv run mypy src/any_llm/providers/mistral/utils.py` - no issues


## PR Type
<!-- Delete the types that don't apply -->

- 🐛 Bug Fix

## Relevant issues
<!-- e.g. "Fixes #123" -->

Follow-up to #1302, which fixed the same bug in the non-streaming converter but missed the
streaming one.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Written in conjunction with my pair programmer Claude. The finding was verified against upstream before any code was written, and the fix is covered by tests that fail against the unpatched source.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mistral response handling when answers are embedded within reasoning content.
  * Recovered wrapped answers consistently in both standard and streaming responses.
  * Prevented response markers from appearing in displayed reasoning.
  * Preserved existing behaviour for ordinary reasoning without response markers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
