### PR TITLE
Replace retired models in integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.VERTEXAI: "gemini-2.5-flash",
         LLMProvider.GITHUB: "openai/gpt-4.1-nano",
         LLMProvider.GROQ: "openai/gpt-oss-20b",
-        LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-20b",
+        LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-120b",
         LLMProvider.OPENAI: "gpt-5-nano",
         # magistral-medium-latest / magistral-small-latest (native reasoning models) are
         # deprecated; mistral-medium-3-5 supports adjustable reasoning via reasoning_effort
@@ -106,7 +106,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.GMI: "zai-org/GLM-5-FP8",
         LLMProvider.GITHUB: "openai/gpt-4.1-nano",
         LLMProvider.VERTEXAI: "gemini-3-flash-preview",
-        LLMProvider.MOONSHOT: "moonshot-v1-8k",
+        LLMProvider.MOONSHOT: "kimi-k2.6",
         LLMProvider.SAMBANOVA: "gpt-oss-120b",
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
         LLMProvider.XAI: "grok-3-mini-latest",
@@ -126,7 +126,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.BEDROCK: "amazon.nova-lite-v1:0",
         LLMProvider.SAGEMAKER: "<sagemaker_endpoint_name>",
         LLMProvider.WATSONX: "ibm/granite-3-8b-instruct",
-        LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-20b",
+        LLMProvider.FIREWORKS: "accounts/fireworks/models/gpt-oss-120b",
         LLMProvider.GROQ: "openai/gpt-oss-20b",
         LLMProvider.PORTKEY: "@any-llm-test/gpt-4.1-mini",
         LLMProvider.LLAMA: "Llama-4-Maverick-17B-128E-Instruct-FP8",


### PR DESCRIPTION
## Description

Replaces retired models from a few providers in integration tests. Specifically:

* For Moonshot, `moonshot-v1-8k` has been replaced with `kimi-k2.6`.
* For Fireworks, `accounts/fireworks/models/gpt-oss-20b` has been replaced with `accounts/fireworks/models/gpt-oss-120b`

## PR Type
<!-- Delete the types that don't apply -->

- 🚦 Infrastructure

## Relevant issues

Impacts current main.

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [x] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated test coverage to reflect the latest supported model names for Fireworks and Moonshot.
  * Fireworks coverage now uses GPT-OSS-120B for reasoning and standard scenarios.
  * Moonshot coverage now uses Kimi K2.6, helping keep validation aligned with current model behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->