### PR TITLE
test(integration): filter tool args to function signature in agent loop

### DIFF
--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -155,7 +156,19 @@ async def test_agent_loop_sequential_tool_calls(
                 tool_fn = available_tools[tool_name]
 
                 args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                tool_result = tool_fn(**args)
+                sig = inspect.signature(tool_fn)
+                if any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD
+                    for param in sig.parameters.values()
+                ):
+                    filtered_args = args
+                else:
+                    filtered_args = {
+                        key: value
+                        for key, value in args.items()
+                        if key in sig.parameters
+                    }
+                tool_result = tool_fn(**filtered_args)
 
                 messages.append(
                     {


### PR DESCRIPTION
## Summary
- Filter tool call arguments to the target function signature before invoking tools in the integration agent loop test harness.
- Avoids flaky failures when models emit extra keys the tool function does not accept.

Fixes #1170

## Test plan
- [x] Logic mirrors signature filtering pattern used elsewhere in the suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequential tool-call handling by passing only supported arguments to functions.
  * Preserved full argument forwarding for functions that accept additional keyword arguments.

* **Tests**
  * Updated integration coverage for sequential tool calls and varied function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->