### PR TITLE
tests(anthropic): migrate transport tests to HTTPX2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ tests = [
   "mktestdocs>=0.2.4",
   "pytest-xdist>=3.6.1",
   "pytest-timeout",
+  "httpx2>=2,<3",
   "debugpy",
   "aiofiles",
 

--- a/tests/unit/providers/test_anthropic_messages.py
+++ b/tests/unit/providers/test_anthropic_messages.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 from anthropic.types import Message, TextBlock, ThinkingBlock, ToolUseBlock, Usage
 from anthropic.types.beta import BetaMCPToolUseBlock, BetaMessage, BetaThinkingBlock, BetaUsage


### PR DESCRIPTION
## Description

Use `httpx2.AsyncClient` in the complete Anthropic Messages transport test module. Anthropic 1.x rejects injected legacy `httpx.AsyncClient` instances and requires HTTPX2 request, response, mock transport, and client types to come from the same package.

The transport import covers all 15 affected call sites. The tests group now declares `httpx2>=2,<3` directly because the package's minimum `openai>=2.18.0` and `anthropic>=0.119.0` releases still depend on legacy `httpx`; relying on a newer transitive SDK dependency could make fresh development installs fail during pytest collection. HTTPX2 2.0 is the minimum release that provides the transport contract used by Anthropic 1.x. The repository ignores `uv.lock`, so the resolved local lock is verified but not committed.

Production dependencies and runtime behavior remain unchanged.

## PR Type

- 🐛 Bug Fix

## Relevant issues

No linked issue.

## Checklist

- [x] I understand the code I am submitting.
- [x] Existing tests prove the transport contract works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## Testing

- all-files pre-commit: passed, including Ruff, Ruff format, and strict mypy
- `uv lock --check`: passed, 163 packages resolved
- `uv run pytest -q tests/unit/providers/test_anthropic_messages.py tests/unit/providers/test_openai_exceptions.py`: 63 passed
- `uv run pytest tests/unit -q`: 2304 passed, 69 skipped

## AI Usage Information

- AI Model used: GPT-5.6 Sol X-HIGH
- AI Developer Tool used: Amp
- Any other info you'd like to share: Verified against the current Anthropic Python SDK 1.2.0 HTTPX2 transport contract.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provider test coverage to use the supported HTTP client package.

* **Chores**
  * Added the HTTP client package to the test dependencies.
  * No user-facing functionality or behaviour has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->