### PR TITLE
fix(anthropic): support JSON Schema type arrays

### DIFF
--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -480,6 +480,28 @@ def _convert_tool_choice(params: CompletionParams) -> dict[str, Any]:
     return {"type": tool_choice, "disable_parallel_tool_use": not parallel_tool_calls}
 
 
+def _normalize_anthropic_type_arrays(value: Any) -> Any:
+    """Rewrite JSON Schema type arrays that ``anthropic.transform_schema`` rejects."""
+    if isinstance(value, list):
+        return [_normalize_anthropic_type_arrays(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    type_value = value.get("type")
+    if not isinstance(type_value, list):
+        return {key: _normalize_anthropic_type_arrays(item) for key, item in value.items()}
+    if not type_value or not all(isinstance(item, str) for item in type_value):
+        msg = "JSON Schema type arrays must contain at least one string type"
+        raise ValueError(msg)
+
+    siblings = {key: item for key, item in value.items() if key != "type"}
+    return {
+        "anyOf": [
+            _normalize_anthropic_type_arrays({"type": item, **siblings}) for item in cast("list[str]", type_value)
+        ]
+    }
+
+
 def _convert_response_format(response_format: dict[str, Any] | type, provider_name: str) -> dict[str, Any]:
     """Convert any-llm response_format to Anthropic's output_config."""
     if is_structured_output_type(response_format):
@@ -501,7 +523,12 @@ def _convert_response_format(response_format: dict[str, Any] | type, provider_na
         msg = f"Unsupported response_format: {response_format}"
         raise ValueError(msg)
 
-    return {"format": {"type": "json_schema", "schema": transform_schema(schema)}}
+    return {
+        "format": {
+            "type": "json_schema",
+            "schema": transform_schema(_normalize_anthropic_type_arrays(schema)),
+        }
+    }
 
 
 def _convert_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -65,7 +65,8 @@ _JSON_SCHEMA_MAPPING_KEYWORDS = frozenset(
         "properties",
     }
 )
-_JSON_SCHEMA_SEQUENCE_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_JSON_SCHEMA_COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf")
+_JSON_SCHEMA_SEQUENCE_KEYWORDS = frozenset((*_JSON_SCHEMA_COMPOSITION_KEYWORDS, "prefixItems"))
 _JSON_SCHEMA_VALUE_KEYWORDS = frozenset(
     {
         "additionalItems",
@@ -532,8 +533,21 @@ def _normalize_anthropic_type_arrays(value: Any) -> Any:
         msg = "JSON Schema type arrays must contain at least one string type"
         raise ValueError(msg)
 
-    siblings = {key: item for key, item in normalized.items() if key != "type"}
-    return {"anyOf": [{"type": item, **siblings} for item in cast("list[str]", type_value)]}
+    composition_constraints = [
+        {keyword: normalized[keyword]} for keyword in _JSON_SCHEMA_COMPOSITION_KEYWORDS if keyword in normalized
+    ]
+    branch_siblings = {
+        key: item
+        for key, item in normalized.items()
+        if key not in {"type", "$defs", *_JSON_SCHEMA_COMPOSITION_KEYWORDS}
+    }
+    type_union: dict[str, Any] = {
+        "anyOf": [{"type": item, **branch_siblings} for item in cast("list[str]", type_value)]
+    }
+    root_keywords: dict[str, Any] = {"$defs": normalized["$defs"]} if "$defs" in normalized else {}
+    if composition_constraints:
+        return {**root_keywords, "allOf": [type_union, *composition_constraints]}
+    return {**root_keywords, **type_union}
 
 
 def _convert_response_format(response_format: dict[str, Any] | type, provider_name: str) -> dict[str, Any]:

--- a/src/any_llm/providers/anthropic/utils.py
+++ b/src/any_llm/providers/anthropic/utils.py
@@ -55,6 +55,33 @@ REASONING_EFFORT_TO_ANTHROPIC_EFFORT = {
     "max": "max",
 }
 
+_JSON_SCHEMA_MAPPING_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "definitions",
+        "dependencies",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    }
+)
+_JSON_SCHEMA_SEQUENCE_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_JSON_SCHEMA_VALUE_KEYWORDS = frozenset(
+    {
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+
 
 def _refusal_stop_details(value: object) -> dict[str, Any] | None:
     """Return typed Anthropic refusal details when the installed SDK exposes them."""
@@ -480,26 +507,33 @@ def _convert_tool_choice(params: CompletionParams) -> dict[str, Any]:
     return {"type": tool_choice, "disable_parallel_tool_use": not parallel_tool_calls}
 
 
+def _normalize_anthropic_schema_keyword(keyword: str, value: Any) -> Any:
+    if keyword in _JSON_SCHEMA_MAPPING_KEYWORDS and isinstance(value, dict):
+        return {name: _normalize_anthropic_type_arrays(schema) for name, schema in value.items()}
+    if keyword in _JSON_SCHEMA_SEQUENCE_KEYWORDS and isinstance(value, list):
+        return [_normalize_anthropic_type_arrays(schema) for schema in value]
+    if keyword == "items" and isinstance(value, list):
+        return [_normalize_anthropic_type_arrays(schema) for schema in value]
+    if keyword == "items" or keyword in _JSON_SCHEMA_VALUE_KEYWORDS:
+        return _normalize_anthropic_type_arrays(value)
+    return value
+
+
 def _normalize_anthropic_type_arrays(value: Any) -> Any:
     """Rewrite JSON Schema type arrays that ``anthropic.transform_schema`` rejects."""
-    if isinstance(value, list):
-        return [_normalize_anthropic_type_arrays(item) for item in value]
     if not isinstance(value, dict):
         return value
 
+    normalized = {key: _normalize_anthropic_schema_keyword(key, item) for key, item in value.items()}
     type_value = value.get("type")
     if not isinstance(type_value, list):
-        return {key: _normalize_anthropic_type_arrays(item) for key, item in value.items()}
+        return normalized
     if not type_value or not all(isinstance(item, str) for item in type_value):
         msg = "JSON Schema type arrays must contain at least one string type"
         raise ValueError(msg)
 
-    siblings = {key: item for key, item in value.items() if key != "type"}
-    return {
-        "anyOf": [
-            _normalize_anthropic_type_arrays({"type": item, **siblings}) for item in cast("list[str]", type_value)
-        ]
-    }
+    siblings = {key: item for key, item in normalized.items() if key != "type"}
+    return {"anyOf": [{"type": item, **siblings} for item in cast("list[str]", type_value)]}
 
 
 def _convert_response_format(response_format: dict[str, Any] | type, provider_name: str) -> dict[str, Any]:

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -745,6 +745,38 @@ def test_normalize_anthropic_type_arrays_preserves_composition_keywords() -> Non
     }
 
 
+def test_normalize_anthropic_type_arrays_preserves_instance_values() -> None:
+    schema = {
+        "type": "object",
+        "examples": [{"type": []}],
+        "default": {"type": ["string", "null"]},
+        "const": {"type": ["integer", "null"]},
+        "enum": [{"type": []}, {"type": ["number", "null"]}],
+    }
+
+    assert _normalize_anthropic_type_arrays(schema) == schema
+
+
+def test_normalize_anthropic_type_arrays_recurses_only_through_subschemas() -> None:
+    schema = {
+        "$defs": {"optionalName": {"type": ["string", "null"]}},
+        "allOf": [{"properties": {"count": {"type": ["integer", "null"]}}}],
+        "items": {"type": ["boolean", "null"]},
+    }
+
+    assert _normalize_anthropic_type_arrays(schema) == {
+        "$defs": {"optionalName": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        "allOf": [
+            {
+                "properties": {
+                    "count": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                }
+            }
+        ],
+        "items": {"anyOf": [{"type": "boolean"}, {"type": "null"}]},
+    }
+
+
 @pytest.mark.parametrize(
     ("type_schema", "error"),
     [

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -723,7 +723,7 @@ def test_convert_response_format_normalizes_type_arrays() -> None:
     assert result["format"]["schema"]["properties"]["answer"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
 
 
-def test_normalize_anthropic_type_arrays_preserves_composition_keywords() -> None:
+def test_normalize_anthropic_type_arrays_separates_composition_keywords() -> None:
     schema = {
         "type": ["string", "null"],
         "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
@@ -732,15 +732,33 @@ def test_normalize_anthropic_type_arrays_preserves_composition_keywords() -> Non
     result = _normalize_anthropic_type_arrays(schema)
 
     assert result == {
-        "anyOf": [
-            {
-                "type": "string",
-                "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
-            },
-            {
-                "type": "null",
-                "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
-            },
+        "allOf": [
+            {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            {"anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}]},
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("composition_keyword", "transformed_keyword"),
+    [("anyOf", "anyOf"), ("oneOf", "anyOf"), ("allOf", "allOf")],
+)
+def test_convert_response_format_keeps_type_arrays_separate_from_composition(
+    composition_keyword: str,
+    transformed_keyword: str,
+) -> None:
+    variants = [{"type": "string"}, {"type": "integer"}]
+    schema = {"type": ["string", "null"], composition_keyword: variants}
+
+    result = _convert_response_format(
+        {"type": "json_schema", "json_schema": {"name": "Composed", "schema": schema}},
+        "anthropic",
+    )
+
+    assert result["format"]["schema"] == {
+        "allOf": [
+            {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            {transformed_keyword: variants},
         ]
     }
 

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -21,6 +21,7 @@ from any_llm.providers.anthropic.utils import (
     _convert_models_list,
     _convert_response_format,
     _convert_tool_spec,
+    _normalize_anthropic_type_arrays,
 )
 from any_llm.types.completion import ChatCompletionMessageFunctionToolCall, CompletionParams, ReasoningEffort
 
@@ -701,6 +702,61 @@ async def test_completion_with_response_format_dict_json_schema() -> None:
 
         call_kwargs = mock_anthropic.return_value.messages.create.call_args[1]
         assert call_kwargs["output_config"] == {"format": {"type": "json_schema", "schema": transform_schema(schema)}}
+
+
+def test_convert_response_format_normalizes_type_arrays() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string"},
+            "answer": {"type": ["string", "null"]},
+        },
+        "required": ["code", "answer"],
+        "additionalProperties": False,
+    }
+
+    result = _convert_response_format(
+        {"type": "json_schema", "json_schema": {"name": "CodeStep", "schema": schema}},
+        "anthropic",
+    )
+
+    assert result["format"]["schema"]["properties"]["answer"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
+
+
+def test_normalize_anthropic_type_arrays_preserves_composition_keywords() -> None:
+    schema = {
+        "type": ["string", "null"],
+        "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
+    }
+
+    result = _normalize_anthropic_type_arrays(schema)
+
+    assert result == {
+        "anyOf": [
+            {
+                "type": "string",
+                "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
+            },
+            {
+                "type": "null",
+                "anyOf": [{"type": "string", "maxLength": 20}, {"type": "null"}],
+            },
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("type_schema", "error"),
+    [
+        ({"type": []}, "at least one string type"),
+        ({"type": ["string", 1]}, "at least one string type"),
+    ],
+)
+def test_convert_response_format_rejects_invalid_type_arrays(type_schema: dict[str, Any], error: str) -> None:
+    response_format = {"type": "json_schema", "json_schema": {"name": "Invalid", "schema": type_schema}}
+
+    with pytest.raises(ValueError, match=error):
+        _convert_response_format(response_format, "anthropic")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Anthropic SDK 1.0 raises an assertion when `transform_schema()` receives the valid JSON Schema multi-type form such as `{"type": ["string", "null"]}`.

This change rewrites type arrays to an equivalent `anyOf` before calling the SDK transformer. It recursively handles nested schemas through schema-bearing keywords, preserves sibling constraints and composition keywords, and leaves instance-valued fields such as `examples`, `default`, `const`, and `enum` unchanged. Invalid empty or non-string type arrays fail with a clear `ValueError`.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

Validation:

- `UV_SYSTEM_PYTHON=0 uv run pre-commit run --all-files --verbose`
- `uv run pytest tests/unit -q --reruns 0`: 2384 passed, 67 skipped
- Live Anthropic request with `claude-haiku-4-5` and a nullable type-array response schema

## AI Usage Information

- AI Model used: GPT-5 Codex
- AI Developer Tool used: Codex
- Any other info you would like to share: AI assisted with rebasing, compatibility analysis, test refinement, review fixes, and PR preparation.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Anthropic response formats using JSON Schema type arrays.
  * Converted supported type arrays into equivalent union schemas, including nested schemas and compositions.
  * Preserved schema values such as examples, defaults, constants and enumerations during normalisation.
  * Added validation for invalid or empty type arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->