### PR TITLE
docs: correct docstring defaults that disagree with the signatures

### DIFF
--- a/src/any_llm/any_llm.py
+++ b/src/any_llm/any_llm.py
@@ -1721,7 +1721,7 @@ class AnyLLM(ABC):
 
         Args:
             after: A cursor for pagination. Returns batches after this batch ID.
-            limit: Maximum number of batches to return (default: 20)
+            limit: Maximum number of batches to return. When omitted, the provider's own default applies.
             **kwargs: Additional provider-specific arguments
 
         Returns:

--- a/src/any_llm/api.py
+++ b/src/any_llm/api.py
@@ -1592,7 +1592,7 @@ def list_batches(
     Args:
         provider: Provider name to use for the request (e.g., 'openai', 'mistral')
         after: A cursor for pagination. Returns batches after this batch ID.
-        limit: Maximum number of batches to return (default: 20)
+        limit: Maximum number of batches to return. When omitted, the provider's own default applies.
         api_key: API key for the provider
         api_base: Base URL for the provider API
         client_args: Additional provider-specific arguments for client instantiation
@@ -1621,7 +1621,7 @@ async def alist_batches(
     Args:
         provider: Provider name to use for the request (e.g., 'openai', 'mistral')
         after: A cursor for pagination. Returns batches after this batch ID.
-        limit: Maximum number of batches to return (default: 20)
+        limit: Maximum number of batches to return. When omitted, the provider's own default applies.
         api_key: API key for the provider
         api_base: Base URL for the provider API
         client_args: Additional provider-specific arguments for client instantiation

--- a/src/any_llm/logging.py
+++ b/src/any_llm/logging.py
@@ -16,9 +16,9 @@ def setup_logger(
     """Configure the any_llm logger with the specified settings.
 
     Args:
-        level: The logging level to use (default: logging.INFO)
+        level: The logging level to use (default: logging.WARNING)
         rich_tracebacks: Whether to enable rich tracebacks (default: True)
-        log_format: Optional custom log format string
+        log_format: Optional custom log format string (default: None)
         propagate: Whether to propagate logs to parent loggers (default: False)
         **kwargs: Additional keyword arguments to pass to RichHandler
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->

Three docstrings state defaults that the signatures do not have. All were checked against the code before changing anything.

**`src/any_llm/logging.py`**

`setup_logger` documents `level` as `default: logging.INFO`, but the signature is `level: int = logging.WARNING`. Corrected to `logging.WARNING`. While there, `log_format` was the only parameter in that `Args:` block without a stated default, so `(default: None)` was added to match its neighbours.

**`src/any_llm/api.py` and `src/any_llm/any_llm.py`**

`list_batches` and `alist_batches` (both the module-level functions and `AnyLLM.alist_batches`) document `limit` as `(default: 20)`. The signature is `limit: int | None = None`, and 20 is not a value this library applies anywhere — it is OpenAI's server-side default, stated in a provider-neutral docstring.

Every provider omits the parameter when it is `None` and lets the provider decide:

- `providers/openai/base.py` — `limit_param = limit if limit is not None else Omit()`, so OpenAI's own default (20) applies
- `providers/mistral/mistral.py` — `page_size = limit if limit is not None else 100`
- `providers/anthropic/base.py` — `if limit: list_kwargs["limit"] = limit`
- `providers/gemini/base.py`, `providers/otari/otari.py` — both guard on `limit is not None`

So the effective default is 100 on Mistral and 20 on OpenAI. The line now reads "When omitted, the provider's own default applies", which is true for all of them.

### Checked and deliberately left alone

`_acreate_batch` in `providers/bedrock/bedrock.py`, `providers/gemini/base.py` and `providers/together/together.py` documents names that are not in the signature — `role_arn`, `output_s3_uri`, `job_name`, `model_id`, `dest`, `display_name`, `model`. These are not stale: they arrive through `**kwargs` and are read with `kwargs.pop(...)` in each method, and they are already documented under `Required keyword arguments:` / `Optional keyword arguments:` rather than under `Args:`. Nothing to fix.

`rerank` in `api.py` documents `top_n` as "Defaults to all documents". The signature is `None`, and `providers/cohere/cohere.py` only forwards `top_n` when it is not `None`, so all documents are returned. The docstring is accurate as written.

`_alist_batches` in `providers/mistral/mistral.py` documents `limit` as "Defaults to 100", which matches `page_size = limit if limit is not None else 100` in the same method. Also accurate.

## PR Type
<!-- Delete the types that don't apply -->

- 📚 Documentation

## Relevant issues
<!-- e.g. "Fixes #123" -->

None — found by sweeping docstring `Args:` blocks against the parsed signatures, not from a filed issue.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

Three boxes are left unchecked on purpose, with reasons:

- *No unit tests added.* The diff is five lines of docstring text; there is no behaviour to assert on.
- *Not run locally to verify a fix.* Nothing here executes. Each claim was verified by reading the signature and the provider implementations listed above.
- *New and existing tests pass locally.* They do not, and I would rather say so than tick the box. `uv sync --all-extras -U --python=3.13` followed by `pytest tests/unit` gives 2288 passed, 69 skipped, **16 failed**, all of them in `tests/unit/providers/test_anthropic_messages.py` and `test_anthropic_provider.py`. These are pre-existing and not caused by this PR: running those two files on a clean checkout of `main` with the change stashed gives the identical 16 failures (16 failed, 141 passed, 80 rerun), and the set of failing node IDs is the same in both runs with nothing new appearing under the change. Mentioning them here in case they are news to you — they look like a flaky-or-broken group around beta header selection and context management, unrelated to docstrings.

`ruff check` and `ruff format --check` pass on all three changed files.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used: Claude (Opus/Sonnet via Claude Code)
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The candidates came from a mechanical sweep comparing docstring `Args:` blocks against the AST-parsed signature. It produced 20 hits in this repo; 15 turned out to be false positives from the heuristic itself and were discarded after reading the surrounding code, which is what the "checked and deliberately left alone" section records. Only the five real ones are in the diff.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated batch-listing documentation to clarify that omitted limits use the provider’s default.
  * Corrected logging documentation to reflect the default warning level.
  * Documented that no log format is applied by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->