### PR TITLE
fix(gemini): honor current thinking capabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ mistral = [
 anthropic = []
 
 gemini = [
-  "google-genai>=1.51.0",
+  "google-genai>=1.70.0",
   "google-cloud-storage",
 ]
 
 vertexai = [
-  "google-genai>=1.51.0",
+  "google-genai>=1.70.0",
   "google-cloud-storage",
 ]
 

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from typing_extensions import override
@@ -52,33 +51,35 @@ if TYPE_CHECKING:
     from any_llm.types.model import Model
 
 REASONING_EFFORT_TO_THINKING_BUDGETS = {
-    "minimal": 256,
+    "minimal": 1024,
     "low": 1024,
     "medium": 8192,
     "high": 24576,
-    "xhigh": 32768,
-    "max": 32768,
 }
 REASONING_EFFORT_TO_THINKING_LEVELS = {
     "minimal": types.ThinkingLevel.MINIMAL,
     "low": types.ThinkingLevel.LOW,
     "medium": types.ThinkingLevel.MEDIUM,
     "high": types.ThinkingLevel.HIGH,
-    "xhigh": types.ThinkingLevel.HIGH,
-    "max": types.ThinkingLevel.HIGH,
 }
 _SUPPORTED_BATCH_ENDPOINTS = frozenset({"/v1/chat/completions"})
-_THINKING_LEVEL_MIN_GEMINI_VERSION = (3, 5)
-_GEMINI_VERSION_PATTERN = re.compile(r"(?:^|/)gemini-(\d+)(?:\.(\d+))?")
-
-
-def _uses_thinking_level(model_id: str) -> bool:
-    """Gemini 3.5 and newer reject `thinking_budget` and expect `thinking_level` instead."""
-    match = _GEMINI_VERSION_PATTERN.search(model_id.lower())
-    if match is None:
-        return False
-    major, minor = int(match.group(1)), int(match.group(2) or 0)
-    return (major, minor) >= _THINKING_LEVEL_MIN_GEMINI_VERSION
+_ALL_THINKING_LEVELS = frozenset(REASONING_EFFORT_TO_THINKING_LEVELS.values())
+# Model capabilities differ within the Gemini 3 family, so a version comparison is not sufficient.
+# Source: https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels
+_THINKING_LEVELS_BY_MODEL = {
+    "gemini-3.8-flash": frozenset({types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH}),
+    "gemini-3.7-flash": frozenset({types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH}),
+    "gemini-3.6-flash": _ALL_THINKING_LEVELS,
+    "gemini-3.5-flash": _ALL_THINKING_LEVELS,
+    "gemini-3.5-flash-lite": _ALL_THINKING_LEVELS,
+    "gemini-3.1-flash-lite": _ALL_THINKING_LEVELS,
+    "gemini-3.1-pro-preview": frozenset(
+        {types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH}
+    ),
+    "gemini-3.1-flash-lite-image": frozenset({types.ThinkingLevel.MINIMAL, types.ThinkingLevel.HIGH}),
+    "gemini-3-flash-preview": _ALL_THINKING_LEVELS,
+}
+_THINKING_BUDGET_MODELS = frozenset({"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"})
 
 
 class GoogleProvider(AnyLLM):
@@ -146,17 +147,41 @@ class GoogleProvider(AnyLLM):
             kwargs["max_output_tokens"] = params.max_tokens
         if params.presence_penalty is not None:
             kwargs["presence_penalty"] = params.presence_penalty
-        if params.reasoning_effort != "auto":
-            if params.reasoning_effort is None or params.reasoning_effort == "none":
-                kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
-            elif _uses_thinking_level(params.model_id):
+        if params.reasoning_effort not in (None, "auto"):
+            error_message = "reasoning_effort"
+            model_name = params.model_id.rsplit("/", maxsplit=1)[-1].lower()
+            supported_levels = _THINKING_LEVELS_BY_MODEL.get(model_name)
+            if supported_levels is not None:
+                reasoning_effort = params.reasoning_effort
+                thinking_level = REASONING_EFFORT_TO_THINKING_LEVELS.get(reasoning_effort)
+                # Google's OpenAI compatibility contract maps `minimal` to `low` for Gemini 3.1 Pro.
+                # Source: https://ai.google.dev/gemini-api/docs/openai#thinking
+                if model_name == "gemini-3.1-pro-preview" and reasoning_effort == "minimal":
+                    thinking_level = types.ThinkingLevel.LOW
+                if thinking_level is None or thinking_level not in supported_levels:
+                    raise UnsupportedParameterError(error_message, provider_name)
                 kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True, thinking_level=REASONING_EFFORT_TO_THINKING_LEVELS[params.reasoning_effort]
+                    include_thoughts=True,
+                    thinking_level=thinking_level,
                 )
+            elif model_name in _THINKING_BUDGET_MODELS:
+                if params.reasoning_effort == "none":
+                    if model_name == "gemini-2.5-pro":
+                        raise UnsupportedParameterError(error_message, provider_name)
+                    kwargs["thinking_config"] = types.ThinkingConfig(
+                        include_thoughts=False,
+                        thinking_budget=0,
+                    )
+                else:
+                    thinking_budget = REASONING_EFFORT_TO_THINKING_BUDGETS.get(params.reasoning_effort)
+                    if thinking_budget is None:
+                        raise UnsupportedParameterError(error_message, provider_name)
+                    kwargs["thinking_config"] = types.ThinkingConfig(
+                        include_thoughts=True,
+                        thinking_budget=thinking_budget,
+                    )
             else:
-                kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[params.reasoning_effort]
-                )
+                raise UnsupportedParameterError(error_message, provider_name)
         if params.seed is not None:
             kwargs["seed"] = params.seed
         if params.service_tier is not None:

--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -19,6 +19,7 @@ from any_llm.types.completion import (
     CreateEmbeddingResponse,
     Function,
     Reasoning,
+    ReasoningEffort,
 )
 from any_llm.utils.structured_output import get_json_schema, is_structured_output_type
 
@@ -82,6 +83,63 @@ _THINKING_LEVELS_BY_MODEL = {
 _THINKING_BUDGET_MODELS = frozenset({"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"})
 
 
+def _convert_reasoning_effort(
+    model_id: str,
+    reasoning_effort: ReasoningEffort | None,
+    provider_name: str,
+) -> types.ThinkingConfig | None:
+    if reasoning_effort in (None, "auto"):
+        return None
+
+    parameter_name = "reasoning_effort"
+    model_name = model_id.rsplit("/", maxsplit=1)[-1].lower()
+    supported_levels = _THINKING_LEVELS_BY_MODEL.get(model_name)
+    if supported_levels is not None:
+        thinking_level = REASONING_EFFORT_TO_THINKING_LEVELS.get(reasoning_effort)
+        # Google's OpenAI compatibility contract maps `minimal` to `low` for Gemini 3.1 Pro.
+        # Source: https://ai.google.dev/gemini-api/docs/openai#thinking
+        if model_name == "gemini-3.1-pro-preview" and reasoning_effort == "minimal":
+            thinking_level = types.ThinkingLevel.LOW
+        if thinking_level is None or thinking_level not in supported_levels:
+            raise UnsupportedParameterError(parameter_name, provider_name)
+        return types.ThinkingConfig(include_thoughts=True, thinking_level=thinking_level)
+
+    if model_name in _THINKING_BUDGET_MODELS:
+        if reasoning_effort == "none":
+            if model_name == "gemini-2.5-pro":
+                raise UnsupportedParameterError(parameter_name, provider_name)
+            return types.ThinkingConfig(include_thoughts=False, thinking_budget=0)
+
+        thinking_budget = REASONING_EFFORT_TO_THINKING_BUDGETS.get(reasoning_effort)
+        if thinking_budget is not None:
+            return types.ThinkingConfig(include_thoughts=True, thinking_budget=thinking_budget)
+
+    raise UnsupportedParameterError(parameter_name, provider_name)
+
+
+def _convert_response_format(response_format: dict[str, Any] | type | None) -> dict[str, Any]:
+    if is_structured_output_type(response_format):
+        schema = get_json_schema(response_format)
+        schema_key = "response_json_schema" if _has_additional_properties(schema) else "response_schema"
+        return {"response_mime_type": "application/json", schema_key: schema}
+    if not isinstance(response_format, dict):
+        return {}
+
+    response_type = response_format.get("type")
+    if response_type == "json_schema":
+        return {
+            "response_mime_type": "application/json",
+            "response_json_schema": response_format["json_schema"]["schema"],
+        }
+    if response_type == "json_object":
+        return {"response_mime_type": "application/json"}
+    if response_type in (None, "text"):
+        return {}
+
+    msg = f"Unsupported response_format type: {response_type}"
+    raise ValueError(msg)
+
+
 class GoogleProvider(AnyLLM):
     """Base Google Provider class with common functionality for Gemini and Vertex AI."""
 
@@ -141,85 +199,36 @@ class GoogleProvider(AnyLLM):
             error_message = "parallel_tool_calls"
             raise UnsupportedParameterError(error_message, provider_name)
 
-        if params.frequency_penalty is not None:
-            kwargs["frequency_penalty"] = params.frequency_penalty
-        if params.max_tokens is not None:
-            kwargs["max_output_tokens"] = params.max_tokens
-        if params.presence_penalty is not None:
-            kwargs["presence_penalty"] = params.presence_penalty
-        if params.reasoning_effort not in (None, "auto"):
-            error_message = "reasoning_effort"
-            model_name = params.model_id.rsplit("/", maxsplit=1)[-1].lower()
-            supported_levels = _THINKING_LEVELS_BY_MODEL.get(model_name)
-            if supported_levels is not None:
-                reasoning_effort = params.reasoning_effort
-                thinking_level = REASONING_EFFORT_TO_THINKING_LEVELS.get(reasoning_effort)
-                # Google's OpenAI compatibility contract maps `minimal` to `low` for Gemini 3.1 Pro.
-                # Source: https://ai.google.dev/gemini-api/docs/openai#thinking
-                if model_name == "gemini-3.1-pro-preview" and reasoning_effort == "minimal":
-                    thinking_level = types.ThinkingLevel.LOW
-                if thinking_level is None or thinking_level not in supported_levels:
-                    raise UnsupportedParameterError(error_message, provider_name)
-                kwargs["thinking_config"] = types.ThinkingConfig(
-                    include_thoughts=True,
-                    thinking_level=thinking_level,
+        kwargs.update(
+            {
+                option_name: option_value
+                for option_name, option_value in (
+                    ("frequency_penalty", params.frequency_penalty),
+                    ("max_output_tokens", params.max_tokens),
+                    ("presence_penalty", params.presence_penalty),
+                    ("seed", params.seed),
+                    ("service_tier", params.service_tier),
+                    ("temperature", params.temperature),
+                    ("top_p", params.top_p),
                 )
-            elif model_name in _THINKING_BUDGET_MODELS:
-                if params.reasoning_effort == "none":
-                    if model_name == "gemini-2.5-pro":
-                        raise UnsupportedParameterError(error_message, provider_name)
-                    kwargs["thinking_config"] = types.ThinkingConfig(
-                        include_thoughts=False,
-                        thinking_budget=0,
-                    )
-                else:
-                    thinking_budget = REASONING_EFFORT_TO_THINKING_BUDGETS.get(params.reasoning_effort)
-                    if thinking_budget is None:
-                        raise UnsupportedParameterError(error_message, provider_name)
-                    kwargs["thinking_config"] = types.ThinkingConfig(
-                        include_thoughts=True,
-                        thinking_budget=thinking_budget,
-                    )
-            else:
-                raise UnsupportedParameterError(error_message, provider_name)
-        if params.seed is not None:
-            kwargs["seed"] = params.seed
-        if params.service_tier is not None:
-            kwargs["service_tier"] = params.service_tier
-        if params.temperature is not None:
-            kwargs["temperature"] = params.temperature
+                if option_value is not None
+            }
+        )
+
+        thinking_config = _convert_reasoning_effort(params.model_id, params.reasoning_effort, provider_name)
+        if thinking_config is not None:
+            kwargs["thinking_config"] = thinking_config
         if params.tools is not None:
             kwargs["tools"] = _convert_tool_spec(params.tools, provider_name)
         if params.tool_choice is not None:
             kwargs["tool_config"] = _convert_tool_choice(params.tool_choice, provider_name)
-        if params.top_p is not None:
-            kwargs["top_p"] = params.top_p
         if params.stop is not None:
             if isinstance(params.stop, str):
                 kwargs["stop_sequences"] = [params.stop]
             else:
                 kwargs["stop_sequences"] = params.stop
 
-        response_format = params.response_format
-        if is_structured_output_type(response_format):
-            kwargs["response_mime_type"] = "application/json"
-            schema = get_json_schema(response_format)
-            if _has_additional_properties(schema):
-                kwargs["response_json_schema"] = schema
-            else:
-                kwargs["response_schema"] = schema
-        elif isinstance(response_format, dict):
-            response_type = response_format.get("type")
-            if response_type == "json_schema":
-                kwargs["response_mime_type"] = "application/json"
-                kwargs["response_json_schema"] = response_format["json_schema"]["schema"]
-            elif response_type == "json_object":
-                kwargs["response_mime_type"] = "application/json"
-            elif response_type == "text":
-                pass
-            else:
-                msg = f"Unsupported response_format type: {response_type}"
-                raise ValueError(msg)
+        kwargs.update(_convert_response_format(params.response_format))
 
         formatted_messages, system_instruction = _convert_messages(params.messages, provider_name=provider_name)
         if system_instruction:

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -2,9 +2,10 @@ import base64
 import json
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
-from typing import Any, get_args
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 from google.genai import types
 from pydantic import BaseModel, ConfigDict
@@ -16,7 +17,7 @@ from any_llm.exceptions import (
     UnsupportedParameterError,
 )
 from any_llm.providers.gemini import GeminiProvider
-from any_llm.providers.gemini.base import REASONING_EFFORT_TO_THINKING_BUDGETS, GoogleProvider
+from any_llm.providers.gemini.base import GoogleProvider
 from any_llm.providers.gemini.utils import (
     _convert_messages,
     _convert_response_to_response_dict,
@@ -816,45 +817,29 @@ async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, 
         assert contents[2].role == "function"
 
 
-@pytest.mark.parametrize("reasoning_effort", [None, *get_args(ReasoningEffort)])
-@pytest.mark.asyncio
-async def test_completion_with_custom_reasoning_effort(reasoning_effort: ReasoningEffort | None) -> None:
-    api_key = "test-api-key"
-    model = "model-id"
-    messages = [{"role": "user", "content": "Hello"}]
-
-    with mock_gemini_provider() as mock_genai:
-        provider = GeminiProvider(api_key=api_key)
-        await provider._acompletion(
-            CompletionParams(model_id=model, messages=messages, reasoning_effort=reasoning_effort)
-        )
-
-        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
-        thinking_config = call_kwargs["config"].thinking_config
-
-        if reasoning_effort == "auto":
-            assert thinking_config is None
-        elif reasoning_effort is None or reasoning_effort == "none":
-            assert thinking_config == types.ThinkingConfig(include_thoughts=False)
-        else:
-            assert thinking_config == types.ThinkingConfig(
-                include_thoughts=True, thinking_budget=REASONING_EFFORT_TO_THINKING_BUDGETS[reasoning_effort]
-            )
-
-
 @pytest.mark.parametrize(
-    ("model_id", "reasoning_effort", "expected_level"),
+    ("model_id", "reasoning_effort", "expected"),
     [
-        ("gemini-3.5-flash", "xhigh", types.ThinkingLevel.HIGH),
-        ("gemini-3.5-flash", "max", types.ThinkingLevel.HIGH),
-        ("gemini-3.5-pro", "low", types.ThinkingLevel.LOW),
-        ("models/gemini-3.5-flash", "medium", types.ThinkingLevel.MEDIUM),
-        ("gemini-3.10-flash", "minimal", types.ThinkingLevel.MINIMAL),
-        ("gemini-4-pro", "high", types.ThinkingLevel.HIGH),
+        ("gemini-3.8-flash", "low", {"includeThoughts": True, "thinkingLevel": "LOW"}),
+        ("gemini-3.7-flash", "medium", {"includeThoughts": True, "thinkingLevel": "MEDIUM"}),
+        ("gemini-3.6-flash", "minimal", {"includeThoughts": True, "thinkingLevel": "MINIMAL"}),
+        ("gemini-3.5-flash", "high", {"includeThoughts": True, "thinkingLevel": "HIGH"}),
+        ("gemini-3.5-flash-lite", "minimal", {"includeThoughts": True, "thinkingLevel": "MINIMAL"}),
+        ("gemini-3.1-flash-lite", "medium", {"includeThoughts": True, "thinkingLevel": "MEDIUM"}),
+        ("models/gemini-3.1-pro-preview", "minimal", {"includeThoughts": True, "thinkingLevel": "LOW"}),
+        ("gemini-3.1-flash-lite-image", "high", {"includeThoughts": True, "thinkingLevel": "HIGH"}),
+        ("gemini-3-flash-preview", "minimal", {"includeThoughts": True, "thinkingLevel": "MINIMAL"}),
+        ("gemini-2.5-flash", "none", {"includeThoughts": False, "thinkingBudget": 0}),
+        ("gemini-2.5-flash", "minimal", {"includeThoughts": True, "thinkingBudget": 1024}),
+        ("gemini-2.5-flash", "low", {"includeThoughts": True, "thinkingBudget": 1024}),
+        ("gemini-2.5-flash-lite", "medium", {"includeThoughts": True, "thinkingBudget": 8192}),
+        ("gemini-2.5-pro", "high", {"includeThoughts": True, "thinkingBudget": 24576}),
     ],
 )
-def test_new_gemini_models_use_thinking_level(
-    model_id: str, reasoning_effort: ReasoningEffort, expected_level: types.ThinkingLevel
+def test_gemini_reasoning_effort_matches_documented_thinking_config(
+    model_id: str,
+    reasoning_effort: ReasoningEffort,
+    expected: dict[str, object],
 ) -> None:
     result = GoogleProvider._convert_completion_params(
         CompletionParams(
@@ -863,29 +848,101 @@ def test_new_gemini_models_use_thinking_level(
         provider_name="gemini",
     )
 
-    assert result["config"].thinking_config == types.ThinkingConfig(
-        include_thoughts=True, thinking_level=expected_level
-    )
+    config = result["config"].model_dump(by_alias=True, exclude_none=True)
+    assert config["thinkingConfig"] == expected
 
 
 @pytest.mark.parametrize(
-    "model_id",
+    ("model_id", "reasoning_effort"),
     [
-        "gemini-3.0-flash",
-        "gemini-3.4-flash",
-        "gemini-3-pro-preview",
-        "gemini-2.5-flash",
-        "gemini-pro",
-        "projects/p/locations/l/publishers/google/models/gemini-3-pro",
+        ("gemini-3.8-flash", "minimal"),
+        ("gemini-3.1-pro-preview", "none"),
+        ("gemini-3.1-flash-lite-image", "low"),
+        ("gemini-3.1-flash-image", "high"),
+        ("gemini-3-pro-image", "high"),
+        ("gemini-robotics-er-2-preview", "high"),
+        ("gemini-2.5-pro", "none"),
+        ("gemini-2.5-flash", "xhigh"),
+        ("gemini-2.5-flash", "max"),
+        ("gemini-2.5-flash-future", "high"),
+        ("gemini-2.0-flash", "high"),
+        ("gemini-pro", "none"),
     ],
 )
-def test_older_gemini_models_keep_thinking_budget(model_id: str) -> None:
+def test_gemini_rejects_undocumented_reasoning_effort(
+    model_id: str,
+    reasoning_effort: ReasoningEffort,
+) -> None:
+    with pytest.raises(UnsupportedParameterError, match="reasoning_effort"):
+        GoogleProvider._convert_completion_params(
+            CompletionParams(
+                model_id=model_id,
+                messages=[{"role": "user", "content": "Hello"}],
+                reasoning_effort=reasoning_effort,
+            ),
+            provider_name="gemini",
+        )
+
+
+@pytest.mark.parametrize("reasoning_effort", [None, "auto"])
+def test_gemini_omits_default_thinking_config(reasoning_effort: ReasoningEffort | None) -> None:
     result = GoogleProvider._convert_completion_params(
-        CompletionParams(model_id=model_id, messages=[{"role": "user", "content": "Hello"}], reasoning_effort="high"),
+        CompletionParams(
+            model_id="gemini-3.8-flash",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort=reasoning_effort,
+        ),
         provider_name="gemini",
     )
 
-    assert result["config"].thinking_config == types.ThinkingConfig(include_thoughts=True, thinking_budget=24576)
+    assert result["config"].thinking_config is None
+
+
+@pytest.mark.parametrize(
+    ("model_id", "reasoning_effort", "expected"),
+    [
+        ("gemini-3.8-flash", "high", {"include_thoughts": True, "thinking_level": "HIGH"}),
+        ("gemini-2.5-flash", "none", {"include_thoughts": False, "thinking_budget": 0}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_gemini_reasoning_effort_reaches_official_sdk_wire(
+    model_id: str,
+    reasoning_effort: ReasoningEffort,
+    expected: dict[str, object],
+) -> None:
+    requests: list[dict[str, object]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "ok"}], "role": "model"},
+                        "finishReason": "STOP",
+                    }
+                ]
+            },
+        )
+
+    provider = GeminiProvider(
+        api_key="test-api-key",
+        http_options=types.HttpOptions(
+            async_client_args={"transport": httpx.MockTransport(handler)},
+        ),
+    )
+    await provider._acompletion(
+        CompletionParams(
+            model_id=model_id,
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort=reasoning_effort,
+        )
+    )
+    provider.client.close()
+
+    assert requests[0]["generationConfig"] == {"thinkingConfig": expected}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Translate `reasoning_effort` into the current Gemini native thinking controls without broadening this PR beyond request conversion.

- Send model-specific `thinking_level` values to documented Gemini 3 models.
- Map `minimal` to `low` for Gemini 3.1 Pro, as required by Google's OpenAI compatibility contract.
- Send documented `thinking_budget` values to Gemini 2.5 Pro, Flash, and Flash-Lite.
- Preserve the service default when `reasoning_effort` is omitted or set to the local `auto` value.
- Disable thinking only for Gemini 2.5 Flash and Flash-Lite, which document a zero budget.
- Reject levels that the selected model does not expose instead of silently narrowing them.
- Keep response parsing, message replay, streaming, media, Batch, and Interactions outside this PR.

Official sources:

- Gemini thinking levels, budgets, and disable behavior: <https://ai.google.dev/gemini-api/docs/generate-content/thinking>
- Gemini OpenAI compatibility mappings: <https://ai.google.dev/gemini-api/docs/openai#thinking>
- Current model catalog: <https://ai.google.dev/gemini-api/docs/models>
- Latest formal SDK used for differential verification, `google-genai` v2.22.0 at immutable commit `0ec3d8a4b2c85817434045dad739f6227c2d5c4c`: <https://github.com/googleapis/python-genai/tree/0ec3d8a4b2c85817434045dad739f6227c2d5c4c>

## Dependency reason

This PR raises the Gemini and Vertex AI extras from `google-genai>=1.51.0` to `google-genai>=1.70.0`. Version 1.56.0 first exposed the complete `ThinkingLevel` enum, but it cannot serve as the provider minimum: existing `service_tier` support requires a later release, and 1.69.0 still cannot express the existing `flex` tier. Version 1.70.0 is the earliest formal release that passes both the existing service-tier contract and the thinking contract added here.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Related: https://github.com/mozilla-ai/any-llm-go/pull/140

## Testing

- Full Gemini provider file with minimum `google-genai==1.70.0`: 252 passed
- Full Gemini provider file with latest `google-genai==2.22.0`: 252 passed
- Full unit suite: 2440 passed, 69 skipped
- `uv run pre-commit run --all-files`: passed, including configured Ruff, formatting, and strict mypy over 287 source files
- Raw Ruff stable-rule scan on owning production lines: no unresolved finding; `COM812` is the formatter-documented conflict
- `git diff --check`: passed
- All three commits pass `git verify-commit`

The request tests use the real official SDK transport and assert the serialized `generationConfig.thinkingConfig` body. The parameter table covers every documented level in the supported model catalog, omission, `auto`, zero-budget disable behavior, and unsupported values.

No Gemini credential was available. Live model acceptance, thought-summary output, live error envelopes, cancellation, and timeout behavior remain unverified. The PR stays in draft until CodeRabbit covers the exact head; lack of a live credential remains an explicit external evidence gap.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing affected tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol X-HIGH
- AI Developer Tool used: Amp
- Any other info you'd like to share: Model capabilities and serialized requests were checked against Google's current documentation and official SDK v2.22.0. Earlier PR assumptions were discarded and the owning scope was rebuilt from current upstream main.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-specific reasoning controls for Gemini models.
  * Gemini 3 models now support configurable thinking levels.
  * Gemini 2.5 models now support configurable reasoning token budgets.
  * Reasoning settings work with resource-style model identifiers and supported robotics and image models.

* **Bug Fixes**
  * Improved validation for unsupported reasoning effort values and configurations.
  * Default and automatic reasoning settings are no longer sent unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->