### PR TITLE
fix(anthropic): align SDK v1 requests and effort controls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "pydantic>2,<3",
   "openai>=2.18.0",
   "openresponses-types>=2.4.0,<3",
-  "anthropic>=1.0.0",
+  "anthropic>=1.0.0,<2",
   "rich",
   "httpx",
   "typing_extensions>=4.5.0",
@@ -49,11 +49,11 @@ vertexai = [
 ]
 
 vertexaianthropic = [
-  "anthropic[vertex]>=1.0.0",
+  "anthropic[vertex]>=1.0.0,<2",
 ]
 
 azureanthropic = [
-  "anthropic>=1.0.0",
+  "anthropic>=1.0.0,<2",
 ]
 
 huggingface = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "pydantic>2,<3",
   "openai>=2.18.0",
   "openresponses-types>=2.4.0,<3",
-  "anthropic>=0.119.0,<1",
+  "anthropic>=1.0.0",
   "rich",
   "httpx",
   "typing_extensions>=4.5.0",
@@ -49,11 +49,11 @@ vertexai = [
 ]
 
 vertexaianthropic = [
-  "anthropic[vertex]>=0.119.0,<1",
+  "anthropic[vertex]>=1.0.0",
 ]
 
 azureanthropic = [
-  "anthropic>=0.119.0,<1",
+  "anthropic>=1.0.0",
 ]
 
 huggingface = [

--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -938,9 +938,9 @@ class AnyLLM(ABC):
             messages: List of messages in Anthropic format.
             max_tokens: Maximum number of tokens to generate.
             system: System prompt (string or list of content blocks with optional cache_control).
-            temperature: Controls randomness (0.0 to 1.0).
-            top_p: Controls diversity via nucleus sampling.
-            top_k: Only sample from the top K options.
+            temperature: Controls randomness. Anthropic deprecates this for current Claude models.
+            top_p: Controls nucleus sampling. Anthropic deprecates this for current Claude models.
+            top_k: Restricts sampling to the top K options. Anthropic deprecates this for current Claude models.
             stream: Whether to stream the response.
             stop_sequences: Custom stop sequences.
             tools: List of tools in Anthropic format.

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -616,9 +616,9 @@ def messages(
         max_tokens: Maximum number of tokens to generate.
         provider: Provider name to use for the request.
         system: System prompt (string or list of content blocks with optional cache_control).
-        temperature: Controls randomness (0.0 to 1.0).
-        top_p: Controls diversity via nucleus sampling.
-        top_k: Only sample from the top K options.
+        temperature: Controls randomness. Anthropic deprecates this for current Claude models.
+        top_p: Controls nucleus sampling. Anthropic deprecates this for current Claude models.
+        top_k: Restricts sampling to the top K options. Anthropic deprecates this for current Claude models.
         stream: Whether to stream the response.
         stop_sequences: Custom stop sequences.
         tools: List of tools in Anthropic format.
@@ -724,9 +724,9 @@ async def amessages(
         max_tokens: Maximum number of tokens to generate.
         provider: Provider name to use for the request.
         system: System prompt (string or list of content blocks with optional cache_control).
-        temperature: Controls randomness (0.0 to 1.0).
-        top_p: Controls diversity via nucleus sampling.
-        top_k: Only sample from the top K options.
+        temperature: Controls randomness. Anthropic deprecates this for current Claude models.
+        top_p: Controls nucleus sampling. Anthropic deprecates this for current Claude models.
+        top_k: Restricts sampling to the top K options. Anthropic deprecates this for current Claude models.
         stream: Whether to stream the response.
         stop_sequences: Custom stop sequences.
         tools: List of tools in Anthropic format.

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -125,12 +125,8 @@ def _pop_anthropic_beta_header(kwargs: dict[str, Any]) -> list[str]:
     found_beta_header = False
     for name, value in extra_headers.items():
         if isinstance(name, str) and name.lower() == "anthropic-beta":
-            if isinstance(value, bytes):
-                try:
-                    value = value.decode()
-                except UnicodeDecodeError:
-                    remaining_headers[name] = value
-                    continue
+            # SDK v1 intentionally rejects bytes header values. Keep them untouched for its validation:
+            # https://github.com/anthropics/anthropic-sdk-python/blob/370ee927ca8a8d3b5d4f907555e890b2df685786/MIGRATION.md#bytes-header-values-no-longer-work
             if isinstance(value, str):
                 found_beta_header = True
                 header_betas.extend(beta.strip() for beta in value.split(",") if beta.strip())

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -36,6 +36,7 @@ try:
         _convert_params,
         _convert_response,
         _create_openai_chunk_from_anthropic_chunk,
+        _set_deprecated_sampling_extra_body,
     )
 except ImportError as e:
     MISSING_PACKAGES_ERROR = e
@@ -329,9 +330,20 @@ class BaseAnthropicProvider(AnyLLM, ABC):
         use_beta = params.context_management is not None or bool(betas)
         messages_resource: Any
 
+        sampling = {
+            name: value
+            for name, value in (("temperature", params.temperature), ("top_p", params.top_p), ("top_k", params.top_k))
+            if value is not None
+        }
+        if sampling:
+            _set_deprecated_sampling_extra_body(kwargs, sampling)
+
         if params.output_format is not None:
             messages_resource = self.client.beta.messages if use_beta else self.client.messages
-            native_kwargs = params.model_dump(exclude_none=True, exclude={"output_format", "stream", "betas"})
+            native_kwargs = params.model_dump(
+                exclude_none=True,
+                exclude={"output_format", "stream", "betas", "temperature", "top_p", "top_k"},
+            )
             if betas:
                 native_kwargs["betas"] = betas
             native_kwargs.update(kwargs)
@@ -346,7 +358,10 @@ class BaseAnthropicProvider(AnyLLM, ABC):
                 message = await messages_resource.create(output_config=cast("Any", output_config), **native_kwargs)
             return self._convert_native_message_to_response(message)
 
-        api_kwargs = params.model_dump(exclude_none=True, exclude={"betas"})
+        api_kwargs = params.model_dump(
+            exclude_none=True,
+            exclude={"betas", "temperature", "top_p", "top_k"},
+        )
         api_kwargs.pop("stream", None)
         if betas:
             api_kwargs["betas"] = betas

--- a/src/any_llm/providers/anthropic/base.py
+++ b/src/any_llm/providers/anthropic/base.py
@@ -45,7 +45,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
 
     from anthropic import AsyncAnthropic, AsyncAnthropicVertex
-    from anthropic.types import Message
+    from anthropic.lib.streaming import MessageStreamEvent as AnthropicStreamEvent
+    from anthropic.types import Message, RawMessageStreamEvent
     from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage
     from anthropic.types.messages.message_batch import MessageBatch
     from anthropic.types.model_info import ModelInfo as AnthropicModelInfo
@@ -95,16 +96,16 @@ _ANTHROPIC_TO_OPENAI_STATUS_MAP: dict[str, str] = {
 }
 
 
-def _get_context_edit_value(edit: Any, field: str) -> Any:
+def _get_context_edit_value(edit: object, field: str) -> object:
     return edit.get(field) if isinstance(edit, Mapping) else getattr(edit, field, None)
 
 
-def _get_context_edit_type(edit: Any) -> str | None:
+def _get_context_edit_type(edit: object) -> str | None:
     edit_type = _get_context_edit_value(edit, "type")
     return edit_type if isinstance(edit_type, str) else None
 
 
-def _validate_compaction_trigger(edit: Any) -> None:
+def _validate_compaction_trigger(edit: object) -> None:
     trigger = _get_context_edit_value(edit, "trigger")
     if trigger is None or _get_context_edit_value(trigger, "type") != "input_tokens":
         return
@@ -261,7 +262,9 @@ class BaseAnthropicProvider(AnyLLM, ABC):
 
     @staticmethod
     @override
-    def _convert_completion_chunk_response(response: Any, **kwargs: Any) -> ChatCompletionChunk:
+    def _convert_completion_chunk_response(
+        response: RawMessageStreamEvent | AnthropicStreamEvent, **kwargs: Any
+    ) -> ChatCompletionChunk:
         """Convert Anthropic streaming chunk to OpenAI ChatCompletionChunk format."""
         model_id = kwargs.get("model_id", "unknown")
         return _create_openai_chunk_from_anthropic_chunk(response, model_id)
@@ -324,7 +327,6 @@ class BaseAnthropicProvider(AnyLLM, ABC):
         header_betas = _pop_anthropic_beta_header(kwargs)
         betas = _messages_betas(params, header_betas)
         use_beta = params.context_management is not None or bool(betas)
-        messages_resource: Any
 
         sampling = {
             name: value
@@ -334,6 +336,9 @@ class BaseAnthropicProvider(AnyLLM, ABC):
         if sampling:
             _set_deprecated_sampling_extra_body(kwargs, sampling)
 
+        # GA, beta, and Vertex resources have incompatible SDK method overloads.
+        # Keep the dynamic boundary here rather than duplicating request handling.
+        messages_resource: Any
         if params.output_format is not None:
             messages_resource = self.client.beta.messages if use_beta else self.client.messages
             native_kwargs = params.model_dump(
@@ -351,7 +356,7 @@ class BaseAnthropicProvider(AnyLLM, ABC):
             # thing on both paths; the native API requires the output_config nesting.
             output_config = normalize_output_config(cast("dict[str, Any]", params.output_format))
             with _translating_nonstreaming_guard(self, params.max_tokens):
-                message = await messages_resource.create(output_config=cast("Any", output_config), **native_kwargs)
+                message = await messages_resource.create(output_config=output_config, **native_kwargs)
             return self._convert_native_message_to_response(message)
 
         api_kwargs = params.model_dump(

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -556,7 +556,9 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
     if params.reasoning_effort is None or params.reasoning_effort == "none":
         result_kwargs["thinking"] = {"type": "disabled"}
     elif params.reasoning_effort != "auto":
-        result_kwargs["thinking"] = {"type": "adaptive"}
+        # Effort applies whether thinking is enabled or disabled and does not
+        # itself enable adaptive thinking.
+        # https://platform.claude.com/docs/en/build-with-claude/effort#effort-with-thinking
         effort = REASONING_EFFORT_TO_ANTHROPIC_EFFORT[params.reasoning_effort]
         output_config = result_kwargs.get("output_config", {})
         output_config["effort"] = effort

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, cast
 
@@ -62,6 +63,30 @@ def _refusal_stop_details(value: object) -> dict[str, Any] | None:
     if isinstance(stop_details, BaseModel):
         return stop_details.model_dump(mode="json", exclude_none=True)
     return None
+
+
+def _set_deprecated_sampling_extra_body(
+    request_kwargs: dict[str, object],
+    sampling: dict[str, float | int],
+) -> None:
+    """Preserve legacy-model sampling fields through the SDK extension point."""
+    # Anthropic SDK v1 removed these method arguments. The API still exposes them as deprecated
+    # fields for older models and directs callers to extra_body:
+    # https://github.com/anthropics/anthropic-sdk-python/blob/370ee927ca8a8d3b5d4f907555e890b2df685786/MIGRATION.md#removed-deprecated-request-parameters
+    if not sampling:
+        return
+
+    extra_body = request_kwargs.get("extra_body")
+    if extra_body is None:
+        request_kwargs["extra_body"] = sampling
+        return
+    if not isinstance(extra_body, Mapping):
+        # Keep invalid values untouched so the official SDK retains ownership of validation.
+        return
+
+    # The SDK merges extra_body second, so caller values override adapter-supplied legacy values:
+    # https://github.com/anthropics/anthropic-sdk-python/blob/370ee927ca8a8d3b5d4f907555e890b2df685786/src/anthropic/_base_client.py#L2428-L2437
+    request_kwargs["extra_body"] = {**sampling, **extra_body}
 
 
 def _is_tool_call(message: dict[str, Any]) -> bool:
@@ -509,6 +534,13 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
     provider_name: str = kwargs.pop("provider_name")
     result_kwargs: dict[str, Any] = kwargs.copy()
 
+    sampling = {
+        name: value
+        for name, value in (("temperature", params.temperature), ("top_p", params.top_p))
+        if value is not None
+    }
+    _set_deprecated_sampling_extra_body(result_kwargs, sampling)
+
     if params.response_format:
         result_kwargs["output_config"] = _convert_response_format(params.response_format, provider_name)
     if params.max_tokens is None:
@@ -540,6 +572,8 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
                 "response_format",
                 "parallel_tool_calls",
                 "stream_options",
+                "temperature",
+                "top_p",
             },
         )
     )

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -1,16 +1,17 @@
 import json
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Literal
 
 from anthropic import transform_schema
+from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
-    ContentBlockStopEvent,
     Message,
     MessageDeltaEvent,
     MessageStopEvent,
+    RawMessageStreamEvent,
 )
 from anthropic.types.model_info import ModelInfo as AnthropicModelInfo
 from pydantic import BaseModel
@@ -40,7 +41,7 @@ _ANTHROPIC_CONTENT_FILTER_REFUSAL = "Response blocked by Anthropic content filte
 # "model_context_window_exceeded" (the model ran out of context rather than out of max_tokens)
 # do have one, and without it a refused or truncated answer looks like a normal completion.
 # See https://docs.claude.com/en/docs/build-with-claude/handling-stop-reasons
-ANTHROPIC_STOP_REASON_TO_FINISH_REASON = {
+ANTHROPIC_STOP_REASON_TO_FINISH_REASON: dict[str, Literal["stop", "length", "tool_calls", "content_filter"]] = {
     "end_turn": "stop",
     "max_tokens": "length",
     "model_context_window_exceeded": "length",
@@ -258,16 +259,19 @@ def _convert_messages_for_anthropic(messages: list[dict[str, Any]]) -> tuple[str
                     "content": content_blocks,
                 }
 
-            if "content" in message and isinstance(message["content"], list):
-                message["content"] = _convert_content_for_anthropic(message["content"])
+            content = message.get("content", "")
+            if isinstance(content, list):
+                content = _convert_content_for_anthropic(content)
 
             # Only keep Anthropic-compatible fields (strips OpenAI-specific fields like 'refusal')
-            filtered_messages.append({"role": message["role"], "content": message.get("content", "")})
+            filtered_messages.append({"role": message["role"], "content": content})
 
     return system_message, filtered_messages
 
 
-def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> ChatCompletionChunk:
+def _create_openai_chunk_from_anthropic_chunk(
+    chunk: RawMessageStreamEvent | MessageStreamEvent, model_id: str
+) -> ChatCompletionChunk:
     """Convert Anthropic streaming chunk to OpenAI ChatCompletionChunk format."""
     chunk_dict = {
         "id": f"chatcmpl-{hash(str(chunk))}",
@@ -278,50 +282,10 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
         "usage": None,
     }
 
-    delta: dict[str, Any] = {}
+    delta = _convert_content_block_event(chunk)
     finish_reason = None
 
-    if isinstance(chunk, ContentBlockStartEvent):
-        if chunk.content_block.type == "text":
-            delta = {"content": ""}
-        elif chunk.content_block.type == "tool_use":
-            delta = {
-                "tool_calls": [
-                    {
-                        "index": chunk.index,
-                        "id": chunk.content_block.id,
-                        "type": "function",
-                        "function": {"name": chunk.content_block.name, "arguments": ""},
-                    }
-                ]
-            }
-        elif chunk.content_block.type == "thinking":
-            delta = {"reasoning": {"content": ""}}
-
-    elif isinstance(chunk, ContentBlockDeltaEvent):
-        if chunk.delta.type == "text_delta":
-            delta = {"content": chunk.delta.text}
-        elif chunk.delta.type == "input_json_delta":
-            delta = {
-                "tool_calls": [
-                    {
-                        "index": chunk.index,
-                        "function": {"arguments": chunk.delta.partial_json},
-                    }
-                ]
-            }
-        elif chunk.delta.type == "thinking_delta":
-            delta = {"reasoning": {"content": chunk.delta.thinking}}
-        elif chunk.delta.type == "signature_delta":
-            # The encrypted signature of the thinking block. Must be preserved unmodified
-            # and passed back to Anthropic on subsequent turns (e.g. alongside tool results)
-            # to maintain reasoning continuity. See https://docs.claude.com/en/docs/build-with-claude/extended-thinking
-            delta = {"extra_content": {"anthropic": {"signature": chunk.delta.signature}}}
-
-    elif isinstance(chunk, ContentBlockStopEvent):
-        finish_reason = None
-
-    elif isinstance(chunk, MessageDeltaEvent):
+    if isinstance(chunk, MessageDeltaEvent):
         stop_reason = chunk.delta.stop_reason
         finish_reason = (
             ANTHROPIC_STOP_REASON_TO_FINISH_REASON.get(stop_reason, "stop") if stop_reason is not None else None
@@ -355,6 +319,47 @@ def _create_openai_chunk_from_anthropic_chunk(chunk: Any, model_id: str) -> Chat
     chunk_dict["choices"] = [choice]
 
     return ChatCompletionChunk.model_validate(chunk_dict)
+
+
+def _convert_content_block_event(chunk: RawMessageStreamEvent | MessageStreamEvent) -> dict[str, Any]:
+    """Convert content-bearing stream events to an OpenAI delta payload."""
+    payload: dict[str, Any] = {}
+
+    if isinstance(chunk, ContentBlockStartEvent):
+        if chunk.content_block.type == "text":
+            payload = {"content": ""}
+        elif chunk.content_block.type == "tool_use":
+            payload = {
+                "tool_calls": [
+                    {
+                        "index": chunk.index,
+                        "id": chunk.content_block.id,
+                        "type": "function",
+                        "function": {"name": chunk.content_block.name, "arguments": ""},
+                    }
+                ]
+            }
+        elif chunk.content_block.type == "thinking":
+            payload = {"reasoning": {"content": ""}}
+
+    elif isinstance(chunk, ContentBlockDeltaEvent):
+        if chunk.delta.type == "text_delta":
+            payload = {"content": chunk.delta.text}
+        elif chunk.delta.type == "input_json_delta":
+            payload = {
+                "tool_calls": [
+                    {
+                        "index": chunk.index,
+                        "function": {"arguments": chunk.delta.partial_json},
+                    }
+                ]
+            }
+        elif chunk.delta.type == "thinking_delta":
+            payload = {"reasoning": {"content": chunk.delta.thinking}}
+        elif chunk.delta.type == "signature_delta":
+            payload = {"extra_content": {"anthropic": {"signature": chunk.delta.signature}}}
+
+    return payload
 
 
 def _convert_response(response: Message) -> ChatCompletion:
@@ -426,13 +431,9 @@ def _convert_response(response: Message) -> ChatCompletion:
         prompt_tokens_details=PromptTokensDetails(cached_tokens=cache_read) if cache_read else None,
     )
 
-    from typing import Literal
-
     choice = Choice(
         index=0,
-        finish_reason=cast(
-            "Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call']", finish_reason or "stop"
-        ),
+        finish_reason=finish_reason,
         message=message,
     )
 
@@ -458,31 +459,19 @@ def _convert_response(response: Message) -> ChatCompletion:
 
 def _convert_tool_spec(openai_tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert OpenAI tool specification to Anthropic format."""
-    generic_tools = []
-
+    anthropic_tools = []
     for tool in openai_tools:
         if tool.get("type") != "function":
             continue
 
         function = tool["function"]
-        generic_tool = {
+        # input_schema is the full JSON Schema, including references and constraints.
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools
+        schema = {"type": "object", "properties": {}, "required": [], **(function.get("parameters") or {})}
+        anthropic_tool = {
             "name": function["name"],
             "description": function.get("description", ""),
-            "parameters": function.get("parameters") or {},
-        }
-        generic_tools.append(generic_tool)
-
-    anthropic_tools = []
-    for tool in generic_tools:
-        params: dict[str, Any] = tool["parameters"] or {}
-        anthropic_tool = {
-            "name": tool["name"],
-            "description": tool["description"],
-            "input_schema": {
-                "type": "object",
-                "properties": params.get("properties") or {},
-                "required": params.get("required", []),
-            },
+            "input_schema": schema,
         }
         anthropic_tools.append(anthropic_tool)
 
@@ -499,7 +488,11 @@ def _convert_tool_choice(params: CompletionParams) -> dict[str, Any]:
     elif isinstance(tool_choice, dict):
         if tool_choice_type := tool_choice.get("type"):
             if tool_choice_type in ("custom", "function"):
-                return {"type": "tool", "name": tool_choice[tool_choice_type]["name"]}
+                return {
+                    "type": "tool",
+                    "name": tool_choice[tool_choice_type]["name"],
+                    "disable_parallel_tool_use": not parallel_tool_calls,
+                }
         msg = f"Unsupported tool_choice format: {tool_choice}"
         raise ValueError(msg)
     return {"type": tool_choice, "disable_parallel_tool_use": not parallel_tool_calls}
@@ -560,7 +553,7 @@ def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         # itself enable adaptive thinking.
         # https://platform.claude.com/docs/en/build-with-claude/effort#effort-with-thinking
         effort = REASONING_EFFORT_TO_ANTHROPIC_EFFORT[params.reasoning_effort]
-        output_config = result_kwargs.get("output_config", {})
+        output_config = result_kwargs.get("output_config", {}).copy()
         output_config["effort"] = effort
         result_kwargs["output_config"] = output_config
 

--- a/src/any_llm/types/messages.py
+++ b/src/any_llm/types/messages.py
@@ -186,13 +186,13 @@ class MessagesParams(BaseModel):
     """System prompt (string or list of content blocks with optional cache_control)"""
 
     temperature: float | None = None
-    """Controls randomness in the response (0.0 to 1.0)"""
+    """Controls randomness; Anthropic deprecates this for current Claude models."""
 
     top_p: float | None = None
-    """Controls diversity via nucleus sampling"""
+    """Controls nucleus sampling; Anthropic deprecates this for current Claude models."""
 
     top_k: int | None = None
-    """Only sample from the top K options for each subsequent token"""
+    """Restricts sampling to the top K options; Anthropic deprecates this for current Claude models."""
 
     stream: bool | None = None
     """Whether to stream the response"""

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usage
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage
@@ -277,6 +277,7 @@ async def test_amessages_non_streaming() -> None:
 @pytest.mark.asyncio
 async def test_anthropic_sdk_accepts_completion_sampling_parameters() -> None:
     requests: list[httpx.Request] = []
+    caller_temperature = 0.2
 
     async def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
@@ -290,19 +291,45 @@ async def test_anthropic_sdk_accepts_completion_sampling_parameters() -> None:
                 messages=[{"role": "user", "content": "Hello"}],
                 max_tokens=1024,
                 temperature=0.7,
-                top_p=0.9,
-            )
+                top_p=0.0,
+            ),
+            extra_body={"custom_key": "custom-value", "temperature": caller_temperature},
         )
 
     assert len(requests) == 1
     request_body = json.loads(requests[0].content)
-    assert request_body["temperature"] == 0.7
-    assert request_body["top_p"] == 0.9
+    assert request_body["custom_key"] == "custom-value"
+    assert request_body["temperature"] == caller_temperature
+    assert request_body["top_p"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_sdk_rejects_non_object_extra_body() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        provider = AnthropicProvider(api_key="test-key", http_client=http_client)
+        with pytest.raises(TypeError, match="'str' object is not a mapping"):
+            await provider._acompletion(
+                CompletionParams(
+                    model_id="claude-3-5-sonnet",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    temperature=0.7,
+                ),
+                extra_body="invalid",
+            )
+
+    assert requests == []
 
 
 @pytest.mark.asyncio
 async def test_anthropic_sdk_accepts_native_messages_parameters() -> None:
     requests: list[httpx.Request] = []
+    caller_top_k = 20
 
     async def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
@@ -320,15 +347,17 @@ async def test_anthropic_sdk_accepts_native_messages_parameters() -> None:
                 top_k=40,
                 container="container_123",
                 service_tier="standard_only",
-            )
+            ),
+            extra_body={"custom_key": "custom-value", "top_k": caller_top_k},
         )
 
     assert isinstance(result, MessageResponse)
     assert len(requests) == 1
     request_body = json.loads(requests[0].content)
+    assert request_body["custom_key"] == "custom-value"
     assert request_body["temperature"] == 0.7
     assert request_body["top_p"] == 0.9
-    assert request_body["top_k"] == 40
+    assert request_body["top_k"] == caller_top_k
     assert request_body["container"] == "container_123"
     assert request_body["service_tier"] == "standard_only"
 
@@ -1018,9 +1047,10 @@ async def test_amessages_non_streaming_with_all_params() -> None:
 
     call_kwargs = mock_client.messages.create.call_args.kwargs
     assert call_kwargs["system"] == "Be helpful"
-    assert call_kwargs["temperature"] == 0.7
-    assert call_kwargs["top_p"] == 0.9
-    assert call_kwargs["top_k"] == 40
+    assert call_kwargs["extra_body"] == {"temperature": 0.7, "top_p": 0.9, "top_k": 40}
+    assert "temperature" not in {key for key in call_kwargs if key != "extra_body"}
+    assert "top_p" not in {key for key in call_kwargs if key != "extra_body"}
+    assert "top_k" not in {key for key in call_kwargs if key != "extra_body"}
     assert call_kwargs["stop_sequences"] == ["END"]
     assert call_kwargs["tools"] == [{"name": "fn", "description": "d", "input_schema": {}}]
     assert call_kwargs["tool_choice"] == {"type": "auto"}
@@ -1066,6 +1096,9 @@ async def test_amessages_output_format_uses_native_parse() -> None:
         model="claude-3-5-sonnet",
         messages=[{"role": "user", "content": "Capital of France?"}],
         max_tokens=1024,
+        temperature=0.5,
+        top_p=0.9,
+        top_k=40,
         output_format=City,
     )
     result = await BaseAnthropicProvider._amessages(provider, params)
@@ -1079,6 +1112,10 @@ async def test_amessages_output_format_uses_native_parse() -> None:
     # output_format is passed to parse as its dedicated kwarg; other params still flow through.
     call_kwargs = mock_client.messages.parse.call_args.kwargs
     assert call_kwargs["output_format"] is City
+    assert call_kwargs["extra_body"] == {"temperature": 0.5, "top_p": 0.9, "top_k": 40}
+    assert "temperature" not in call_kwargs
+    assert "top_p" not in call_kwargs
+    assert "top_k" not in call_kwargs
 
 
 @pytest.mark.asyncio
@@ -1237,6 +1274,7 @@ async def test_amessages_none_params_not_included() -> None:
     assert "tools" not in call_kwargs
     assert "thinking" not in call_kwargs
     assert "cache_control" not in call_kwargs
+    assert "extra_body" not in call_kwargs
 
 
 @pytest.mark.asyncio
@@ -1249,10 +1287,13 @@ async def test_amessages_streaming_delegates_to_stream_method() -> None:
         model="claude-3-5-sonnet",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=1024,
+        top_p=0.9,
         stream=True,
     )
     await BaseAnthropicProvider._amessages(provider, params)
-    provider._stream_messages_async.assert_called_once()
+    call_kwargs = provider._stream_messages_async.call_args.kwargs
+    assert call_kwargs["extra_body"] == {"top_p": 0.9}
+    assert "top_p" not in {key for key in call_kwargs if key != "extra_body"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -611,18 +611,20 @@ def test_messages_betas_rejects_non_list_edits(edits: Any) -> None:
         _messages_betas(params)
 
 
-def test_pop_anthropic_beta_header_decodes_bytes() -> None:
+def test_pop_anthropic_beta_header_preserves_bytes_for_sdk_validation() -> None:
+    value = b"fast-mode-2026-02-01, compact-2026-01-12"
     kwargs = {
         "extra_headers": {
-            "anthropic-beta": b"fast-mode-2026-02-01, compact-2026-01-12",
+            "anthropic-beta": value,
             "x-custom-header": "custom-value",
         }
     }
 
     betas = _pop_anthropic_beta_header(kwargs)
 
-    assert betas == ["fast-mode-2026-02-01", "compact-2026-01-12"]
-    assert kwargs == {"extra_headers": {"x-custom-header": "custom-value"}}
+    assert betas == []
+    assert kwargs["extra_headers"]["anthropic-beta"] is value
+    assert kwargs["extra_headers"]["x-custom-header"] == "custom-value"
 
 
 @pytest.mark.parametrize("value", [object(), b"\xff"])
@@ -1056,6 +1058,30 @@ async def test_amessages_non_streaming_with_all_params() -> None:
     assert call_kwargs["tool_choice"] == {"type": "auto"}
     assert call_kwargs["metadata"] == {"user_id": "u1"}
     assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 8192}
+
+
+@pytest.mark.asyncio
+async def test_amessages_sdk_v1_rejects_bytes_beta_header() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = AnthropicProvider(api_key="test-key", http_client=http_client)
+    params = MessagesParams(
+        model="claude-opus-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1024,
+    )
+    try:
+        with pytest.raises(AttributeError, match="encode"):
+            await provider._amessages(params, extra_headers={"anthropic-beta": b"future-beta"})
+    finally:
+        await http_client.aclose()
+
+    assert requests == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -383,7 +383,7 @@ async def test_completion_with_custom_reasoning_effort(reasoning_effort: Reasoni
         elif reasoning_effort == "auto":
             assert "thinking" not in call_kwargs
         else:
-            assert call_kwargs["thinking"] == {"type": "adaptive"}
+            assert "thinking" not in call_kwargs
             assert call_kwargs["output_config"] == {"effort": REASONING_EFFORT_TO_ANTHROPIC_EFFORT[reasoning_effort]}
 
 
@@ -682,7 +682,7 @@ async def test_completion_with_response_format_and_reasoning_effort() -> None:
             "format": {"type": "json_schema", "schema": expected_schema},
             "effort": "medium",
         }
-        assert call_kwargs["thinking"] == {"type": "adaptive"}
+        assert "thinking" not in call_kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -108,7 +108,7 @@ async def test_completion_with_multiple_system_messages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_completion_with_kwargs() -> None:
+async def test_completion_sends_deprecated_sampling_through_sdk_extra_body() -> None:
     api_key = "test-api-key"
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
@@ -120,7 +120,10 @@ async def test_completion_with_kwargs() -> None:
         )
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
-            model=model, messages=messages, max_tokens=100, temperature=0.5
+            model=model,
+            messages=messages,
+            max_tokens=100,
+            extra_body={"temperature": 0.5},
         )
 
 

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -257,15 +257,31 @@ async def test_completion_with_tool_choice_required() -> None:
         {"type": "custom", "custom": {"name": "FOO"}},
     ],
 )
-async def test_completion_with_tool_choice_specific_tool(tool_choice: dict[str, Any]) -> None:
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+async def test_completion_with_tool_choice_specific_tool(
+    tool_choice: dict[str, Any], parallel_tool_calls: bool
+) -> None:
     api_key = "test-api-key"
     model = "model-id"
     messages = [{"role": "user", "content": "Hello"}]
     with mock_anthropic_provider() as mock_anthropic:
         provider = AnthropicProvider(api_key=api_key)
-        await provider._acompletion(CompletionParams(model_id=model, messages=messages, tool_choice=tool_choice))
+        await provider._acompletion(
+            CompletionParams(
+                model_id=model,
+                messages=messages,
+                tool_choice=tool_choice,
+                parallel_tool_calls=parallel_tool_calls,
+            )
+        )
 
-        expected_kwargs = {"tool_choice": {"type": "tool", "name": "FOO"}}
+        expected_kwargs = {
+            "tool_choice": {
+                "type": "tool",
+                "name": "FOO",
+                "disable_parallel_tool_use": not parallel_tool_calls,
+            }
+        }
 
         mock_anthropic.return_value.messages.create.assert_called_once_with(
             model=model,
@@ -683,6 +699,29 @@ async def test_completion_with_response_format_and_reasoning_effort() -> None:
             "effort": "medium",
         }
         assert "thinking" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_completion_merges_reasoning_effort_without_mutating_output_config() -> None:
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+
+    with mock_anthropic_provider() as mock_anthropic:
+        provider = AnthropicProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="claude-opus-4-6",
+                messages=[{"role": "user", "content": "Hello"}],
+                reasoning_effort="medium",
+            ),
+            output_config=output_config,
+        )
+
+        call_kwargs = mock_anthropic.return_value.messages.create.call_args.kwargs
+        assert call_kwargs["output_config"] == {
+            "format": {"type": "json_schema", "schema": {"type": "object"}},
+            "effort": "medium",
+        }
+        assert output_config == {"format": {"type": "json_schema", "schema": {"type": "object"}}}
 
 
 @pytest.mark.asyncio
@@ -1269,12 +1308,13 @@ def test_stream_sequence_has_one_terminal_reason(stop_reason: StopReason, expect
         MessageDeltaEvent,
         MessageDeltaUsage,
         MessageStopEvent,
+        RawMessageStreamEvent,
     )
     from anthropic.types.raw_message_delta_event import Delta
 
     from any_llm.providers.anthropic.utils import _create_openai_chunk_from_anthropic_chunk
 
-    events = [
+    events: list[RawMessageStreamEvent] = [
         ContentBlockStopEvent(type="content_block_stop", index=0),
         MessageDeltaEvent(
             type="message_delta",
@@ -1557,6 +1597,24 @@ def test_convert_messages_keeps_text_when_tool_calls_is_empty() -> None:
     assert converted[0]["content"] == [{"type": "text", "text": "I will check the weather."}]
 
 
+def test_convert_messages_does_not_mutate_list_content() -> None:
+    from any_llm.providers.anthropic.utils import _convert_messages_for_anthropic
+
+    content = [{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}]
+    messages: list[dict[str, Any]] = [{"role": "user", "content": content}]
+
+    _, converted = _convert_messages_for_anthropic(messages)
+
+    assert messages[0]["content"] is content
+    assert messages == [{"role": "user", "content": content}]
+    assert converted == [
+        {
+            "role": "user",
+            "content": [{"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}}],
+        }
+    ]
+
+
 def test_convert_messages_replays_thinking_block_with_text() -> None:
     """A plain-text assistant message that carries a thinking signature should also replay it.
 
@@ -1725,6 +1783,25 @@ def test_convert_tool_spec_parameters_missing_properties() -> None:
     tools = _convert_tool_spec([{"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}])
     assert len(tools) == 1
     assert tools[0]["input_schema"]["properties"] == {}
+
+
+def test_convert_tool_spec_preserves_complete_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "$defs": {"count": {"type": "integer", "minimum": 9007199254740993}},
+        "additionalProperties": False,
+        "x-future": {"enabled": False},
+    }
+    tools = _convert_tool_spec(
+        [
+            {"type": "function", "function": {"name": "ping", "parameters": schema}},
+        ]
+    )
+
+    assert tools[0]["input_schema"] == schema
+    assert tools[0]["input_schema"] is not schema
 
 
 def test_convert_models_list_uses_created_at() -> None:

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -15,7 +15,6 @@ from anthropic.types.beta import (
     BetaIterationsUsage,
     BetaMessage,
     BetaMessageDeltaUsage,
-    BetaSkill,
     BetaStopReason,
     BetaUsage,
 )
@@ -397,7 +396,11 @@ def test_message_response_preserves_beta_usage_speed_and_container_skills() -> N
     assert response.usage.speed == "fast"
     assert isinstance(response.container, BetaContainer)
     assert response.container.skills is not None
-    assert isinstance(response.container.skills[0], BetaSkill)
+    assert beta_message.container is not None
+    assert beta_message.container.skills is not None
+    # SDK 1.2 renamed this generated response model from BetaSkill to BetaContainerSkill:
+    # https://github.com/anthropics/anthropic-sdk-python/blob/370ee927ca8a8d3b5d4f907555e890b2df685786/src/anthropic/types/beta/beta_container.py
+    assert type(response.container.skills[0]) is type(beta_message.container.skills[0])
     assert response.container.skills[0].skill_id == "pdf"
 
 


### PR DESCRIPTION
## Description

This draft contains the Anthropic SDK v1 migration, its request regressions, and one directly related Anthropic effort correction. It replaces the previous 33-commit, +1,934/-406 mixed branch with four signed commits across 9 files, +165/-45 lines.

The owning changes are:

- require `anthropic>=1.0.0,<2`, following the v1.3.0 migration guide's supported major range, with 1.0.0 as the first formal release backed by `httpx2>=2,<3`;
- preserve the binding's existing deprecated `temperature`, `top_p`, and `top_k` fields for legacy models through the SDK migration guide's `extra_body` extension;
- preserve the SDK's merge rule when caller `extra_body` contains a sampling key, and leave non-object values for the SDK itself to reject;
- stop decoding bytes-valued `anthropic-beta` headers so SDK v1 rejects them as documented;
- keep `httpx2` transport tests compatible with the minimum and latest SDK releases;
- keep `output_config.effort` independent from `thinking`, as required by the current service documentation, instead of enabling adaptive thinking as a side effect of every explicit effort.

This PR does not add a deprecated public parameter. Response replay, custom stream state, media/file validation, Batch expansion, copied SDK fixtures, and pure coverage additions were removed from this PR. They require separate, independently justified responsibilities.

Production/config changes are +71/-24 lines. Necessary regression tests are +94/-21 lines. The SDK migration commit is +128/-32. The header-validation commit is +32/-10. The dependency-range review fix changes three declarations without increasing the final diff. The effort correction is +5/-3. All commits are within the preferred review size.

## Contract sources

Checked live on 2026-09-04:

- Anthropic Messages API: https://platform.claude.com/docs/en/api/messages
- Anthropic effort and thinking relationship: https://platform.claude.com/docs/en/build-with-claude/effort#effort-with-thinking
- Anthropic thinking controls: https://platform.claude.com/docs/en/build-with-claude/thinking#thinking-and-effort
- Anthropic SDK v1 migration guide at immutable SDK 1.3.0 commit: https://github.com/anthropics/anthropic-sdk-python/blob/370ee927ca8a8d3b5d4f907555e890b2df685786/MIGRATION.md
- Latest formal Python SDK release, v1.3.0: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v1.3.0
- SDK source at immutable commit: https://github.com/anthropics/anthropic-sdk-python/tree/370ee927ca8a8d3b5d4f907555e890b2df685786

The service documentation marks all three sampling controls deprecated. For models released after Claude Opus 4.6, `temperature` accepts only `1.0`, `top_p` accepts only values at least `0.99`, and `top_k` rejects every value. SDK v1 removes them from Messages method signatures and documents `extra_body` for callers targeting older models. Any-llm exposed these fields before this PR, so this change preserves an existing compatibility contract without advertising them as current-model controls.

The current effort and thinking guides define `output_config.effort` and `thinking` as separate controls. Effort works with or without thinking. Explicit `low`, `medium`, `high`, `xhigh`, or `max` therefore sends only `output_config.effort`; normalized `minimal` maps to Anthropic's lowest level, `low`. `auto` preserves both provider defaults, while explicit `none` sends `thinking.type=disabled`.

Anthropic's SDK is MIT licensed. This rebuilt branch copies no upstream fixture or implementation. Fantasy was considered only as architecture input; no Fantasy code, control flow, fixture, or assertion sequence is copied or closely adapted.

## Verification

- current locked environment, Anthropic 1.2.0 on Python 3.13.15: full unit suite, 2,433 passed and 69 skipped;
- latest formal SDK overlay, Anthropic 1.3.0 on Python 3.13.15: full unit suite, 2,433 passed and 69 skipped;
- strict mypy under 1.0.0 and 1.3.0: no issues in the three changed source files;
- `uv run pre-commit run --all-files`: passed, including Ruff, Ruff format, strict mypy over 287 source files, codespell, and repository hygiene hooks;
- `ruff check --select ALL` on all changed files: no finding on an added production line. Added-test findings are pytest `assert` (`S101`) and direct contract testing of private provider entry points (`SLF001`);
- independent differential serialization: identical Completion and native Messages inputs produced matching HTTP JSON bodies through any-llm and direct official SDK 1.0.0/1.3.0 clients;
- invalid `extra_body` and bytes beta-header checks use real official SDK clients and confirm each SDK rejects before transport;
- deletion ablation: allowing `top_k` to leak into the native parse kwargs made the parse-path regression fail on the new exclusion assertion, while preserving the independently checked `extra_body` value;
- effort ablation: restoring the implicit `thinking.type=adaptive` side effect fails the two tests that independently require absence for plain effort and structured-output plus effort.
- typing ablation: removing the stable/beta resource `Any` boundaries and parsed-return cast produced the same four strict-mypy overload errors under SDK 1.0.0 and 1.3.0. Removing them would require duplicated control flow or a local copy of generated SDK signatures.

The four commits have valid configured SSH signatures. The branch is rebased on current upstream `main`.

No `ANTHROPIC_API_KEY` or `ANTHROPIC_API_BASE` is available in the verification orb. Live authentication, service errors, timeout, and streaming remain unverified. Exact-head CodeRabbit review is pending for `2043497d6783d7fe7d698b10db2f4d2f78c127d6`; the prior review does not prove this head. This PR remains **not ready for review** and does not claim complete Anthropic alignment.

## PR Type

- 🐛 Bug Fix

## Relevant issues

The HTTPX2 migration previously proposed in closed PR #1356 is reimplemented here without retaining that PR's mixed history.

## Checklist

- [x] I understand the code I am submitting.
- [x] Existing tests cover the changed behavior.
- [x] New and existing unit tests pass locally.
- [x] I have read and followed the contribution guidelines.
- [x] **AI Usage:** This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol X-HIGH
- AI Developer Tool used: Amp

Reviewer claims are independently checked against current official documentation and immutable SDK source before changes are made.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic sampling options (`temperature`, `top_p`, and `top_k`) are now forwarded correctly through request metadata.
  - Custom request metadata is preserved and combined with sampling options.
  - Invalid metadata values now produce a clear error before a request is sent.
  - Reasoning effort settings no longer enable adaptive thinking unexpectedly.
  - Beta header handling is more compatible with SDK validation.

- **Documentation**
  - Updated guidance now notes that Anthropic deprecates sampling options for current Claude models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->