### PR TITLE
fix(gemini): map tool_choice none and the named-function form

### DIFF
--- a/src/any_llm/providers/gemini/base.py
+++ b/src/any_llm/providers/gemini/base.py
@@ -165,8 +165,8 @@ class GoogleProvider(AnyLLM):
             kwargs["temperature"] = params.temperature
         if params.tools is not None:
             kwargs["tools"] = _convert_tool_spec(params.tools, provider_name)
-        if isinstance(params.tool_choice, str):
-            kwargs["tool_config"] = _convert_tool_choice(params.tool_choice)
+        if params.tool_choice is not None:
+            kwargs["tool_config"] = _convert_tool_choice(params.tool_choice, provider_name)
         if params.top_p is not None:
             kwargs["top_p"] = params.top_p
         if params.stop is not None:

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -143,7 +143,10 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
                 raise UnsupportedParameterError(error_message, provider_name, additional_message)
             # Every entry is kept so that an unusable one fails the name check below rather than
             # being dropped, which would silently narrow the set of tools the caller asked for.
-            functions = [tool.get("function") if isinstance(tool, dict) else None for tool in allowed_tools]
+            functions = [
+                tool.get("function") if isinstance(tool, dict) and tool.get("type") == "function" else None
+                for tool in allowed_tools
+            ]
         else:
             functions = [tool_choice.get("function")] if tool_choice.get("type") == "function" else []
         raw_names = [function.get("name") if isinstance(function, dict) else None for function in functions]

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -133,14 +133,22 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
     additional_message = f"Unsupported tool_choice: {tool_choice}"
 
     if isinstance(tool_choice, dict):
-        function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
-        name = function.get("name") if isinstance(function, dict) else None
-        if not isinstance(name, str) or not name:
+        if tool_choice.get("type") == "allowed_tools":
+            allowed = tool_choice.get("allowed_tools")
+            # Gemini only honors allowed_function_names in ANY mode, so mode="auto" has no equivalent.
+            if not isinstance(allowed, dict) or allowed.get("mode") != "required":
+                raise UnsupportedParameterError(error_message, provider_name, additional_message)
+            functions = [tool.get("function") for tool in allowed.get("tools", []) if isinstance(tool, dict)]
+        else:
+            functions = [tool_choice.get("function")] if tool_choice.get("type") == "function" else []
+        raw_names = [function.get("name") if isinstance(function, dict) else None for function in functions]
+        names = [name for name in raw_names if isinstance(name, str) and name]
+        if not names or len(names) != len(raw_names):
             raise UnsupportedParameterError(error_message, provider_name, additional_message)
         return types.ToolConfig(
             function_calling_config=types.FunctionCallingConfig(
                 mode=types.FunctionCallingConfigMode.ANY,
-                allowed_function_names=[name],
+                allowed_function_names=names,
             )
         )
 

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -138,7 +138,12 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
             # Gemini only honors allowed_function_names in ANY mode, so mode="auto" has no equivalent.
             if not isinstance(allowed, dict) or allowed.get("mode") != "required":
                 raise UnsupportedParameterError(error_message, provider_name, additional_message)
-            functions = [tool.get("function") for tool in allowed.get("tools", []) if isinstance(tool, dict)]
+            allowed_tools = allowed.get("tools")
+            if not isinstance(allowed_tools, list):
+                raise UnsupportedParameterError(error_message, provider_name, additional_message)
+            # Every entry is kept so that an unusable one fails the name check below rather than
+            # being dropped, which would silently narrow the set of tools the caller asked for.
+            functions = [tool.get("function") if isinstance(tool, dict) else None for tool in allowed_tools]
         else:
             functions = [tool_choice.get("function")] if tool_choice.get("type") == "function" else []
         raw_names = [function.get("name") if isinstance(function, dict) else None for function in functions]

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -10,7 +10,7 @@ from google.genai import types
 from google.genai.pagers import Pager
 from pydantic import ValidationError
 
-from any_llm.exceptions import InvalidRequestError
+from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
 from any_llm.logging import logger
 from any_llm.types.batch import Batch, BatchRequestCounts, BatchResult, BatchResultError, BatchResultItem
 from any_llm.types.completion import (
@@ -128,13 +128,32 @@ def _convert_tool_spec(tools: list[dict[str, Any] | Any], provider_name: str) ->
     return converted_tools
 
 
-def _convert_tool_choice(tool_choice: str) -> types.ToolConfig:
+def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) -> types.ToolConfig:
+    error_message = "tool_choice"
+    additional_message = f"Unsupported tool_choice: {tool_choice}"
+
+    if isinstance(tool_choice, dict):
+        function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
+        name = function.get("name") if isinstance(function, dict) else None
+        if not name:
+            raise UnsupportedParameterError(error_message, provider_name, additional_message)
+        return types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode=types.FunctionCallingConfigMode.ANY,
+                allowed_function_names=[name],
+            )
+        )
+
     tool_choice_to_mode = {
         "required": types.FunctionCallingConfigMode.ANY,
         "auto": types.FunctionCallingConfigMode.AUTO,
+        "none": types.FunctionCallingConfigMode.NONE,
     }
+    mode = tool_choice_to_mode.get(tool_choice)
+    if mode is None:
+        raise UnsupportedParameterError(error_message, provider_name, additional_message)
 
-    return types.ToolConfig(function_calling_config=types.FunctionCallingConfig(mode=tool_choice_to_mode[tool_choice]))
+    return types.ToolConfig(function_calling_config=types.FunctionCallingConfig(mode=mode))
 
 
 def _parse_data_uri(data_uri: str, field_name: str, provider_name: str) -> tuple[str, bytes]:

--- a/src/any_llm/providers/gemini/utils.py
+++ b/src/any_llm/providers/gemini/utils.py
@@ -135,7 +135,7 @@ def _convert_tool_choice(tool_choice: str | dict[str, Any], provider_name: str) 
     if isinstance(tool_choice, dict):
         function = tool_choice.get("function") if tool_choice.get("type") == "function" else None
         name = function.get("name") if isinstance(function, dict) else None
-        if not name:
+        if not isinstance(name, str) or not name:
             raise UnsupportedParameterError(error_message, provider_name, additional_message)
         return types.ToolConfig(
             function_calling_config=types.FunctionCallingConfig(

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -340,6 +340,37 @@ async def test_completion_with_named_function_tool_choice() -> None:
         assert function_calling_config.allowed_function_names == ["get_weather"]
 
 
+@pytest.mark.asyncio
+async def test_completion_with_allowed_tools_tool_choice() -> None:
+    """A required allowed_tools choice must forward every listed name in ANY mode."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="gemini-pro",
+                messages=messages,
+                tool_choice={
+                    "type": "allowed_tools",
+                    "allowed_tools": {
+                        "mode": "required",
+                        "tools": [
+                            {"type": "function", "function": {"name": "get_weather"}},
+                            {"type": "function", "function": {"name": "get_time"}},
+                        ],
+                    },
+                },
+            ),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        function_calling_config = call_kwargs["config"].tool_config.function_calling_config
+
+        assert function_calling_config.mode.value == "ANY"
+        assert function_calling_config.allowed_function_names == ["get_weather", "get_time"]
+
+
 @pytest.mark.parametrize(
     "tool_choice",
     [
@@ -347,6 +378,26 @@ async def test_completion_with_named_function_tool_choice() -> None:
         {"type": "custom", "custom": {"name": "get_weather"}},
         {"type": "function"},
         {"type": "function", "function": {"name": 1}},
+        # Gemini honors allowed_function_names only in ANY mode, so "auto" cannot be expressed.
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {"mode": "auto", "tools": [{"type": "function", "function": {"name": "get_weather"}}]},
+        },
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": []}},
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "required",
+                "tools": [
+                    {"type": "function", "function": {"name": "get_weather"}},
+                    {"type": "function", "function": {"name": ""}},
+                ],
+            },
+        },
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {"mode": "required", "tools": [{"type": "function", "function": {"name": 1}}]},
+        },
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -302,6 +302,62 @@ async def test_completion_with_tool_choice_auto(tool_choice: str, expected_mode:
 
 
 @pytest.mark.asyncio
+async def test_completion_with_tool_choice_none_disables_function_calling() -> None:
+    """tool_choice='none' must map to Gemini's NONE mode instead of raising."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(model_id="gemini-pro", messages=messages, tool_choice="none"),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        generation_config = call_kwargs["config"]
+
+        assert generation_config.tool_config.function_calling_config.mode.value == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_completion_with_named_function_tool_choice() -> None:
+    """The OpenAI named-function tool_choice must force that function via allowed_function_names."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider() as mock_genai:
+        provider = GeminiProvider(api_key="test-api-key")
+        await provider._acompletion(
+            CompletionParams(
+                model_id="gemini-pro",
+                messages=messages,
+                tool_choice={"type": "function", "function": {"name": "get_weather"}},
+            ),
+        )
+
+        _, call_kwargs = mock_genai.return_value.aio.models.generate_content.call_args
+        function_calling_config = call_kwargs["config"].tool_config.function_calling_config
+
+        assert function_calling_config.mode.value == "ANY"
+        assert function_calling_config.allowed_function_names == ["get_weather"]
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    ["sometimes", {"type": "custom", "custom": {"name": "get_weather"}}, {"type": "function"}],
+)
+@pytest.mark.asyncio
+async def test_completion_with_unsupported_tool_choice_raises(tool_choice: str | dict[str, Any]) -> None:
+    """Unrecognized tool_choice values report the offending value rather than leaking a KeyError."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with mock_gemini_provider():
+        provider = GeminiProvider(api_key="test-api-key")
+        with pytest.raises(UnsupportedParameterError, match="tool_choice"):
+            await provider._acompletion(
+                CompletionParams(model_id="gemini-pro", messages=messages, tool_choice=tool_choice),
+            )
+
+
+@pytest.mark.asyncio
 async def test_completion_without_tool_choice() -> None:
     """Test that completion works correctly without tool_choice."""
     api_key = "test-api-key"

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -408,6 +408,10 @@ async def test_completion_with_allowed_tools_tool_choice() -> None:
             "type": "allowed_tools",
             "allowed_tools": {"mode": "required", "tools": [{"type": "function", "function": {"name": 1}}]},
         },
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {"mode": "required", "tools": [{"type": "custom", "function": {"name": "get_weather"}}]},
+        },
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -384,6 +384,16 @@ async def test_completion_with_allowed_tools_tool_choice() -> None:
             "allowed_tools": {"mode": "auto", "tools": [{"type": "function", "function": {"name": "get_weather"}}]},
         },
         {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": []}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required"}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": None}},
+        {"type": "allowed_tools", "allowed_tools": {"mode": "required", "tools": 1}},
+        {
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "required",
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}, "get_time"],
+            },
+        },
         {
             "type": "allowed_tools",
             "allowed_tools": {

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -342,7 +342,12 @@ async def test_completion_with_named_function_tool_choice() -> None:
 
 @pytest.mark.parametrize(
     "tool_choice",
-    ["sometimes", {"type": "custom", "custom": {"name": "get_weather"}}, {"type": "function"}],
+    [
+        "sometimes",
+        {"type": "custom", "custom": {"name": "get_weather"}},
+        {"type": "function"},
+        {"type": "function", "function": {"name": 1}},
+    ],
 )
 @pytest.mark.asyncio
 async def test_completion_with_unsupported_tool_choice_raises(tool_choice: str | dict[str, Any]) -> None:


### PR DESCRIPTION
## Description

Re-creation of #1300 by @tonycoder-hub, which was closed as stale on 2026-08-21 without a review. His four commits are cherry-picked unchanged, `Co-authored-by` trailers intact, onto current main. The only merge touch is the `_convert_tool_spec(params.tools, provider_name)` line from #1309 that sits above the changed `tool_choice` call.

From the original: Gemini's `_convert_tool_choice` only knew `auto` and `required`, so `"none"` raised `KeyError`, and the OpenAI named-function dict was discarded at the `isinstance(..., str)` gate, so a forced function ran as AUTO with no error. `"none"` now maps to `FunctionCallingConfigMode.NONE`; the named-function dict and the `allowed_tools` form map to `mode=ANY` with `allowed_function_names`; anything else raises `UnsupportedParameterError`. VertexAI inherits the conversion.

I confirmed the silent drop live on #1300 and we hit it building against Gemini, which is why I am carrying it. Verified live on this branch with `gemini-3-flash-preview` and a `get_weather` tool:

| `tool_choice` | result |
|---|---|
| `"none"` on "What is the weather in Paris?" | no tool call, text answer, `finish_reason=stop` |
| `{"type": "function", "function": {"name": "get_weather"}}` on "Hello there, how are you?" | `get_weather` called, `finish_reason=tool_calls` |
| `"auto"` | unchanged, `get_weather` called |

Tests: `tests/unit/providers/test_gemini_provider.py` and `test_vertexai_provider.py`, 225 passed. Pre-commit clean.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Supersedes #1300.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Opus 5) for the rebase, live verification and this description. The commits themselves are @tonycoder-hub's, authored with Cursor.
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Gemini tool-choice handling, including support for disabling tools, selecting a specific function, and restricting available functions.
  * Added support for more flexible tool-choice configurations when making requests.

* **Bug Fixes**
  * Prevented invalid or malformed tool-choice inputs from causing unexpected errors during request preparation.
  * Improved validation and reporting for unsupported tool-choice configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->