### PR TITLE
test: cover synchronous Responses streaming

### DIFF
--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -179,7 +179,9 @@ def test_responses_helper_streaming_returns_sync_iterator() -> None:
         patch.object(provider, "_aresponses", new=AsyncMock(return_value=_response_event_stream())) as mock_aresponses,
     ):
         stream = responses("gpt-4.1-mini", "hello", provider="openai", api_key="test-key", stream=True)
-        assert list(stream) == ["response.created", "response.completed"]
+        events = list(stream)
+        assert all(isinstance(event, str) for event in events)
+        assert cast("list[str]", events) == ["response.created", "response.completed"]
 
     assert mock_aresponses.call_args.args[0].stream is True
 

--- a/tests/unit/test_responses.py
+++ b/tests/unit/test_responses.py
@@ -11,6 +11,11 @@ from any_llm.exceptions import UnsupportedParameterError
 from any_llm.types.responses import ResponsesParams
 
 
+async def _response_event_stream() -> Any:
+    yield "response.created"
+    yield "response.completed"
+
+
 @pytest.mark.asyncio
 async def test_responses_invalid_model_format_no_slash() -> None:
     """Test responses raises ValueError for model without separator."""
@@ -164,6 +169,19 @@ def test_responses_helper_forwards_timeout_to_provider_sync() -> None:
         responses("gpt-4.1-mini", "hello", provider="openai", api_key="test-key", timeout=60)
 
     assert mock_aresponses.call_args.kwargs["timeout"] == 60
+
+
+def test_responses_helper_streaming_returns_sync_iterator() -> None:
+    """The synchronous Responses API must bridge an async event stream."""
+    provider = AnyLLM.create("openai", api_key="test-key")
+    with (
+        patch("any_llm.any_llm.AnyLLM.create", return_value=provider),
+        patch.object(provider, "_aresponses", new=AsyncMock(return_value=_response_event_stream())) as mock_aresponses,
+    ):
+        stream = responses("gpt-4.1-mini", "hello", provider="openai", api_key="test-key", stream=True)
+        assert list(stream) == ["response.created", "response.completed"]
+
+    assert mock_aresponses.call_args.args[0].stream is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Add deterministic unit coverage for the synchronous Responses streaming wrapper. The test verifies that asynchronous response events are exposed through a synchronous iterator and that `stream=True` is forwarded to the response provider.

## PR Type

- 🚦 Infrastructure

## Relevant issues

- No issue — this PR adds regression coverage for existing synchronous Responses streaming behavior.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5
- AI Developer Tool used: Codex
- Any other info you'd like to share: AI assistance was used to review and update the PR description in response to automated review feedback.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for synchronous response streaming, confirming that asynchronous response events are exposed through a synchronous iterator in the correct order.
  - Verified that streaming options are correctly passed through to the response provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->