### PR TITLE
test: tolerate spurious tool arguments in agent loop

### DIFF
--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,13 @@ def get_weather(location: str) -> str:
 def _call_tool(tool_fn: Callable[..., str], args: dict[str, Any]) -> str:
     """Call a model-selected tool without passing arguments it does not accept."""
     accepted = inspect.signature(tool_fn).parameters
+    unexpected = set(args) - set(accepted)
+    if unexpected:
+        warnings.warn(
+            f"Ignoring unexpected arguments for {tool_fn.__name__}: {', '.join(sorted(unexpected))}",
+            UserWarning,
+            stacklevel=2,
+        )
     return tool_fn(**{name: value for name, value in args.items() if name in accepted})
 
 

--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,4 +1,6 @@
+import inspect
 import json
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -13,8 +15,6 @@ from any_llm.exceptions import MissingApiKeyError
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from any_llm.types.completion import ChatCompletion, ChatCompletionMessage
 
 
@@ -30,6 +30,12 @@ def get_weather(location: str) -> str:
         location: The city name to get weather for.
     """
     return json.dumps({"location": location, "temperature": "15C", "condition": "sunny"})
+
+
+def _call_tool(tool_fn: Callable[..., str], args: dict[str, Any]) -> str:
+    """Call a model-selected tool without passing arguments it does not accept."""
+    accepted = inspect.signature(tool_fn).parameters
+    return tool_fn(**{name: value for name, value in args.items() if name in accepted})
 
 
 @pytest.mark.asyncio
@@ -70,7 +76,7 @@ async def test_agent_loop_parallel_tool_calls(
                 continue
             assert tool_call.function.name == "get_weather"
             args = json.loads(tool_call.function.arguments)
-            tool_result = get_weather(**args)
+            tool_result = _call_tool(get_weather, args)
 
             messages.append(
                 {
@@ -155,7 +161,7 @@ async def test_agent_loop_sequential_tool_calls(
                 tool_fn = available_tools[tool_name]
 
                 args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                tool_result = tool_fn(**args)
+                tool_result = _call_tool(tool_fn, args)
 
                 messages.append(
                     {

--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -44,6 +44,7 @@ async def test_agent_loop_parallel_tool_calls(
     provider_model_map: dict[LLMProvider, str],
     provider_client_config: dict[LLMProvider, dict[str, Any]],
 ) -> None:
+    """Execute multiple model-selected tool calls and return their results."""
     if provider in (*LOCAL_PROVIDERS, LLMProvider.PERPLEXITY):
         pytest.skip(f"{provider} does not support tools, skipping")
 
@@ -111,6 +112,7 @@ async def test_agent_loop_sequential_tool_calls(
     provider_model_map: dict[LLMProvider, str],
     provider_client_config: dict[LLMProvider, dict[str, Any]],
 ) -> None:
+    """Execute model-selected tools over several agent-loop iterations."""
     if provider in (*LOCAL_PROVIDERS, LLMProvider.PERPLEXITY):
         pytest.skip(f"{provider} does not support tools, skipping")
 

--- a/tests/unit/test_agent_loop_helpers.py
+++ b/tests/unit/test_agent_loop_helpers.py
@@ -2,8 +2,10 @@ from tests.integration.test_agent_loop import _call_tool, get_current_date, get_
 
 
 def test_call_tool_ignores_spurious_model_arguments_for_zero_arg_tool() -> None:
+    """Ignore model-generated arguments that a zero-argument tool cannot accept."""
     assert _call_tool(get_current_date, {"result": "unexpected"}) == "2025-12-18 12:30"
 
 
 def test_call_tool_preserves_declared_tool_arguments() -> None:
+    """Preserve arguments declared by a parameterized tool while filtering extras."""
     assert "Paris" in _call_tool(get_weather, {"location": "Paris", "result": "unexpected"})

--- a/tests/unit/test_agent_loop_helpers.py
+++ b/tests/unit/test_agent_loop_helpers.py
@@ -1,11 +1,15 @@
+import pytest
+
 from tests.integration.test_agent_loop import _call_tool, get_current_date, get_weather
 
 
 def test_call_tool_ignores_spurious_model_arguments_for_zero_arg_tool() -> None:
     """Ignore model-generated arguments that a zero-argument tool cannot accept."""
-    assert _call_tool(get_current_date, {"result": "unexpected"}) == "2025-12-18 12:30"
+    with pytest.warns(UserWarning, match="Ignoring unexpected arguments for get_current_date: result"):
+        assert _call_tool(get_current_date, {"result": "unexpected"}) == "2025-12-18 12:30"
 
 
 def test_call_tool_preserves_declared_tool_arguments() -> None:
     """Preserve arguments declared by a parameterized tool while filtering extras."""
-    assert "Paris" in _call_tool(get_weather, {"location": "Paris", "result": "unexpected"})
+    with pytest.warns(UserWarning, match="Ignoring unexpected arguments for get_weather: result"):
+        assert "Paris" in _call_tool(get_weather, {"location": "Paris", "result": "unexpected"})

--- a/tests/unit/test_agent_loop_helpers.py
+++ b/tests/unit/test_agent_loop_helpers.py
@@ -1,0 +1,9 @@
+from tests.integration.test_agent_loop import _call_tool, get_current_date, get_weather
+
+
+def test_call_tool_ignores_spurious_model_arguments_for_zero_arg_tool() -> None:
+    assert _call_tool(get_current_date, {"result": "unexpected"}) == "2025-12-18 12:30"
+
+
+def test_call_tool_preserves_declared_tool_arguments() -> None:
+    assert "Paris" in _call_tool(get_weather, {"location": "Paris", "result": "unexpected"})


### PR DESCRIPTION
## Description

Ignore unexpected model-generated keyword arguments when executing test tools, and add deterministic coverage for zero-argument and parameterized tools.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Closes #1170

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: The implementation and validation were performed in the Codex environment.

- [x] I am an AI Agent filling out this form (check box if true)

## Motivation

Together tool calls can occasionally include a spurious argument for the zero-argument `get_current_date` test tool. Passing that argument directly raises `TypeError` and makes the agent-loop integration test flaky. The original failure is documented in [Issue #1170](https://github.com/mozilla-ai/any-llm/issues/1170), including the failing [CI run](https://github.com/mozilla-ai/any-llm/actions/runs/28503597221). The helper now filters arguments against the selected callable's signature while preserving declared parameters, and emits a `UserWarning` when it ignores unexpected arguments.

## Validation

- `\.venv\Scripts\python.exe -m pytest tests/unit/test_agent_loop_helpers.py -q` (2 passed)
- `\.venv\Scripts\python.exe -m pytest tests/unit -q --basetemp .pytest-tmp-full-unit-2` (2369 passed, 69 skipped, 4 unrelated environment failures: three local HTTP 502 responses and one Windows symlink privilege error)
- `\.venv\Scripts\python.exe -m pytest tests/integration -n auto -q --basetemp .pytest-tmp-full-integration-disabled` with both provider inclusion flags disabled (22 passed, 43 skipped, 2 unrelated Ollama HTTP 502 failures)
- `\.venv\Scripts\python.exe -m mypy --follow-imports=skip --config-file pyproject.toml tests/integration/test_agent_loop.py tests/unit/test_agent_loop_helpers.py` (passed)
- `uvx ruff check tests/integration/test_agent_loop.py tests/unit/test_agent_loop_helpers.py` (fails only on pre-existing `CPY001` copyright errors in both files)
- `uvx ruff format --check tests/integration/test_agent_loop.py tests/unit/test_agent_loop_helpers.py` (reports pre-existing CRLF formatting differences)
- `git diff --check` (passed)

The repository pre-commit hooks could not be completed locally because the first-time hook installation remained blocked by a pre-commit cache lock. No external provider API keys were available, and the local Ollama endpoint returned HTTP 502 responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool invocation so unexpected model-supplied arguments are ignored.
  - Ensured tools receive only the parameters they explicitly support.
  - Improved handling for both sequential and parallel agent operations.

- **Tests**
  - Added coverage for zero-argument tools and parameterised tools.
  - Updated integration test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
