### PR TITLE
fix(azureopenai): align provider with GA v1 contracts

### DIFF
--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -105,10 +105,10 @@ class AzureopenaiProvider(BaseOpenAIProvider):
         # deployment name in `model`. Rejecting legacy routing options prevents
         # a dated-route configuration from appearing to work while being ignored.
         # https://learn.microsoft.com/azure/foundry/openai/api-version-lifecycle
-        if api_version is not None:
+        if api_version not in (None, "v1"):
             parameter_name = "api_version"
             raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
-        if os.getenv("OPENAI_API_VERSION"):
+        if os.getenv("OPENAI_API_VERSION") not in (None, "", "v1"):
             parameter_name = "OPENAI_API_VERSION"
             raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
         if azure_deployment is not None:

--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -1,62 +1,147 @@
+import asyncio
 import os
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
-from openai import AsyncAzureOpenAI
+from openai import AsyncOpenAI, OpenAIError
 from typing_extensions import override
 
-from any_llm.exceptions import MissingApiKeyError
+from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.providers.openai.base import BaseOpenAIProvider
+
+_AzureADTokenProvider = Callable[[], str | Awaitable[str]]
+_PROVIDER_NAME = "azureopenai"
+_API_KEY_ENV_NAME = "AZURE_OPENAI_API_KEY"
+_AD_TOKEN_ENV_NAME = "AZURE_OPENAI_AD_TOKEN"  # noqa: S105, environment variable name, not a credential
+
+
+def _resolve_credential(
+    api_key: str | None,
+    azure_ad_token: str | None,
+    azure_ad_token_provider: _AzureADTokenProvider | None,
+) -> str | Callable[[], Awaitable[str]]:
+    # Match the official Azure client's explicit-credential and Entra-first
+    # environment precedence, while treating empty environment values as absent.
+    # https://github.com/openai/openai-python/blob/88391abf981df3ea395ca1b5bf55ec6a4011ea93/src/openai/lib/azure.py
+    explicit_credential = any(value is not None for value in (api_key, azure_ad_token, azure_ad_token_provider))
+    api_key = api_key or None
+    azure_ad_token = azure_ad_token or None
+    if not explicit_credential:
+        azure_ad_token = os.getenv(_AD_TOKEN_ENV_NAME) or None
+        if azure_ad_token is None:
+            api_key = os.getenv(_API_KEY_ENV_NAME) or None
+
+    configured_credentials = sum(value is not None for value in (api_key, azure_ad_token, azure_ad_token_provider))
+    if configured_credentials > 1:
+        message = (
+            "The `api_key`, `azure_ad_token` and `azure_ad_token_provider` arguments are mutually exclusive; "
+            "only one can be passed at a time."
+        )
+        raise OpenAIError(message)
+
+    if azure_ad_token_provider is not None:
+
+        async def get_token() -> str:
+            token = await asyncio.to_thread(azure_ad_token_provider)
+            resolved_token = token if isinstance(token, str) else await token
+            if not resolved_token:
+                message = "Expected `azure_ad_token_provider` to return a non-empty string."
+                raise ValueError(message)
+            return resolved_token
+
+        return get_token
+
+    credential = api_key or azure_ad_token
+    if credential is None:
+        env_var_name = f"{_API_KEY_ENV_NAME} or {_AD_TOKEN_ENV_NAME}"
+        raise MissingApiKeyError(_PROVIDER_NAME, env_var_name)
+
+    return credential
 
 
 class AzureopenaiProvider(BaseOpenAIProvider):
-    """Azure OpenAI AnyLLM.
+    """Azure OpenAI provider using Azure's GA v1 OpenAI-compatible API."""
 
-    Moderation support is disabled by default because Azure OpenAI deployments
-    do not typically expose the moderation endpoint. Set
-    ``SUPPORTS_MODERATION = True`` on a subclass only if you have verified the
-    deployment supports it.
-    """
-
-    ENV_API_KEY_NAME = "AZURE_OPENAI_API_KEY"
+    ENV_API_KEY_NAME = _API_KEY_ENV_NAME
     ENV_API_BASE_NAME = "AZURE_OPENAI_ENDPOINT"
-    PROVIDER_NAME = "azureopenai"
-    PROVIDER_DOCUMENTATION_URL = "https://learn.microsoft.com/en-us/azure/ai-foundry/"
+    PROVIDER_NAME = _PROVIDER_NAME
+    PROVIDER_DOCUMENTATION_URL = "https://learn.microsoft.com/azure/foundry/openai/api-version-lifecycle"
     SUPPORTS_RESPONSES = True
     SUPPORTS_LIST_MODELS = True
     SUPPORTS_COMPLETION_PDF = False
-    SUPPORTS_IMAGE_GENERATION = True
-    SUPPORTS_AUDIO_TRANSCRIPTION = True
-    SUPPORTS_AUDIO_SPEECH = True
+    # Azure media remains a dated preview API. Inheriting the false media
+    # capability defaults prevents GA v1 requests from being misrouted there.
     SUPPORTS_MODERATION = False
 
-    DEFAULT_API_VERSION = "preview"
-
-    client: AsyncAzureOpenAI
+    client: AsyncOpenAI
 
     @override
     def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
-        return api_key or os.getenv(self.ENV_API_KEY_NAME)
+        # Resolve Azure's three credential forms together in _init_client so an
+        # ambient API key cannot override an explicit Microsoft Entra credential.
+        return api_key
+
+    @override
+    def _resolve_api_base(self, api_base: str | None = None) -> str | None:
+        # Defer the environment fallback until _init_client can apply precedence
+        # between api_base and the Azure-specific azure_endpoint argument.
+        return api_base
 
     @override
     def _init_client(
         self,
         api_key: str | None = None,
         api_base: str | None = None,
+        *,
+        azure_endpoint: str | None = None,
+        azure_ad_token: str | None = None,
+        azure_ad_token_provider: _AzureADTokenProvider | None = None,
+        api_version: str | None = None,
+        azure_deployment: str | None = None,
+        default_query: Mapping[str, object] | None = None,
         **kwargs: Any,
     ) -> None:
-        api_version = kwargs.pop("api_version", None) or os.getenv("OPENAI_API_VERSION", self.DEFAULT_API_VERSION)
-        azure_ad_token = kwargs.pop("azure_ad_token", None) or os.getenv("AZURE_OPENAI_AD_TOKEN")
-        if not api_key and not azure_ad_token and not kwargs.get("azure_ad_token_provider"):
-            raise MissingApiKeyError(self.PROVIDER_NAME, self.ENV_API_KEY_NAME)
+        # Microsoft v1 defaults to an implicit `v1` API version and uses the
+        # deployment name in `model`. Rejecting legacy routing options prevents
+        # a dated-route configuration from appearing to work while being ignored.
+        # https://learn.microsoft.com/azure/foundry/openai/api-version-lifecycle
+        if api_version is not None:
+            parameter_name = "api_version"
+            raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
+        if os.getenv("OPENAI_API_VERSION"):
+            parameter_name = "OPENAI_API_VERSION"
+            raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
+        if azure_deployment is not None:
+            parameter_name = "azure_deployment"
+            raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
+        # The GA schema still permits an explicit `api-version=v1`, even though
+        # the lifecycle guide recommends omitting it. Dated values belong to the
+        # retired route family, and preview features now use headers or paths.
+        # https://learn.microsoft.com/rest/api/microsoft-foundry/azureopenai/chat
+        if default_query is not None and default_query.get("api-version", "v1") != "v1":
+            parameter_name = "default_query['api-version']"
+            raise UnsupportedParameterError(parameter_name, self.PROVIDER_NAME)
 
-        azure_endpoint = api_base or kwargs.pop("azure_endpoint", None) or os.getenv("AZURE_OPENAI_ENDPOINT")
-        if not azure_endpoint:
-            raise MissingApiKeyError(self.PROVIDER_NAME, "AZURE_OPENAI_ENDPOINT")
+        client_api_key = _resolve_credential(api_key, azure_ad_token, azure_ad_token_provider)
 
-        self.client = AsyncAzureOpenAI(
-            api_key=api_key,
-            azure_endpoint=azure_endpoint,
-            api_version=api_version,
-            azure_ad_token=azure_ad_token,
+        endpoint = api_base or azure_endpoint or os.getenv(self.ENV_API_BASE_NAME)
+        if not endpoint:
+            message = (
+                "Azure OpenAI endpoint is required. Pass `api_base` or `azure_endpoint`, "
+                f"or set {self.ENV_API_BASE_NAME}."
+            )
+            raise ValueError(message)
+
+        endpoint = endpoint.rstrip("/")
+        if not endpoint.endswith("/openai/v1"):
+            endpoint = f"{endpoint}/openai/v1"
+
+        # Current Microsoft Python examples use the generic OpenAI client for
+        # both API keys and Entra token providers. This also leaves retries,
+        # refresh timing and sensitive Authorization redirects with the SDK.
+        self.client = AsyncOpenAI(
+            api_key=client_api_key,
+            base_url=f"{endpoint}/",
+            default_query=default_query,
             **kwargs,
         )

--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -43,8 +43,8 @@ def _resolve_credential(
 
         async def get_token() -> str:
             token = await asyncio.to_thread(azure_ad_token_provider)
-            resolved_token = token if isinstance(token, str) else await token
-            if not resolved_token:
+            resolved_token = await token if isinstance(token, Awaitable) else token
+            if not isinstance(resolved_token, str) or not resolved_token:
                 message = "Expected `azure_ad_token_provider` to return a non-empty string."
                 raise ValueError(message)
             return resolved_token

--- a/tests/unit/providers/test_azureopenai_provider.py
+++ b/tests/unit/providers/test_azureopenai_provider.py
@@ -1,7 +1,7 @@
 import json
 import re
 import threading
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -272,16 +272,13 @@ async def test_azureopenai_refreshes_sync_entra_provider_before_sdk_retry() -> N
 
 
 @pytest.mark.asyncio
-async def test_azureopenai_rejects_empty_entra_provider_token() -> None:
-    """Reject an empty dynamic token before sending the request."""
-
-    def token_provider() -> str:
-        return ""
-
+@pytest.mark.parametrize("token", ["", 1])
+async def test_azureopenai_rejects_invalid_entra_provider_token(token: object) -> None:
+    """Reject empty and non-string dynamic tokens before sending the request."""
     transport, _ = _azure_transport()
     provider = AzureopenaiProvider(
         api_base="https://resource.openai.azure.com",
-        azure_ad_token_provider=token_provider,
+        azure_ad_token_provider=AsyncMock(return_value=token),
         http_client=httpx.AsyncClient(transport=transport),
         max_retries=0,
     )

--- a/tests/unit/providers/test_azureopenai_provider.py
+++ b/tests/unit/providers/test_azureopenai_provider.py
@@ -1,154 +1,345 @@
-from contextlib import contextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+import re
+import threading
+from unittest.mock import patch
 
+import httpx
 import pytest
+from openai import OpenAIError
 
-from any_llm.exceptions import MissingApiKeyError
+from any_llm.exceptions import MissingApiKeyError, UnsupportedParameterError
 from any_llm.providers.azureopenai.azureopenai import AzureopenaiProvider
-from any_llm.types.completion import CompletionParams
+
+_HTTP_OK = 200
+_HTTP_TOO_MANY_REQUESTS = 429
+_CHAT_RESPONSE = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "created": 1,
+    "model": "deployment-name",
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "logprobs": None,
+            "message": {"role": "assistant", "content": "Hello from Azure", "future_message_field": True},
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    "future_response_field": True,
+}
+_CHAT_STREAM = (
+    b'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,'
+    b'"model":"deployment-name","choices":[{"index":0,"delta":{"role":"assistant",'
+    b'"content":"Hello"},"finish_reason":null}]}\n\n'
+    b"data: [DONE]\n\n"
+)
+_RESPONSES_RESPONSE = {
+    "id": "resp-test",
+    "object": "response",
+    "created_at": 1,
+    "model": "deployment-name",
+    "output": [
+        {
+            "id": "msg-test",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "Hello from Responses", "annotations": []}],
+        }
+    ],
+    "parallel_tool_calls": False,
+    "tool_choice": "auto",
+    "tools": [],
+    "future_response_field": True,
+}
 
 
-@contextmanager
-def mock_azureopenai_provider():  # type: ignore[no-untyped-def]
-    with patch("any_llm.providers.azureopenai.azureopenai.AsyncAzureOpenAI") as mock_azure_client:
-        mock_client_instance = MagicMock()
-        mock_azure_client.return_value = mock_client_instance
+def _azure_transport(
+    status_codes: tuple[int, ...] = (_HTTP_OK,),
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
 
-        mock_response = MagicMock()
-        mock_client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+    def handle(request: httpx.Request) -> httpx.Response:
+        request.read()
+        requests.append(request)
+        status = status_codes[min(len(requests) - 1, len(status_codes) - 1)]
+        if status != _HTTP_OK:
+            return httpx.Response(
+                status,
+                headers={"Retry-After": "0"},
+                json={
+                    "error": {
+                        "message": "request rejected",
+                        "type": "rate_limit_error",
+                        "code": "rate_limit_exceeded",
+                    }
+                },
+            )
+        if request.url.path.endswith("/responses"):
+            return httpx.Response(_HTTP_OK, json=_RESPONSES_RESPONSE)
+        if b'"stream":true' in request.content:
+            return httpx.Response(_HTTP_OK, headers={"Content-Type": "text/event-stream"}, content=_CHAT_STREAM)
+        return httpx.Response(_HTTP_OK, json=_CHAT_RESPONSE)
 
-        yield mock_client_instance, mock_azure_client
-
-
-@pytest.mark.asyncio
-async def test_azureopenai_uses_azure_endpoint() -> None:
-    """Test that AzureopenaiProvider maps api_base to azure_endpoint."""
-    api_key = "test-api-key"
-    api_base = "https://test.openai.azure.com"
-
-    messages = [{"role": "user", "content": "Hello"}]
-
-    with mock_azureopenai_provider() as (mock_client, mock_azure_client):
-        provider = AzureopenaiProvider(api_key=api_key, api_base=api_base)
-        await provider._acompletion(CompletionParams(model_id="gpt-4", messages=messages))
-
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["azure_endpoint"] == api_base
-        assert kwargs["api_key"] == api_key
-
-        mock_client.chat.completions.create.assert_called_once()
+    return httpx.MockTransport(handle), requests
 
 
-@pytest.mark.asyncio
-async def test_azureopenai_api_version_default() -> None:
-    """Test that AzureopenaiProvider uses default API version."""
-    api_key = "test-api-key"
-    api_base = "https://test.openai.azure.com"
-
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=api_key, api_base=api_base)
-
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["api_version"] == "preview"
-
-
-@pytest.mark.asyncio
-async def test_azureopenai_api_version_custom() -> None:
-    """Test that AzureopenaiProvider accepts custom API version via kwargs."""
-    api_key = "test-api-key"
-    api_base = "https://test.openai.azure.com"
-    custom_api_version = "2024-06-01"
-
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=api_key, api_base=api_base, api_version=custom_api_version)
-
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["api_version"] == custom_api_version
-
-
-@pytest.mark.asyncio
-async def test_azureopenai_api_version_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that AzureopenaiProvider reads API version from environment."""
-    api_key = "test-api-key"
-    api_base = "https://test.openai.azure.com"
-    env_api_version = "2024-08-01-preview"
-
-    monkeypatch.setenv("OPENAI_API_VERSION", env_api_version)
-
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=api_key, api_base=api_base)
-
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["api_version"] == env_api_version
-
-
-@pytest.mark.asyncio
-async def test_azureopenai_ad_token_auth() -> None:
-    """Test that AzureopenaiProvider supports Azure AD token authentication."""
-    api_base = "https://test.openai.azure.com"
-    azure_ad_token = "test-ad-token"  # noqa: S105
-
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=None, api_base=api_base, azure_ad_token=azure_ad_token)
-
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["azure_ad_token"] == azure_ad_token
-
-
-def test_azureopenai_requires_api_key_or_ad_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no key and no Entra token the typed error is raised, not the SDK's own OpenAIError."""
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
-
-    with pytest.raises(MissingApiKeyError, match="AZURE_OPENAI_API_KEY"):
-        AzureopenaiProvider(api_key=None, api_base="https://test.openai.azure.com")
-
-
-def test_azureopenai_ad_token_provider_counts_as_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A token provider callable is the third Azure auth path and must not trip the check."""
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
-
-    def token_provider() -> str:
-        return "t"
-
-    with mock_azureopenai_provider() as (_, mock_azure_client):
+def test_azureopenai_normalizes_v1_endpoint_and_preserves_client_options() -> None:
+    with patch("any_llm.providers.azureopenai.azureopenai.AsyncOpenAI") as sdk_client:
         AzureopenaiProvider(
-            api_key=None, api_base="https://test.openai.azure.com", azure_ad_token_provider=token_provider
+            api_key="key",
+            api_base="https://explicit.openai.azure.com/openai/v1/",
+            azure_endpoint="https://ignored.openai.azure.com",
+            default_query={"api-version": "v1", "trace": "1"},
+            timeout=30,
         )
 
-        kwargs = mock_azure_client.call_args.kwargs
-        assert kwargs["api_key"] is None
-        assert kwargs["azure_ad_token_provider"] is token_provider
+    sdk_client.assert_called_once_with(
+        api_key="key",
+        base_url="https://explicit.openai.azure.com/openai/v1/",
+        default_query={"api-version": "v1", "trace": "1"},
+        timeout=30,
+    )
+
+
+def test_azureopenai_uses_environment_endpoint_and_entra_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://resource.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", "entra-token")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "lower-precedence-key")
+
+    with patch("any_llm.providers.azureopenai.azureopenai.AsyncOpenAI") as sdk_client:
+        AzureopenaiProvider()
+
+    assert sdk_client.call_args.kwargs["api_key"] == "entra-token"
+    assert sdk_client.call_args.kwargs["base_url"] == "https://resource.openai.azure.com/openai/v1/"
+
+
+def test_azureopenai_explicit_azure_arguments_override_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://environment.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "environment-key")
+
+    with patch("any_llm.providers.azureopenai.azureopenai.AsyncOpenAI") as sdk_client:
+        AzureopenaiProvider(
+            azure_endpoint="https://explicit.openai.azure.com",
+            azure_ad_token="explicit-token",  # noqa: S106
+        )
+
+    assert sdk_client.call_args.kwargs["api_key"] == "explicit-token"
+    assert sdk_client.call_args.kwargs["base_url"] == "https://explicit.openai.azure.com/openai/v1/"
+
+
+@pytest.mark.parametrize(
+    ("legacy_options", "expected_parameter"),
+    [
+        ({"api_version": "2024-10-21"}, "api_version"),
+        ({"azure_deployment": "deployment-name"}, "azure_deployment"),
+        ({"default_query": {"api-version": "2024-10-21"}}, "default_query['api-version']"),
+    ],
+)
+def test_azureopenai_rejects_legacy_routing_options(legacy_options: dict[str, object], expected_parameter: str) -> None:
+    with pytest.raises(UnsupportedParameterError, match=re.escape(expected_parameter)):
+        AzureopenaiProvider(
+            api_key="key",
+            api_base="https://resource.openai.azure.com",
+            **legacy_options,
+        )
+
+
+def test_azureopenai_rejects_legacy_api_version_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_VERSION", "2024-10-21")
+
+    with pytest.raises(UnsupportedParameterError, match="OPENAI_API_VERSION"):
+        AzureopenaiProvider(api_key="key", api_base="https://resource.openai.azure.com")
+
+
+@pytest.mark.parametrize(
+    ("api_key", "ad_token", "expected_credential"),
+    [("", "entra-token", "entra-token"), ("api-key", "", "api-key")],
+)
+def test_azureopenai_treats_empty_environment_credentials_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    api_key: str,
+    ad_token: str,
+    expected_credential: str,
+) -> None:
+    """An empty environment value must not count as a second credential."""
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://resource.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", api_key)
+    monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", ad_token)
+
+    with patch("any_llm.providers.azureopenai.azureopenai.AsyncOpenAI") as sdk_client:
+        AzureopenaiProvider()
+
+    assert sdk_client.call_args.kwargs["api_key"] == expected_credential
+
+
+def test_azureopenai_requires_one_endpoint_and_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in ("AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_AD_TOKEN", "AZURE_OPENAI_API_KEY"):
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(ValueError, match="endpoint is required"):
+        AzureopenaiProvider(api_key="key")
+    with pytest.raises(MissingApiKeyError, match="AZURE_OPENAI_API_KEY or AZURE_OPENAI_AD_TOKEN"):
+        AzureopenaiProvider(api_base="https://resource.openai.azure.com")
+    token = "token"  # noqa: S105
+    with pytest.raises(OpenAIError, match="mutually exclusive"):
+        AzureopenaiProvider(
+            api_key="key",
+            api_base="https://resource.openai.azure.com",
+            azure_ad_token=token,
+        )
+    with pytest.raises(OpenAIError, match="mutually exclusive"):
+        AzureopenaiProvider(
+            api_key="key",
+            api_base="https://resource.openai.azure.com",
+            azure_ad_token_provider=lambda: token,
+        )
 
 
 @pytest.mark.asyncio
-async def test_azureopenai_preserves_extra_kwargs() -> None:
-    """Test that AzureopenaiProvider preserves extra kwargs."""
-    api_key = "test-api-key"
-    api_base = "https://test.openai.azure.com"
-    custom_timeout = 30
+async def test_azureopenai_sends_chat_to_v1_with_bearer_api_key_and_preserves_optional_presence() -> None:
+    transport, requests = _azure_transport()
+    provider = AzureopenaiProvider(
+        api_key="api-key",
+        api_base="https://resource.openai.azure.com",
+        http_client=httpx.AsyncClient(transport=transport),
+        max_retries=0,
+    )
+    try:
+        first = await provider.acompletion(
+            model="deployment-name",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        await provider.acompletion(
+            model="deployment-name",
+            messages=[{"role": "user", "content": "Hello"}],
+            temperature=0,
+        )
+    finally:
+        await provider.client.close()
 
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=api_key, api_base=api_base, timeout=custom_timeout)
+    assert first.choices[0].message.content == "Hello from Azure"
+    assert [request.url.path for request in requests] == [
+        "/openai/v1/chat/completions",
+        "/openai/v1/chat/completions",
+    ]
+    assert [request.headers["Authorization"] for request in requests] == ["Bearer api-key", "Bearer api-key"]
+    first_body = json.loads(requests[0].content)
+    second_body = json.loads(requests[1].content)
+    assert first_body["model"] == "deployment-name"
+    assert "temperature" not in first_body
+    assert second_body["temperature"] == 0
 
-        mock_azure_client.assert_called_once()
-        call_args = mock_azure_client.call_args
-        assert call_args is not None
-        _, kwargs = call_args
-        assert kwargs["timeout"] == custom_timeout
+
+@pytest.mark.asyncio
+async def test_azureopenai_refreshes_sync_entra_provider_before_sdk_retry() -> None:
+    """The SDK retries with refreshed credentials without blocking the event loop."""
+    tokens = iter(("entra-token-1", "entra-token-2"))
+    event_loop_thread = threading.get_ident()
+    provider_threads: list[int] = []
+
+    def token_provider() -> str:
+        provider_threads.append(threading.get_ident())
+        return next(tokens)
+
+    transport, requests = _azure_transport((_HTTP_TOO_MANY_REQUESTS, _HTTP_OK))
+    provider = AzureopenaiProvider(
+        api_base="https://resource.openai.azure.com",
+        azure_ad_token_provider=token_provider,
+        http_client=httpx.AsyncClient(transport=transport),
+        max_retries=1,
+    )
+    try:
+        result = await provider.acompletion(
+            model="deployment-name",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+    finally:
+        await provider.client.close()
+
+    assert result.choices[0].message.content == "Hello from Azure"
+    assert [request.url.path for request in requests] == [
+        "/openai/v1/chat/completions",
+        "/openai/v1/chat/completions",
+    ]
+    assert [request.headers["Authorization"] for request in requests] == [
+        "Bearer entra-token-1",
+        "Bearer entra-token-2",
+    ]
+    assert provider_threads
+    assert all(thread_id != event_loop_thread for thread_id in provider_threads)
+
+
+@pytest.mark.asyncio
+async def test_azureopenai_rejects_empty_entra_provider_token() -> None:
+    """Reject an empty dynamic token before sending the request."""
+
+    def token_provider() -> str:
+        return ""
+
+    transport, _ = _azure_transport()
+    provider = AzureopenaiProvider(
+        api_base="https://resource.openai.azure.com",
+        azure_ad_token_provider=token_provider,
+        http_client=httpx.AsyncClient(transport=transport),
+        max_retries=0,
+    )
+    try:
+        with (
+            pytest.warns(DeprecationWarning, match="Provider-specific exceptions"),
+            pytest.raises(ValueError, match="non-empty string"),
+        ):
+            await provider.acompletion(
+                model="deployment-name",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+    finally:
+        await provider.client.close()
+
+
+@pytest.mark.asyncio
+async def test_azureopenai_supports_async_entra_provider_and_chat_sse() -> None:
+    async def token_provider() -> str:
+        return "async-entra-token"
+
+    transport, requests = _azure_transport()
+    provider = AzureopenaiProvider(
+        api_base="https://resource.openai.azure.com",
+        azure_ad_token_provider=token_provider,
+        http_client=httpx.AsyncClient(transport=transport),
+        max_retries=0,
+    )
+    try:
+        stream = await provider.acompletion(
+            model="deployment-name",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+        chunks = [chunk async for chunk in stream]
+    finally:
+        await provider.client.close()
+
+    assert [request.url.path for request in requests] == ["/openai/v1/chat/completions"]
+    assert [request.headers["Authorization"] for request in requests] == ["Bearer async-entra-token"]
+    assert [chunk.choices[0].delta.content for chunk in chunks] == ["Hello"]
+
+
+@pytest.mark.asyncio
+async def test_azureopenai_sends_responses_to_v1() -> None:
+    transport, requests = _azure_transport()
+    provider = AzureopenaiProvider(
+        api_key="api-key",
+        api_base="https://resource.openai.azure.com",
+        http_client=httpx.AsyncClient(transport=transport),
+        max_retries=0,
+    )
+    try:
+        response = await provider.aresponses(model="deployment-name", input_data="Hello")
+    finally:
+        await provider.client.close()
+
+    assert response.id == "resp-test"
+    assert [request.url.path for request in requests] == ["/openai/v1/responses"]
+    assert [request.headers["Authorization"] for request in requests] == ["Bearer api-key"]
+    assert requests[0].read() == b'{"input":"Hello","model":"deployment-name"}'

--- a/tests/unit/providers/test_azureopenai_provider.py
+++ b/tests/unit/providers/test_azureopenai_provider.py
@@ -85,12 +85,18 @@ def _azure_transport(
     return httpx.MockTransport(handle), requests
 
 
-def test_azureopenai_normalizes_v1_endpoint_and_preserves_client_options() -> None:
+@pytest.mark.parametrize("api_version", [None, "v1"])
+@pytest.mark.parametrize("environment_version", ["", "v1"])
+def test_azureopenai_normalizes_v1_endpoint_and_preserves_client_options(
+    api_version: str | None, environment_version: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_VERSION", environment_version)
     with patch("any_llm.providers.azureopenai.azureopenai.AsyncOpenAI") as sdk_client:
         AzureopenaiProvider(
             api_key="key",
             api_base="https://explicit.openai.azure.com/openai/v1/",
             azure_endpoint="https://ignored.openai.azure.com",
+            api_version=api_version,
             default_query={"api-version": "v1", "trace": "1"},
             timeout=30,
         )

--- a/tests/unit/test_audio.py
+++ b/tests/unit/test_audio.py
@@ -401,7 +401,7 @@ def test_speech_params_rejects_extra_fields() -> None:
 
 
 def test_supports_audio_only_on_expected_providers() -> None:
-    expected_supported = {LLMProvider.OPENAI, LLMProvider.AZUREOPENAI, LLMProvider.OTARI}
+    expected_supported = {LLMProvider.OPENAI, LLMProvider.OTARI}
 
     for provider_enum in expected_supported:
         cls = AnyLLM.get_provider_class(provider_enum)

--- a/tests/unit/test_image_generation.py
+++ b/tests/unit/test_image_generation.py
@@ -164,7 +164,6 @@ def test_image_generation_params_rejects_extra_fields() -> None:
 def test_supports_image_generation_only_on_expected_providers() -> None:
     expected_supported = {
         LLMProvider.OPENAI,
-        LLMProvider.AZUREOPENAI,
         LLMProvider.NEOSANTARA,
         LLMProvider.OTARI,
     }


### PR DESCRIPTION
## Description

Use the public OpenAI client with Azure's GA `/openai/v1/` endpoint, preserving explicit endpoint and credential precedence.

- Accept an API key, static Microsoft Entra token, or sync/async token provider.
- Keep header generation, token refresh, retries and redirect handling in the SDK.
- Accept explicit `api_version="v1"` and `OPENAI_API_VERSION=v1` as the GA route default. Reject dated versions and deployment-in-path options. Preserve valid `default_query["api-version"]="v1"`.
- Advertise the implemented GA capabilities; keep preview media and Batch disabled.

The explicit `v1` acceptance fixes a constructor rejection found during independent review. It does not add a legacy route or change the service version. Microsoft defines the optional API-version query default as `v1` in the [official schema](https://github.com/Azure/azure-rest-api-specs/blob/3e3f840f52f06cc593b6301d30ea0e04802473b2/specification/ai/data-plane/OpenAI.v1/azure-v1-v1-generated.json).

The provider owns Azure configuration; shared OpenAI code owns request, response and stream conversion. The two constructor overrides prevent ambient credentials or endpoints from overriding explicit Azure options. No SDK dependency change is needed for this correction.

## Verification

The new explicit-version regression failed before the fix. With the fix:

- Azure provider tests: 19 passed.
- Full unit suite in this worktree's declared dependency environment, Python 3.13: 2442 passed, 69 skipped.
- Changed-file Ruff lint and format checks passed. The all-stable scan reports only test assertions, the intentional test namespace package, and COM812's conflict with the formatter.
- After `uv sync --all-extras --python 3.13`, `UV_NO_SYNC=1 uv run pre-commit run --all-files` passed, including mypy over 287 source files. Preserving the synced environment prevents a nested `uv run` from pruning optional SDK dependencies.
- `git diff --check` passed.

Local wire tests exercise the real SDK with a mock transport. They are not live Azure verification. Live authentication across Azure resource families, exact-head CodeRabbit review and final provider-level acceptance remain pending; this PR stays Draft.

## AI usage

Generated with Amp using GPT-5.6 Sol X-HIGH.
