### PR TITLE
test(integration): filter tool args to function signature in agent loop

### DIFF
--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -33,6 +33,31 @@ def get_weather(location: str) -> str:
     return json.dumps({"location": location, "temperature": "15C", "condition": "sunny"})
 
 
+def filter_tool_args(tool_fn: Callable[..., str], args: dict[str, Any]) -> dict[str, Any]:
+    """Keep only arguments accepted by ``tool_fn`` unless it accepts ``**kwargs``."""
+    sig = inspect.signature(tool_fn)
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()):
+        return args
+    return {key: value for key, value in args.items() if key in sig.parameters}
+
+
+def get_weather_with_extras(location: str, **kwargs: Any) -> str:
+    """Get the weather for a location, forwarding extra model-supplied keys."""
+    payload: dict[str, Any] = {"location": location, "temperature": "15C", "condition": "sunny"}
+    payload.update(kwargs)
+    return json.dumps(payload)
+
+
+def test_filter_tool_args_var_keyword_forwards_extra_keys() -> None:
+    args = {"location": "Paris", "unexpected_key": "ignored-by-strict-tools"}
+    assert filter_tool_args(get_weather_with_extras, args) == args
+
+
+def test_filter_tool_args_strict_signature_drops_extra_keys() -> None:
+    args = {"location": "Paris", "unexpected_key": "drop-me"}
+    assert filter_tool_args(get_weather, args) == {"location": "Paris"}
+
+
 @pytest.mark.asyncio
 async def test_agent_loop_parallel_tool_calls(
     provider: LLMProvider,
@@ -156,18 +181,7 @@ async def test_agent_loop_sequential_tool_calls(
                 tool_fn = available_tools[tool_name]
 
                 args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                sig = inspect.signature(tool_fn)
-                if any(
-                    param.kind == inspect.Parameter.VAR_KEYWORD
-                    for param in sig.parameters.values()
-                ):
-                    filtered_args = args
-                else:
-                    filtered_args = {
-                        key: value
-                        for key, value in args.items()
-                        if key in sig.parameters
-                    }
+                filtered_args = filter_tool_args(tool_fn, args)
                 tool_result = tool_fn(**filtered_args)
 
                 messages.append(

--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -14,8 +15,6 @@ from any_llm.exceptions import MissingApiKeyError
 from tests.constants import EXPECTED_PROVIDERS, LOCAL_PROVIDERS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from any_llm.types.completion import ChatCompletion, ChatCompletionMessage
 
 

--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -155,7 +156,19 @@ async def test_agent_loop_sequential_tool_calls(
                 tool_fn = available_tools[tool_name]
 
                 args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                tool_result = tool_fn(**args)
+                sig = inspect.signature(tool_fn)
+                if any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD
+                    for param in sig.parameters.values()
+                ):
+                    filtered_args = args
+                else:
+                    filtered_args = {
+                        key: value
+                        for key, value in args.items()
+                        if key in sig.parameters
+                    }
+                tool_result = tool_fn(**filtered_args)
 
                 messages.append(
                     {


### PR DESCRIPTION
## Description
Filter tool call arguments to the target function signature before invoking tools in the integration agent loop test harness. Avoids flaky failures when models emit extra keys the tool function does not accept.

## PR Type
- 🐛 Bug Fix

## Relevant issues
Fixes #1170

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
- AI Model used: Claude (Cursor)
- AI Developer Tool used: Cursor
- All changes reviewed by the contributor before submission.

## Test plan
- [x] Added unit tests covering strict signatures vs `**kwargs` forwarding
- [x] Sequential agent-loop harness uses shared `filter_tool_args` helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequential tool execution by ignoring unsupported arguments before invoking tools.
  * Preserved additional arguments for tools that explicitly support flexible keyword inputs.
  * Added coverage to verify both strict and flexible tool argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->