### PR TITLE
fix(xai): map the provider finish reason instead of hardcoding stop

### DIFF
--- a/src/any_llm/providers/xai/utils.py
+++ b/src/any_llm/providers/xai/utils.py
@@ -7,6 +7,7 @@ from xai_sdk.chat import Response as XaiResponse
 from xai_sdk.chat import tool as xai_make_tool
 from xai_sdk.proto import chat_pb2 as xai_chat_pb2
 from xai_sdk.proto import models_pb2 as xai_models_pb2
+from xai_sdk.proto import sample_pb2 as xai_sample_pb2
 
 from any_llm.types.completion import (
     ChatCompletion,
@@ -40,6 +41,25 @@ def _map_xai_role_to_openai(
     return None
 
 
+# Reasons without an OpenAI counterpart are left out on purpose: REASON_INVALID, which every
+# non-final chunk carries, and REASON_TIME_LIMIT. Callers pick their own fallback from there,
+# since a chunk must not be labelled terminal while a complete response has to report something.
+_FINISH_REASON_MAP: dict[int, Literal["stop", "length", "tool_calls"]] = {
+    xai_sample_pb2.REASON_STOP: "stop",
+    xai_sample_pb2.REASON_MAX_LEN: "length",
+    xai_sample_pb2.REASON_MAX_CONTEXT: "length",
+    xai_sample_pb2.REASON_TOOL_CALLS: "tool_calls",
+}
+
+# Stream chunks carry the raw enum value, while Response.finish_reason returns its name. The
+# stubs shipped with xai_sdk describe FinishReason as a plain int subclass, so the
+# EnumTypeWrapper helpers provided by its metaclass are invisible to mypy.
+_FINISH_REASON_MAP_BY_NAME: dict[str, Literal["stop", "length", "tool_calls"]] = {
+    xai_sample_pb2.FinishReason.Name(value): mapped  # type: ignore[attr-defined]
+    for value, mapped in _FINISH_REASON_MAP.items()
+}
+
+
 def _convert_xai_chunk_to_anyllm_chunk(chunk: XaiChunk) -> ChatCompletionChunk:
     # Collect deltas from the first (and only) choice index 0
     choices: list[ChunkChoice] = []
@@ -71,7 +91,7 @@ def _convert_xai_chunk_to_anyllm_chunk(chunk: XaiChunk) -> ChatCompletionChunk:
             ChunkChoice(
                 index=i,
                 delta=delta,
-                finish_reason=None,
+                finish_reason=_FINISH_REASON_MAP.get(choice.finish_reason),
             )
         )
 
@@ -116,7 +136,12 @@ def _convert_xai_completion_to_anyllm_response(response: XaiResponse) -> ChatCom
         reasoning=reasoning,
     )
 
-    choice = Choice(index=0, finish_reason="tool_calls" if tool_calls else "stop", message=message)
+    # Truncation takes priority over "tool_calls": a response cut short mid tool call must not
+    # look like a completed tool call round.
+    mapped_finish_reason = _FINISH_REASON_MAP_BY_NAME.get(response.finish_reason)
+    finish_reason = mapped_finish_reason or ("tool_calls" if tool_calls else "stop")
+
+    choice = Choice(index=0, finish_reason=finish_reason, message=message)
 
     usage = CompletionUsage(
         prompt_tokens=response.proto.usage.prompt_text_tokens,

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -96,7 +96,9 @@ async def test_truncated_tool_call_response_reports_length_not_tool_calls() -> N
 
 
 @pytest.mark.asyncio
-async def test_tool_call_response_reports_tool_calls_finish_reason() -> None:
+@pytest.mark.parametrize("xai_finish_reason", ["REASON_TOOL_CALLS", "REASON_TIME_LIMIT"])
+async def test_tool_call_response_reports_tool_calls_finish_reason(xai_finish_reason: str) -> None:
+    """Mapped directly for REASON_TOOL_CALLS; for a reason without a counterpart, the tool calls decide."""
     from any_llm.providers.xai.xai import XaiProvider
 
     with mock_xai_provider() as (_, mock_response):
@@ -105,7 +107,7 @@ async def test_tool_call_response_reports_tool_calls_finish_reason() -> None:
         tool_call.function.name = "test_function"
         tool_call.function.arguments = "{}"
         mock_response.tool_calls = [tool_call]
-        mock_response.finish_reason = "REASON_TOOL_CALLS"
+        mock_response.finish_reason = xai_finish_reason
 
         provider = XaiProvider(api_key="test-api-key")
         response = await provider._acompletion(

--- a/tests/unit/providers/test_xai_provider.py
+++ b/tests/unit/providers/test_xai_provider.py
@@ -47,6 +47,107 @@ async def test_response_function_call_id_is_preserved() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("xai_finish_reason", "expected"),
+    [
+        ("REASON_STOP", "stop"),
+        ("REASON_MAX_LEN", "length"),
+        ("REASON_MAX_CONTEXT", "length"),
+        # No OpenAI counterpart, so the response falls back to a terminal reason.
+        ("REASON_TIME_LIMIT", "stop"),
+    ],
+)
+async def test_response_finish_reason_is_mapped(xai_finish_reason: str, expected: str) -> None:
+    """A truncated response must report "length", not "stop": callers (including the
+    structured-output truncation check) cannot tell a cut-off answer from a complete one
+    otherwise."""
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with mock_xai_provider() as (_, mock_response):
+        mock_response.finish_reason = xai_finish_reason
+
+        provider = XaiProvider(api_key="test-api-key")
+        response = await provider._acompletion(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}])
+        )
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].finish_reason == expected
+
+
+@pytest.mark.asyncio
+async def test_truncated_tool_call_response_reports_length_not_tool_calls() -> None:
+    """A response cut short mid tool call must not look like a completed tool call round."""
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with mock_xai_provider() as (_, mock_response):
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function.name = "test_function"
+        tool_call.function.arguments = '{"key": "va'
+        mock_response.tool_calls = [tool_call]
+        mock_response.finish_reason = "REASON_MAX_LEN"
+
+        provider = XaiProvider(api_key="test-api-key")
+        response = await provider._acompletion(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}])
+        )
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].finish_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_response_reports_tool_calls_finish_reason() -> None:
+    from any_llm.providers.xai.xai import XaiProvider
+
+    with mock_xai_provider() as (_, mock_response):
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function.name = "test_function"
+        tool_call.function.arguments = "{}"
+        mock_response.tool_calls = [tool_call]
+        mock_response.finish_reason = "REASON_TOOL_CALLS"
+
+        provider = XaiProvider(api_key="test-api-key")
+        response = await provider._acompletion(
+            CompletionParams(model_id="model", messages=[{"role": "user", "content": "Hello"}])
+        )
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.parametrize(
+    ("xai_finish_reason_name", "expected"),
+    [
+        ("REASON_INVALID", None),
+        ("REASON_STOP", "stop"),
+        ("REASON_MAX_LEN", "length"),
+        ("REASON_TOOL_CALLS", "tool_calls"),
+    ],
+)
+def test_stream_chunk_finish_reason_is_mapped(xai_finish_reason_name: str, expected: str | None) -> None:
+    """Streamed chunks used to always report finish_reason=None, so a stream never signalled
+    why it ended. Non-final chunks carry REASON_INVALID and must stay None."""
+    from xai_sdk.chat import Chunk as XaiChunk
+    from xai_sdk.proto import chat_pb2
+
+    from any_llm.providers.xai.utils import _convert_xai_chunk_to_anyllm_chunk
+
+    proto = chat_pb2.GetChatCompletionChunk(
+        outputs=[
+            chat_pb2.CompletionOutputChunk(
+                index=0,
+                delta=chat_pb2.Delta(role=chat_pb2.ROLE_ASSISTANT, content="hi"),
+                finish_reason=xai_finish_reason_name,
+            )
+        ]
+    )
+
+    chunk = _convert_xai_chunk_to_anyllm_chunk(XaiChunk(proto, index=None))
+
+    assert chunk.choices[0].finish_reason == expected
+
+
+@pytest.mark.asyncio
 async def test_completion_inside_agent_loop(agent_loop_messages: list[dict[str, Any]]) -> None:
     from any_llm.providers.xai.xai import XaiProvider
 


### PR DESCRIPTION
## Description

Re-creation of #1304 by @tonycoder-hub, which was closed as stale on 2026-08-21 without a review. His commit is cherry-picked unchanged, `Co-authored-by` trailer intact, onto current main, where it applies cleanly.

From the original: the xAI converters hardcoded `finish_reason`. Non-streaming used `tool_calls if tool_calls else stop`, so `REASON_MAX_LEN` and `REASON_MAX_CONTEXT` came back as a clean `stop` and `_acompletion_with_structured_output` never raised `LengthFinishReasonError`. Streamed chunks hardcoded `finish_reason=None`, so a stream never said why it ended. `sample_pb2.FinishReason` is now mapped onto the OpenAI vocabulary in both converters, with truncation taking priority over `tool_calls`. Same shape as #1301 for Cohere, which merged.

Verified live on this branch with `grok-4-1-fast-non-reasoning`:

| call | `finish_reason` |
|---|---|
| non-streaming, `max_tokens=8` | `length` (main hardcodes `stop` here) |
| non-streaming, normal | `stop` |
| streaming, `max_tokens=8`, last chunk | `length` (main hardcodes `None` here) |

Tests: `tests/unit/providers/test_xai_provider.py`, 23 passed. Pre-commit clean.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Supersedes #1304.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (not applicable)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Opus 5) for the rebase, live verification and this description. The commit itself is @tonycoder-hub's, authored with Cursor.
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of xAI completion and streaming termination reasons.
  * Responses now correctly distinguish between stopped, length-limited, and tool-call outcomes.
  * Truncated tool-call responses are now reported as length-limited rather than completed tool calls.

* **Tests**
  * Added coverage for completion and streaming finish-reason mapping, including invalid and truncated responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->