### PR TITLE
fix(azureopenai): raise MissingApiKeyError when no key or Entra token is given

### DIFF
--- a/src/any_llm/providers/azureopenai/azureopenai.py
+++ b/src/any_llm/providers/azureopenai/azureopenai.py
@@ -46,6 +46,8 @@ class AzureopenaiProvider(BaseOpenAIProvider):
     ) -> None:
         api_version = kwargs.pop("api_version", None) or os.getenv("OPENAI_API_VERSION", self.DEFAULT_API_VERSION)
         azure_ad_token = kwargs.pop("azure_ad_token", None) or os.getenv("AZURE_OPENAI_AD_TOKEN")
+        if not api_key and not azure_ad_token and not kwargs.get("azure_ad_token_provider"):
+            raise MissingApiKeyError(self.PROVIDER_NAME, self.ENV_API_KEY_NAME)
 
         azure_endpoint = api_base or kwargs.pop("azure_endpoint", None) or os.getenv("AZURE_OPENAI_ENDPOINT")
         if not azure_endpoint:

--- a/tests/unit/providers/test_azureopenai_provider.py
+++ b/tests/unit/providers/test_azureopenai_provider.py
@@ -124,10 +124,17 @@ def test_azureopenai_ad_token_provider_counts_as_credentials(monkeypatch: pytest
     monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
 
-    with mock_azureopenai_provider() as (_, mock_azure_client):
-        AzureopenaiProvider(api_key=None, api_base="https://test.openai.azure.com", azure_ad_token_provider=lambda: "t")
+    def token_provider() -> str:
+        return "t"
 
-        assert mock_azure_client.call_args.kwargs["api_key"] is None
+    with mock_azureopenai_provider() as (_, mock_azure_client):
+        AzureopenaiProvider(
+            api_key=None, api_base="https://test.openai.azure.com", azure_ad_token_provider=token_provider
+        )
+
+        kwargs = mock_azure_client.call_args.kwargs
+        assert kwargs["api_key"] is None
+        assert kwargs["azure_ad_token_provider"] is token_provider
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_azureopenai_provider.py
+++ b/tests/unit/providers/test_azureopenai_provider.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from any_llm.exceptions import MissingApiKeyError
 from any_llm.providers.azureopenai.azureopenai import AzureopenaiProvider
 from any_llm.types.completion import CompletionParams
 
@@ -107,6 +108,26 @@ async def test_azureopenai_ad_token_auth() -> None:
         assert call_args is not None
         _, kwargs = call_args
         assert kwargs["azure_ad_token"] == azure_ad_token
+
+
+def test_azureopenai_requires_api_key_or_ad_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no key and no Entra token the typed error is raised, not the SDK's own OpenAIError."""
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
+
+    with pytest.raises(MissingApiKeyError, match="AZURE_OPENAI_API_KEY"):
+        AzureopenaiProvider(api_key=None, api_base="https://test.openai.azure.com")
+
+
+def test_azureopenai_ad_token_provider_counts_as_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token provider callable is the third Azure auth path and must not trip the check."""
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
+
+    with mock_azureopenai_provider() as (_, mock_azure_client):
+        AzureopenaiProvider(api_key=None, api_base="https://test.openai.azure.com", azure_ad_token_provider=lambda: "t")
+
+        assert mock_azure_client.call_args.kwargs["api_key"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`AzureopenaiProvider` skips the base class key check on purpose, since Azure also accepts an Entra ID token. When neither an API key nor a token was present, `_init_client` handed `api_key=None` to `AsyncAzureOpenAI`, and the openai SDK's `OpenAIError("Missing credentials...")` escaped from `AnyLLM.create`. Every other provider raises `MissingApiKeyError` there.

The fix checks the three Azure credential paths (`api_key`, `azure_ad_token`, `azure_ad_token_provider`) and raises `MissingApiKeyError` naming `AZURE_OPENAI_API_KEY` when all are absent. The endpoint check two lines down is unchanged, and so is every path that has credentials.

Two unit tests: no credentials raises the typed error, and a token provider callable alone is accepted (the third auth path, not covered before).

Side effect: the integration suite now skips `azureopenai` without credentials, as it does for every other provider, instead of erroring in every file except `test_moderation.py` (which catches `OpenAIError` by hand). Verified locally: `tests/integration/test_agent_loop.py::test_agent_loop_parallel_tool_calls[azureopenai]` went from `OpenAIError` to `SKIPPED [azureopenai API key not provided]`.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1350

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Opus 5)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure OpenAI now reports a clear, typed missing-credentials error when no API key or Entra authentication method is provided.
  * Azure AD token providers are now correctly recognised as valid authentication credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->