### PR TITLE
feat(providers): add orcarouter as a registry-only gateway

### DIFF
--- a/src/any_llm/providers/registry.py
+++ b/src/any_llm/providers/registry.py
@@ -187,6 +187,13 @@ PROVIDER_REGISTRY: dict[str, OpenAICompatibleProviderConfig] = {
         supports_completion_image=True,
         supports_moderation=True,
     ),
+    "orcarouter": OpenAICompatibleProviderConfig(
+        name="orcarouter",
+        api_base="https://api.orcarouter.ai/v1",
+        env_api_key_name="ORCAROUTER_API_KEY",
+        env_api_base_name="ORCAROUTER_API_BASE",
+        provider_documentation_url="https://docs.orcarouter.ai",
+    ),
 }
 
 _class_cache: dict[str, type[BaseOpenAIProvider]] = {}

--- a/tests/unit/providers/test_orcarouter_provider.py
+++ b/tests/unit/providers/test_orcarouter_provider.py
@@ -1,0 +1,82 @@
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.exceptions import MissingApiKeyError
+from any_llm.providers.registry import get_registry_config, get_registry_provider_class
+
+OrcarouterProvider = get_registry_provider_class("orcarouter")
+
+
+def test_provider_metadata() -> None:
+    provider = OrcarouterProvider(api_key="test-api-key")
+    assert provider.PROVIDER_NAME == "orcarouter"
+    assert provider.API_BASE == "https://api.orcarouter.ai/v1"
+    assert provider.ENV_API_KEY_NAME == "ORCAROUTER_API_KEY"
+    assert provider.ENV_API_BASE_NAME == "ORCAROUTER_API_BASE"
+    assert provider.PROVIDER_DOCUMENTATION_URL == "https://docs.orcarouter.ai"
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # OrcaRouter is a hosted, keyed gateway: constructing without a key must fail.
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    with pytest.raises(MissingApiKeyError):
+        OrcarouterProvider()
+
+
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+    provider = OrcarouterProvider()
+    assert provider._verify_and_set_api_key(None) == "env-key"
+
+
+def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+    provider = OrcarouterProvider(api_key="explicit-key")
+    assert provider._verify_and_set_api_key("explicit-key") == "explicit-key"
+
+
+def test_api_base_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_BASE", "https://proxy.internal/v1")
+    provider = OrcarouterProvider(api_key="test-api-key")
+    assert provider._resolve_api_base(None) == "https://proxy.internal/v1"
+    assert str(provider.client.base_url).rstrip("/") == "https://proxy.internal/v1"
+
+
+def test_api_base_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORCAROUTER_API_BASE", raising=False)
+    provider = OrcarouterProvider(api_key="test-api-key")
+    assert provider._resolve_api_base(None) is None
+    assert str(provider.client.base_url).rstrip("/") == "https://api.orcarouter.ai/v1"
+
+
+def test_explicit_api_base_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_BASE", "https://proxy.internal/v1")
+    provider = OrcarouterProvider(api_key="test-api-key", api_base="https://explicit.example/v1")
+    assert provider._resolve_api_base("https://explicit.example/v1") == "https://explicit.example/v1"
+    assert str(provider.client.base_url).rstrip("/") == "https://explicit.example/v1"
+
+
+def test_capability_flags() -> None:
+    # Conservative baseline only: completion, streaming and model listing were
+    # exercised against the live endpoint; everything else stays opt-in.
+    assert OrcarouterProvider.SUPPORTS_COMPLETION
+    assert OrcarouterProvider.SUPPORTS_COMPLETION_STREAMING
+    assert OrcarouterProvider.SUPPORTS_LIST_MODELS
+    assert not OrcarouterProvider.SUPPORTS_COMPLETION_REASONING
+    assert not OrcarouterProvider.SUPPORTS_COMPLETION_IMAGE
+    assert not OrcarouterProvider.SUPPORTS_COMPLETION_PDF
+    assert not OrcarouterProvider.SUPPORTS_EMBEDDING
+    assert not OrcarouterProvider.SUPPORTS_MODERATION
+    assert not OrcarouterProvider.SUPPORTS_BATCH
+    assert not OrcarouterProvider.SUPPORTS_IMAGE_GENERATION
+    assert not OrcarouterProvider.SUPPORTS_RERANK
+    assert not OrcarouterProvider.SUPPORTS_RESPONSES
+
+
+def test_registered_in_registry_and_loader() -> None:
+    assert get_registry_config("orcarouter") is not None
+    assert AnyLLM.get_provider_class("orcarouter") is OrcarouterProvider
+    assert "orcarouter" in AnyLLM.get_supported_providers()
+    # No LLMProvider enum member: this is a brand-new registry-only row, not a
+    # migrated provider carrying a legacy folder/enum compat shim.
+    assert "orcarouter" in AnyLLM.get_registry_provider_names()


### PR DESCRIPTION
## Description

Adds **orcarouter** as a first-class, named provider in `any-llm`'s provider registry.

The README frames `any-llm` as "communicate with any LLM provider using a single, unified interface," and for OpenAI-compatible gateways the project already ships a config registry (`src/any_llm/providers/registry.py`) where a gateway needs nothing beyond a base URL, an API key env var, and capability flags. This PR mirrors the existing `ovhcloud` / `telnyx` / `perplexity` rows: one `OpenAICompatibleProviderConfig` entry, no folder, no `LLMProvider` member, no `pyproject.toml` extra.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- `src/any_llm/providers/registry.py`: one row in `PROVIDER_REGISTRY`.
  - `api_base`: `https://api.orcarouter.ai/v1`
  - `env_api_key_name`: `ORCAROUTER_API_KEY`, `env_api_base_name`: `ORCAROUTER_API_BASE`
  - `provider_documentation_url`: `https://docs.orcarouter.ai`
  - Capability flags stay at the conservative registry baseline (completion, streaming, model listing). The row deliberately does **not** opt into reasoning/image/embedding/etc., because those flags are only set once exercised against the live endpoint.
- `tests/unit/providers/test_orcarouter_provider.py`: mirrors `test_ovhcloud_provider.py`, covering metadata, api-key resolution from env and explicit argument, api-base resolution (env override, default, explicit precedence), the conservative capability baseline, and registry/loader registration.

### Local verification

- `uv run pre-commit run --all-files` passes (ruff lint + format, mypy strict, codespell).
- `uv run pytest tests/unit/providers/test_orcarouter_provider.py tests/unit/test_registry.py` passes (70 passed). The full `tests/unit` run is green except for 16 pre-existing `test_anthropic_*` failures that reproduce on `main` without this change (anthropic SDK `httpx2` client-type conflict in the container's dependency set).

### Live verification

Ran against the real endpoint with `AnyLLM.create("orcarouter", ...)` (key from `ORCAROUTER_API_KEY`, redacted):

```python
resp = llm.completion(model="deepseek/deepseek-v4-flash-free", messages=[{"role": "user", "content": "Say hi in one word"}])
print(resp.choices[0].message.content)
# Hi

for chunk in llm.completion(model="deepseek/deepseek-v4-flash-free", messages=[{"role": "user", "content": "Count to 3"}], stream=True):
    print(chunk.choices[0].delta.content or "", end="")
# 1, 2, 3.

print([m.id for m in llm.list_models()][:5])
# ['orcarouter/free', 'orcarouter/fusion', 'orcarouter/fusion-flash', 'orcarouter/fusion-mini', 'orcarouter/orcacode-review']
```

## PR Type

- 🆕 New Feature

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (no docs change needed: `docs/providers.md` is generated by CI from the registry)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
  - [x] AI was used for drafting/refactoring.

## AI Usage Information

- AI Model used: Claude (Fable)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Live verification was run manually; the API key was not printed or committed.

- [x] I am an AI Agent filling out this form (check box if true)

---

I'm an engineer on the OrcaRouter team. Questions? Reach out on Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported provider.
  * Configured API key and base URL settings, with links to provider documentation.
  * Enabled standard completion, streaming, and model-listing capabilities.

* **Bug Fixes**
  * Added validation for missing API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->