### PR TITLE
fix(bedrock): map the full Converse stopReason set to finish_reason

### DIFF
--- a/src/any_llm/providers/bedrock/utils.py
+++ b/src/any_llm/providers/bedrock/utils.py
@@ -36,6 +36,23 @@ INFERENCE_PARAMETERS = ["maxTokens", "temperature", "topP", "stopSequences"]
 # Titan, Llama, ...) have no equivalent verified mechanism, so they keep raising.
 _STRUCTURED_OUTPUT_TOOL_NAME = "any_llm_structured_output"
 
+_FinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
+
+# The Converse API reports nine stop reasons (botocore's bedrock-runtime service model, shape
+# "StopReason"). OpenAI has no counterpart for "stop_sequence", "malformed_model_output" and
+# "malformed_tool_use", so those fall through to the "stop" default along with any reason a
+# future service model adds. The rest do have one, and without it a guardrail block or a
+# context overflow looks like a normal completion to callers, including the structured-output
+# guard in any_llm.py that is supposed to raise ContentFilterFinishReasonError.
+BEDROCK_STOP_REASON_TO_FINISH_REASON: dict[str, _FinishReason] = {
+    "end_turn": "stop",
+    "max_tokens": "length",
+    "model_context_window_exceeded": "length",
+    "tool_use": "tool_calls",
+    "content_filtered": "content_filter",
+    "guardrail_intervened": "content_filter",
+}
+
 REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "minimal": 1024,
     "low": 2048,
@@ -44,6 +61,13 @@ REASONING_EFFORT_TO_THINKING_BUDGETS = {
     "xhigh": 32768,
     "max": 32768,
 }
+
+
+def _map_stop_reason(stop_reason: Any) -> _FinishReason:
+    """Map a Converse API stopReason onto the OpenAI finish_reason vocabulary."""
+    if not isinstance(stop_reason, str):
+        return "stop"
+    return BEDROCK_STOP_REASON_TO_FINISH_REASON.get(stop_reason, "stop")
 
 
 def _is_anthropic_model(model_id: str) -> bool:
@@ -521,8 +545,7 @@ def _convert_response(response: dict[str, Any]) -> ChatCompletion:
         )
 
     content = "".join(content_parts)
-    stop_reason = response.get("stopReason")
-    finish_reason: Literal["stop", "length"] = "length" if stop_reason == "max_tokens" else "stop"
+    finish_reason = _map_stop_reason(response.get("stopReason"))
 
     message = ChatCompletionMessage(
         role="assistant",
@@ -534,9 +557,7 @@ def _convert_response(response: dict[str, Any]) -> ChatCompletion:
     choices_out.append(
         Choice(
             index=0,
-            finish_reason=cast(
-                "Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call']", finish_reason
-            ),
+            finish_reason=finish_reason,
             message=message,
         )
     )
@@ -570,7 +591,7 @@ def _create_openai_chunk_from_aws_chunk(
 
     content: str | None = None
     reasoning_content: str | None = None
-    finish_reason: Literal["stop", "length", "tool_calls"] | None = None
+    finish_reason: _FinishReason | None = None
     tool_call: ChoiceDeltaToolCall | None = None
     usage: CompletionUsage | None = None
 
@@ -616,13 +637,7 @@ def _create_openai_chunk_from_aws_chunk(
                 ),
             )
     elif "messageStop" in chunk:
-        stop_reason = chunk["messageStop"]["stopReason"]
-        if stop_reason == "max_tokens":
-            finish_reason = "length"
-        elif stop_reason == "tool_use":
-            finish_reason = "tool_calls"
-        else:
-            finish_reason = "stop"
+        finish_reason = _map_stop_reason(chunk["messageStop"]["stopReason"])
     elif "messageStart" in chunk:
         content = ""
     elif "metadata" in chunk:

--- a/tests/unit/providers/test_aws_provider.py
+++ b/tests/unit/providers/test_aws_provider.py
@@ -13,7 +13,12 @@ from botocore.exceptions import ProfileNotFound
 from botocore.tokens import ScopedEnvTokenProvider
 from pydantic import BaseModel
 
-from any_llm.exceptions import InvalidRequestError, MissingApiKeyError, UnsupportedParameterError
+from any_llm.exceptions import (
+    ContentFilterFinishReasonError,
+    InvalidRequestError,
+    MissingApiKeyError,
+    UnsupportedParameterError,
+)
 from any_llm.providers.bedrock import BedrockProvider
 from any_llm.providers.bedrock.utils import (
     _STRUCTURED_OUTPUT_TOOL_NAME,
@@ -1584,3 +1589,90 @@ def test_convert_messages_merges_consecutive_user_messages() -> None:
         {"toolResult": {"toolUseId": "t1", "content": [{"text": "here"}]}},
         {"text": "what is in it"},
     ]
+
+
+def _bedrock_stop_reasons() -> tuple[str, ...]:
+    """Every stopReason the Converse API can return, read from the installed botocore service model.
+
+    Reading the enum out of the service model rather than hardcoding it means a botocore upgrade
+    that adds a stop reason fails the parametrized tests below instead of silently defaulting the
+    new reason to "stop".
+    """
+    service_model = botocore.session.Session().get_service_model("bedrock-runtime")  # type: ignore[no-untyped-call]
+    return tuple(service_model.shape_for("StopReason").enum)
+
+
+_EXPECTED_FINISH_REASONS = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "malformed_model_output": "stop",
+    "malformed_tool_use": "stop",
+    "max_tokens": "length",
+    "model_context_window_exceeded": "length",
+    "tool_use": "tool_calls",
+    "content_filtered": "content_filter",
+    "guardrail_intervened": "content_filter",
+}
+
+
+@pytest.mark.parametrize("stop_reason", _bedrock_stop_reasons())
+def test_convert_response_maps_every_bedrock_stop_reason(stop_reason: str) -> None:
+    """Every stopReason the Converse API can return needs an explicit OpenAI finish_reason.
+
+    An unmapped one falls back to "stop", which tells callers the model answered normally when it
+    was actually blocked by a guardrail or ran out of context.
+    """
+    assert stop_reason in _EXPECTED_FINISH_REASONS, (
+        f"New Bedrock stop reason {stop_reason!r} needs a finish_reason mapping."
+    )
+
+    response: dict[str, Any] = {
+        "output": {"message": {"content": [{"text": "Hello!"}]}},
+        "stopReason": stop_reason,
+    }
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == _EXPECTED_FINISH_REASONS[stop_reason]
+
+
+@pytest.mark.parametrize("stop_reason", _bedrock_stop_reasons())
+def test_streaming_chunk_maps_every_bedrock_stop_reason(stop_reason: str) -> None:
+    """The streaming path must agree with the non-streaming one on every stopReason."""
+    result = _create_openai_chunk_from_aws_chunk({"messageStop": {"stopReason": stop_reason}}, "test-model")
+
+    assert result is not None
+    assert result.choices[0].finish_reason == _EXPECTED_FINISH_REASONS[stop_reason]
+
+
+def test_convert_response_without_stop_reason_finishes_as_stop() -> None:
+    """A response with no stopReason at all still needs a valid finish_reason."""
+    response: dict[str, Any] = {"output": {"message": {"content": [{"text": "Hello!"}]}}}
+
+    result = _convert_response(response)
+
+    assert result.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_blocked_structured_output_raises_content_filter_error() -> None:
+    """A guardrail block on a structured-output call must reach the caller as a typed error.
+
+    While guardrail_intervened mapped to "stop", the content_filter guard in
+    AnyLLM.acompletion never fired and the guardrail's blocked-message prose was handed to the
+    JSON parser instead, so callers saw a pydantic ValidationError from an unrelated layer.
+    """
+    custom_client = Mock()
+    custom_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "Sorry, I cannot answer that."}]}},
+        "stopReason": "guardrail_intervened",
+    }
+
+    provider = BedrockProvider(client=custom_client)
+
+    with pytest.raises(ContentFilterFinishReasonError):
+        await provider.acompletion(
+            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            messages=[{"role": "user", "content": "Hello"}],
+            response_format=_City,
+        )


### PR DESCRIPTION
## Description

The Bedrock provider maps only three of the Converse API's nine `stopReason` values, so a guardrail-blocked or context-overflowed response reaches the caller as an ordinary `finish_reason="stop"`.

`src/any_llm/providers/bedrock/utils.py:517` (non-streaming):

```python
finish_reason: Literal["stop", "length"] = "length" if stop_reason == "max_tokens" else "stop"
```

and `:611-617` (streaming) handles `max_tokens` and `tool_use` and sends everything else to `"stop"`.

The visible failure is the structured-output guard in `src/any_llm/any_llm.py:798-806`. When a Bedrock Guardrail blocks a response, Converse returns `stopReason="guardrail_intervened"` with the guardrail's blocked-message text as content. Because that arrives as `finish_reason="stop"`, the `content_filter` branch never fires and the guardrail's prose is handed to `parse_json_content()` instead, so the caller gets a pydantic `ValidationError` from an unrelated layer rather than the `ContentFilterFinishReasonError` this library raises for every other provider. `content_filtered` behaves the same way, and `model_context_window_exceeded` reports as `"stop"` rather than `"length"`.

This is the same fix already merged for gemini (#1202), zai (#1204), cohere (#1301) and anthropic (#1306/#1328). Bedrock was the last provider still hardcoding a partial mapping, so this follows `ANTHROPIC_STOP_REASON_TO_FINISH_REASON` in shape and naming:

```python
BEDROCK_STOP_REASON_TO_FINISH_REASON: dict[str, _FinishReason] = {
    "end_turn": "stop",
    "max_tokens": "length",
    "model_context_window_exceeded": "length",
    "tool_use": "tool_calls",
    "content_filtered": "content_filter",
    "guardrail_intervened": "content_filter",
}
```

`stop_sequence`, `malformed_model_output` and `malformed_tool_use` have no OpenAI counterpart and keep falling through to the `"stop"` default, as do any values a future service model adds. Both call sites now go through one `_map_stop_reason()` helper, which also lets the `cast` at the non-streaming call site go away.

The nine-value enum is not taken from the AWS docs prose. It is read out of the installed botocore service model (`bedrock-runtime`, shape `StopReason`), which is the same source the SDK validates against:

```python
>>> import botocore.session
>>> botocore.session.Session().get_service_model("bedrock-runtime").shape_for("StopReason").enum
['end_turn', 'tool_use', 'max_tokens', 'stop_sequence', 'guardrail_intervened', 'content_filtered',
 'malformed_model_output', 'malformed_tool_use', 'model_context_window_exceeded']
```

The tests read the enum from that same service model and parametrize over it, so a botocore upgrade that adds a stop reason fails the suite instead of silently defaulting the new reason to `"stop"`.

## Reproduction

```python
import asyncio
from unittest.mock import Mock

from pydantic import BaseModel

from any_llm.exceptions import ContentFilterFinishReasonError
from any_llm.providers.bedrock import BedrockProvider


class City(BaseModel):
    name: str


# What Converse returns when a Bedrock Guardrail blocks the response.
blocked = {
    "output": {"message": {"content": [{"text": "Sorry, I cannot answer that."}]}},
    "stopReason": "guardrail_intervened",
}

client = Mock()
client.converse.return_value = blocked
provider = BedrockProvider(client=client)

print("finish_reason:", provider._convert_completion_response(blocked).choices[0].finish_reason)

try:
    asyncio.run(
        provider.acompletion(
            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
            messages=[{"role": "user", "content": "Hello"}],
            response_format=City,
        )
    )
except Exception as exc:
    print("raised:", type(exc).__name__)
```

Before:

```
finish_reason: stop
raised: ValidationError
```

After:

```
finish_reason: content_filter
raised: ContentFilterFinishReasonError
```

## Tests

Added to `tests/unit/providers/test_aws_provider.py`:

- `test_convert_response_maps_every_bedrock_stop_reason` and `test_streaming_chunk_maps_every_bedrock_stop_reason`, parametrized over the full botocore `StopReason` enum, asserting both paths agree.
- `test_convert_response_without_stop_reason_finishes_as_stop`.
- `test_guardrail_blocked_structured_output_raises_content_filter_error`, the end-to-end case above.

On the unfixed tree these fail:

```
FAILED test_convert_response_maps_every_bedrock_stop_reason[tool_use]
FAILED test_convert_response_maps_every_bedrock_stop_reason[guardrail_intervened]
FAILED test_convert_response_maps_every_bedrock_stop_reason[content_filtered]
FAILED test_convert_response_maps_every_bedrock_stop_reason[model_context_window_exceeded]
FAILED test_streaming_chunk_maps_every_bedrock_stop_reason[guardrail_intervened]
FAILED test_streaming_chunk_maps_every_bedrock_stop_reason[content_filtered]
FAILED test_streaming_chunk_maps_every_bedrock_stop_reason[model_context_window_exceeded]
FAILED test_guardrail_blocked_structured_output_raises_content_filter_error
8 failed, 12 passed
```

With the fix, `uv run pytest tests/unit/providers/test_aws_provider.py` → 116 passed.

The `[tool_use]` case is the one behaviour change beyond the three broken reasons: a `stopReason="tool_use"` response that carries no `toolUse` block now reports `"tool_calls"` instead of `"stop"`. Both real `tool_use` shapes (a genuine tool call, and the synthetic `any_llm_structured_output` unwrap) return earlier in `_convert_response` and are untouched.

## PR Type

- 🐛 Bug Fix

## Relevant issues

No open issue. Same fix as #1202 / #1204 / #1301 / #1328, applied to the remaining provider.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary (no user-facing API changed)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## Verification

- `uv run pre-commit run --all-files` (ruff, ruff-format, mypy, codespell) clean.
- `uv run pytest tests/unit/providers/test_aws_provider.py` → 116 passed.
- `uv run pytest tests/unit` → 2308 passed, 69 skipped, 16 failed. All 16 failures are in `test_anthropic_messages.py` / `test_anthropic_provider.py` and reproduce identically on an unmodified `main` in this environment: `TypeError: Invalid 'http_client' argument; Expected an instance of httpx2.AsyncClient but got <class 'httpx.AsyncClient'>`, from what a local `uv sync --all-extras -U` resolves. Nothing bedrock-related.
- No integration run: I do not have AWS Bedrock credentials, and the two Bedrock paths this touches are pure response converters exercised by the unit tests above against service-model-sourced stop reasons.

## AI Usage Information

- AI Model used: Claude Opus 5
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: The stop-reason enum was read from the installed botocore service model rather than the AWS docs, and the tests read it from the same place so the list cannot drift.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Amazon Bedrock response handling for length limits, tool calls, and content-filter outcomes.
  * Standardised finish reasons across streaming and non-streaming responses.
  * Unknown or unsupported stop reasons now safely default to `stop`.
  * Structured-output requests blocked by a Bedrock guardrail now report a content-filter error correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->