### PR TITLE
fix(deepseek): align the current V4 Chat contract

### DIFF
--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -14,15 +14,19 @@ from any_llm.providers.deepseek.utils import (
 from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, ReasoningEffort
 
-# DeepSeek Chat accepts low, high, and max. Its compatibility mapping collapses medium and
-# xhigh to high. OpenAI's minimal value is not part of the DeepSeek Chat contract.
+# Each entry maps an any-llm effort to DeepSeek's top-level effort and thinking toggle.
+# DeepSeek Chat accepts low, high, and max, maps medium and xhigh to high, and does not
+# accept OpenAI's minimal value.
 # https://api-docs.deepseek.com/guides/thinking_mode/
-_REASONING_EFFORT_MAP: dict[ReasoningEffort, str] = {
-    "low": "low",
-    "medium": "high",
-    "high": "high",
-    "xhigh": "high",
-    "max": "max",
+_REASONING_CONTROLS: dict[ReasoningEffort | None, tuple[str | None, str | None]] = {
+    None: (None, None),
+    "auto": (None, None),
+    "none": (None, "disabled"),
+    "low": ("low", "enabled"),
+    "medium": ("high", "enabled"),
+    "high": ("high", "enabled"),
+    "xhigh": ("high", "enabled"),
+    "max": ("max", "enabled"),
 }
 
 # These normalized fields are absent from the current DeepSeek Chat schema, except for the two
@@ -36,7 +40,6 @@ _UNSUPPORTED_DEEPSEEK_FIELDS = frozenset(
         "n",
         "parallel_tool_calls",
         "presence_penalty",
-        "prompt_cache_key",
         "seed",
         "service_tier",
     }
@@ -73,17 +76,14 @@ class DeepseekProvider(BaseOpenAIProvider):
             converted_params.pop(field, None)
 
         converted_params.pop("reasoning_effort", None)
-        reasoning_effort = params.reasoning_effort
-        thinking: dict[str, str] | None = None
-        if reasoning_effort == "none":
-            thinking = {"type": "disabled"}
-        elif reasoning_effort not in (None, "auto"):
-            mapped_effort = _REASONING_EFFORT_MAP.get(reasoning_effort)
-            if mapped_effort is None:
-                msg = f"reasoning_effort {reasoning_effort!r} is not supported by DeepSeek Chat"
-                raise InvalidRequestError(msg, provider_name=DeepseekProvider.PROVIDER_NAME)
-            converted_params["reasoning_effort"] = mapped_effort
-            thinking = {"type": "enabled"}
+        controls = _REASONING_CONTROLS.get(params.reasoning_effort)
+        if controls is None:
+            msg = f"reasoning_effort {params.reasoning_effort!r} is not supported by DeepSeek Chat"
+            raise InvalidRequestError(msg, provider_name=DeepseekProvider.PROVIDER_NAME)
+        reasoning_effort, thinking_type = controls
+        if reasoning_effort is not None:
+            converted_params["reasoning_effort"] = reasoning_effort
+        thinking = {"type": thinking_type} if thinking_type is not None else None
 
         if user_id is not None or thinking is not None:
             extra_body = converted_params.get("extra_body")
@@ -96,7 +96,7 @@ class DeepseekProvider(BaseOpenAIProvider):
                 if re.fullmatch(r"[a-zA-Z0-9_-]{1,512}", user_id) is None:
                     msg = (
                         "DeepSeek user_id must contain only ASCII letters, digits, underscores, or hyphens "
-                        "and be at most 512 characters"
+                        "and be between 1 and 512 characters"
                     )
                     raise InvalidRequestError(msg, provider_name=DeepseekProvider.PROVIDER_NAME)
                 extra_body["user_id"] = user_id

--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -85,9 +86,20 @@ class DeepseekProvider(BaseOpenAIProvider):
             thinking = {"type": "enabled"}
 
         if user_id is not None or thinking is not None:
-            extra_body = converted_params.setdefault("extra_body", {})
-            if user_id is not None:
-                extra_body.setdefault("user_id", user_id)
+            extra_body = converted_params.get("extra_body")
+            if extra_body is None:
+                extra_body = {}
+                converted_params["extra_body"] = extra_body
+            if user_id is not None and "user_id" not in extra_body:
+                # DeepSeek's user_id contract is stricter than any-llm's shared user field.
+                # https://api-docs.deepseek.com/quick_start/rate_limit/#setting-user_id
+                if re.fullmatch(r"[a-zA-Z0-9_-]{1,512}", user_id) is None:
+                    msg = (
+                        "DeepSeek user_id must contain only ASCII letters, digits, underscores, or hyphens "
+                        "and be at most 512 characters"
+                    )
+                    raise InvalidRequestError(msg, provider_name=DeepseekProvider.PROVIDER_NAME)
+                extra_body["user_id"] = user_id
             if thinking is not None:
                 extra_body.setdefault("thinking", thinking)
         return converted_params

--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from typing_extensions import override
 
+from any_llm.exceptions import InvalidRequestError
 from any_llm.providers.deepseek.utils import (
     _inject_cached_tokens,
     _inject_cached_tokens_chunk,
@@ -10,13 +11,35 @@ from any_llm.providers.deepseek.utils import (
     _preprocess_messages,
 )
 from any_llm.providers.openai.base import BaseOpenAIProvider
-from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams
+from any_llm.types.completion import ChatCompletion, ChatCompletionChunk, CompletionParams, ReasoningEffort
 
-# The two legacy API model names being discontinued 2026-07-24 in favor of deepseek-v4-flash /
-# deepseek-v4-pro. See https://api-docs.deepseek.com/updates/#date-2026-04-24. They hard-code
-# their own thinking behavior (non-thinking / thinking respectively) and don't need, and may not
-# accept, the `thinking` request toggle added below for the new model family.
-_LEGACY_MODEL_IDS = frozenset({"deepseek-chat", "deepseek-reasoner"})
+# DeepSeek Chat accepts low, high, and max. Its compatibility mapping collapses medium and
+# xhigh to high. OpenAI's minimal value is not part of the DeepSeek Chat contract.
+# https://api-docs.deepseek.com/guides/thinking_mode/
+_REASONING_EFFORT_MAP: dict[ReasoningEffort, str] = {
+    "low": "low",
+    "medium": "high",
+    "high": "high",
+    "xhigh": "high",
+    "max": "max",
+}
+
+# These normalized fields are absent from the current DeepSeek Chat schema, except for the two
+# penalty fields, which the API marks deprecated and ineffective. They remain accepted by
+# any_llm's shared interface for compatibility but are not sent to DeepSeek.
+# https://api-docs.deepseek.com/api/create-chat-completion
+_UNSUPPORTED_DEEPSEEK_FIELDS = frozenset(
+    {
+        "frequency_penalty",
+        "logit_bias",
+        "n",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "prompt_cache_key",
+        "seed",
+        "service_tier",
+    }
+)
 
 
 class DeepseekProvider(BaseOpenAIProvider):
@@ -36,25 +59,37 @@ class DeepseekProvider(BaseOpenAIProvider):
     def _convert_completion_params(params: CompletionParams, **kwargs: Any) -> dict[str, Any]:
         """DeepSeek only accepts ``max_tokens``, not ``max_completion_tokens``.
 
-        Also maps ``reasoning_effort`` to DeepSeek's ``thinking`` toggle for the V4 model
-        family. DeepSeek's V4 models default to thinking mode ENABLED when the toggle is
-        omitted from the request (see https://api-docs.deepseek.com/guides/thinking_mode), so
-        any_llm explicitly defaults it to disabled here -- matching the legacy ``deepseek-chat``
-        behavior -- unless the caller opts in via ``reasoning_effort``. A caller-supplied
-        ``extra_body`` override is respected and not clobbered.
+        DeepSeek's V4 models default to enabled thinking with high effort, so ``None`` and the
+        normalized ``auto`` sentinel leave both controls absent. An explicit ``none`` uses the
+        provider's thinking toggle. Caller-supplied ``extra_body`` values take precedence.
         """
         converted_params = BaseOpenAIProvider._convert_completion_params(params, **kwargs)
         if "max_completion_tokens" in converted_params:
             converted_params["max_tokens"] = converted_params.pop("max_completion_tokens")
 
-        if params.model_id not in _LEGACY_MODEL_IDS:
-            # ``"auto"`` means "no explicit reasoning requested" (BaseOpenAIProvider._acompletion
-            # normalizes it to this provider's default before we run), so it is treated the same
-            # as ``None``/``"none"`` here -- matching every other provider's converter and keeping
-            # this self-contained even if called directly with ``"auto"``.
-            thinking_disabled = params.reasoning_effort in (None, "none", "auto")
+        user_id = converted_params.pop("user", None)
+        for field in _UNSUPPORTED_DEEPSEEK_FIELDS:
+            converted_params.pop(field, None)
+
+        converted_params.pop("reasoning_effort", None)
+        reasoning_effort = params.reasoning_effort
+        thinking: dict[str, str] | None = None
+        if reasoning_effort == "none":
+            thinking = {"type": "disabled"}
+        elif reasoning_effort not in (None, "auto"):
+            mapped_effort = _REASONING_EFFORT_MAP.get(reasoning_effort)
+            if mapped_effort is None:
+                msg = f"reasoning_effort {reasoning_effort!r} is not supported by DeepSeek Chat"
+                raise InvalidRequestError(msg, provider_name=DeepseekProvider.PROVIDER_NAME)
+            converted_params["reasoning_effort"] = mapped_effort
+            thinking = {"type": "enabled"}
+
+        if user_id is not None or thinking is not None:
             extra_body = converted_params.setdefault("extra_body", {})
-            extra_body.setdefault("thinking", {"type": "disabled" if thinking_disabled else "enabled"})
+            if user_id is not None:
+                extra_body.setdefault("user_id", user_id)
+            if thinking is not None:
+                extra_body.setdefault("thinking", thinking)
         return converted_params
 
     @staticmethod

--- a/src/any_llm/providers/deepseek/deepseek.py
+++ b/src/any_llm/providers/deepseek/deepseek.py
@@ -86,10 +86,8 @@ class DeepseekProvider(BaseOpenAIProvider):
         thinking = {"type": thinking_type} if thinking_type is not None else None
 
         if user_id is not None or thinking is not None:
-            extra_body = converted_params.get("extra_body")
-            if extra_body is None:
-                extra_body = {}
-                converted_params["extra_body"] = extra_body
+            extra_body = dict(converted_params.get("extra_body") or {})
+            converted_params["extra_body"] = extra_body
             if user_id is not None and "user_id" not in extra_body:
                 # DeepSeek's user_id contract is stricter than any-llm's shared user field.
                 # https://api-docs.deepseek.com/quick_start/rate_limit/#setting-user_id

--- a/src/any_llm/providers/deepseek/utils.py
+++ b/src/any_llm/providers/deepseek/utils.py
@@ -44,15 +44,13 @@ Return the JSON object only, no other text, do not wrap it in ```json or ```.
     return modified_messages
 
 
-def _reinject_reasoning_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Restore ``reasoning_content`` on replayed assistant tool-call turns.
+def _reinject_reasoning_content(messages: list[dict[str, Any]], *, replay_reasoning: bool) -> list[dict[str, Any]]:
+    """Restore ``reasoning_content`` when the current request carries tools.
 
-    DeepSeek's thinking mode requires ``reasoning_content`` to be passed back verbatim on any
-    assistant turn that performed a tool call, or the API returns a 400. any_llm's shared
-    message serialization (``AnyLLM.acompletion``) strips the normalized ``reasoning`` field
-    before replaying a ``ChatCompletionMessage`` back as a request message, so we restore it
-    here from the ``extra_content["deepseek"]`` side-channel populated by
-    ``_inject_reasoning_extra_content`` when the response was first received.
+    DeepSeek requires all previous assistant reasoning to be replayed when ``tools`` is present,
+    including turns that did not call a tool. any_llm's shared message serialization strips the
+    normalized ``reasoning`` field, so this restores it from the provider side-channel populated
+    by ``_inject_reasoning_extra_content``.
 
     Reference: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
 
@@ -64,7 +62,7 @@ def _reinject_reasoning_content(messages: list[dict[str, Any]]) -> list[dict[str
     for message in messages:
         extra_content = message.get("extra_content")
         cleaned = {k: v for k, v in message.items() if k != "extra_content"} if extra_content is not None else message
-        if message.get("role") == "assistant" and message.get("tool_calls") is not None:
+        if replay_reasoning and message.get("role") == "assistant":
             deepseek_extra = extra_content.get("deepseek") if isinstance(extra_content, dict) else None
             if isinstance(deepseek_extra, dict) and isinstance(deepseek_extra.get("reasoning_content"), str):
                 result.append({**cleaned, "reasoning_content": deepseek_extra["reasoning_content"]})
@@ -81,7 +79,7 @@ def _preprocess_messages(params: CompletionParams) -> CompletionParams:
             params.response_format = {"type": "json_object"}
             params.messages = modified_messages
 
-    params.messages = _reinject_reasoning_content(params.messages)
+    params.messages = _reinject_reasoning_content(params.messages, replay_reasoning=params.tools is not None)
 
     return params
 

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -6,9 +6,10 @@ from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatComple
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
 from pydantic import BaseModel
 
+from any_llm.exceptions import InvalidRequestError
 from any_llm.providers.deepseek.deepseek import DeepseekProvider
 from any_llm.providers.deepseek.utils import _preprocess_messages, _reinject_reasoning_content
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import CompletionParams, ReasoningEffort
 
 
 class PersonResponseFormat(BaseModel):
@@ -251,19 +252,20 @@ def test_deepseek_no_max_tokens_when_neither_set() -> None:
     assert "max_completion_tokens" not in result
 
 
-def test_deepseek_thinking_disabled_by_default_for_v4_model() -> None:
-    """V4 model ids without reasoning_effort should default to thinking disabled."""
+def test_deepseek_preserves_provider_thinking_default() -> None:
+    """No explicit effort leaves DeepSeek's enabled/high provider default in control."""
     params = CompletionParams(
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
         reasoning_effort=None,
     )
     result = DeepseekProvider._convert_completion_params(params)
-    assert result["extra_body"]["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in result
+    assert "extra_body" not in result
 
 
 def test_deepseek_thinking_disabled_for_none_reasoning_effort_value() -> None:
-    """reasoning_effort="none" is also treated as "no reasoning requested"."""
+    """An explicit none uses DeepSeek's thinking toggle, not an invalid wire effort."""
     params = CompletionParams(
         model_id="deepseek-v4-pro",
         messages=[{"role": "user", "content": "hi"}],
@@ -271,41 +273,47 @@ def test_deepseek_thinking_disabled_for_none_reasoning_effort_value() -> None:
     )
     result = DeepseekProvider._convert_completion_params(params)
     assert result["extra_body"]["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in result
 
 
-def test_deepseek_thinking_disabled_for_auto_reasoning_effort_value() -> None:
-    """reasoning_effort="auto" (the default) is treated as "no reasoning requested"."""
+def test_deepseek_auto_preserves_provider_thinking_default() -> None:
+    """The normalized auto sentinel does not override DeepSeek's provider default."""
     params = CompletionParams(
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
         reasoning_effort="auto",
     )
     result = DeepseekProvider._convert_completion_params(params)
-    assert result["extra_body"]["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in result
+    assert "extra_body" not in result
 
 
-def test_deepseek_thinking_enabled_when_reasoning_effort_set() -> None:
-    """An explicit reasoning_effort should enable thinking mode and be passed through."""
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_effort"),
+    [("low", "low"), ("medium", "high"), ("high", "high"), ("xhigh", "high"), ("max", "max")],
+)
+def test_deepseek_maps_current_reasoning_efforts(reasoning_effort: ReasoningEffort, expected_effort: str) -> None:
+    """Normalized efforts map to DeepSeek's current low, high, and max wire values."""
     params = CompletionParams(
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
-        reasoning_effort="high",
+        reasoning_effort=reasoning_effort,
     )
     result = DeepseekProvider._convert_completion_params(params)
     assert result["extra_body"]["thinking"] == {"type": "enabled"}
-    assert result["reasoning_effort"] == "high"
+    assert result["reasoning_effort"] == expected_effort
 
 
-def test_deepseek_thinking_untouched_for_legacy_model_ids() -> None:
-    """Legacy deepseek-chat/deepseek-reasoner ids must not get the thinking toggle injected."""
-    for model_id in ("deepseek-chat", "deepseek-reasoner"):
-        params = CompletionParams(
-            model_id=model_id,
-            messages=[{"role": "user", "content": "hi"}],
-            reasoning_effort="high",
-        )
-        result = DeepseekProvider._convert_completion_params(params)
-        assert "extra_body" not in result
+def test_deepseek_rejects_unsupported_minimal_reasoning_effort() -> None:
+    """DeepSeek Chat does not document OpenAI's minimal effort."""
+    params = CompletionParams(
+        model_id="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="minimal",
+    )
+
+    with pytest.raises(InvalidRequestError, match="minimal"):
+        DeepseekProvider._convert_completion_params(params)
 
 
 def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
@@ -317,6 +325,38 @@ def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
     )
     result = DeepseekProvider._convert_completion_params(params, extra_body={"thinking": {"type": "enabled"}})
     assert result["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        user="account_42",
+        n=2,
+        frequency_penalty=0.5,
+        presence_penalty=0.5,
+        seed=7,
+        parallel_tool_calls=False,
+        logit_bias={"123": 1.0},
+        prompt_cache_key="cache-key",
+        service_tier="priority",
+    )
+
+    result = DeepseekProvider._convert_completion_params(params)
+
+    assert result["extra_body"]["user_id"] == "account_42"
+    for field in (
+        "user",
+        "n",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "parallel_tool_calls",
+        "logit_bias",
+        "prompt_cache_key",
+        "service_tier",
+    ):
+        assert field not in result
 
 
 def test_convert_completion_response_stashes_reasoning_into_extra_content() -> None:
@@ -389,7 +429,7 @@ def test_reinject_reasoning_content_on_tool_call_message() -> None:
         {"role": "tool", "tool_call_id": "call_1", "content": "Sunny"},
     ]
 
-    result = _reinject_reasoning_content(messages)
+    result = _reinject_reasoning_content(messages, replay_reasoning=True)
 
     assert result[1]["reasoning_content"] == "I should call get_weather."
     # The any_llm-internal extra_content must not be forwarded to DeepSeek's API.
@@ -399,8 +439,8 @@ def test_reinject_reasoning_content_on_tool_call_message() -> None:
     assert "extra_content" in messages[1]
 
 
-def test_reinject_reasoning_content_skips_non_tool_call_message() -> None:
-    """Assistant messages without tool_calls should be left untouched."""
+def test_reinject_reasoning_content_includes_assistant_turn_without_tool_call() -> None:
+    """A request carrying tools replays reasoning from every previous assistant turn."""
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "hi"},
         {
@@ -410,11 +450,44 @@ def test_reinject_reasoning_content_skips_non_tool_call_message() -> None:
         },
     ]
 
-    result = _reinject_reasoning_content(messages)
+    result = _reinject_reasoning_content(messages, replay_reasoning=True)
 
-    assert "reasoning_content" not in result[1]
-    # extra_content is any_llm-internal and is stripped even when reasoning is not reinjected.
+    assert result[1]["reasoning_content"] == "greeting"
     assert "extra_content" not in result[1]
+
+
+def test_preprocess_messages_replays_all_assistant_reasoning_when_tools_are_present() -> None:
+    params = CompletionParams(
+        model_id="deepseek-v4-pro",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "hello",
+                "extra_content": {"deepseek": {"reasoning_content": "greeting"}},
+            }
+        ],
+        tools=[{"type": "function", "function": {"name": "lookup"}}],
+    )
+
+    processed = _preprocess_messages(params)
+
+    assert processed.messages[0]["reasoning_content"] == "greeting"
+    assert "extra_content" not in processed.messages[0]
+
+
+def test_reinject_reasoning_content_omits_reasoning_without_tools() -> None:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": "hello",
+            "extra_content": {"deepseek": {"reasoning_content": "greeting"}},
+        }
+    ]
+
+    result = _reinject_reasoning_content(messages, replay_reasoning=False)
+
+    assert "reasoning_content" not in result[0]
+    assert "extra_content" not in result[0]
 
 
 def test_reinject_reasoning_content_handles_missing_extra_content() -> None:
@@ -429,6 +502,6 @@ def test_reinject_reasoning_content_handles_missing_extra_content() -> None:
         },
     ]
 
-    result = _reinject_reasoning_content(messages)
+    result = _reinject_reasoning_content(messages, replay_reasoning=True)
 
     assert "reasoning_content" not in result[0]

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -322,7 +322,7 @@ def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
         reasoning_effort="max",
-        user="normalized-user",
+        user="ignored.invalid-user",
     )
     result = DeepseekProvider._convert_completion_params(
         params,
@@ -333,10 +333,11 @@ def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
 
 
 def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
+    user_id = "a" * 512
     params = CompletionParams(
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
-        user="account_42",
+        user=user_id,
         n=2,
         frequency_penalty=0.5,
         presence_penalty=0.5,
@@ -349,7 +350,7 @@ def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
 
     result = DeepseekProvider._convert_completion_params(params)
 
-    assert result["extra_body"]["user_id"] == "account_42"
+    assert result["extra_body"]["user_id"] == user_id
     for field in (
         "user",
         "n",
@@ -362,6 +363,39 @@ def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
         "service_tier",
     ):
         assert field not in result
+
+
+@pytest.mark.parametrize("user_id", ["", "account.42", "a" * 513])
+def test_deepseek_rejects_invalid_user_id(user_id: str) -> None:
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        user=user_id,
+    )
+
+    with pytest.raises(InvalidRequestError, match="user_id"):
+        DeepseekProvider._convert_completion_params(params)
+
+
+@pytest.mark.parametrize(
+    ("params_kwargs", "expected_extra_body"),
+    [
+        ({"user": "account_42"}, {"user_id": "account_42"}),
+        ({"reasoning_effort": "low"}, {"thinking": {"type": "enabled"}}),
+    ],
+)
+def test_deepseek_treats_explicit_none_extra_body_as_absent(
+    params_kwargs: dict[str, Any], expected_extra_body: dict[str, Any]
+) -> None:
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        **params_kwargs,
+    )
+
+    result = DeepseekProvider._convert_completion_params(params, extra_body=None)
+
+    assert result["extra_body"] == expected_extra_body
 
 
 def test_convert_completion_response_stashes_reasoning_into_extra_content() -> None:

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -1,6 +1,8 @@
 import dataclasses
+import json
 from typing import Any
 
+import httpx
 import pytest
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk as OpenAIChatCompletionChunk
@@ -332,25 +334,65 @@ def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
     assert result["extra_body"] == {"thinking": {"type": "disabled"}, "user_id": "caller-user"}
 
 
-def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
+@pytest.mark.asyncio
+async def test_deepseek_emits_current_chat_wire_contract() -> None:
+    requests: list[httpx.Request] = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        request.read()
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "deepseek-v4-pro",
+                "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "ok"}}],
+            },
+        )
+
     user_id = "a" * 512
-    params = CompletionParams(
-        model_id="deepseek-v4-flash",
-        messages=[{"role": "user", "content": "hi"}],
-        user=user_id,
-        n=2,
-        frequency_penalty=0.5,
-        presence_penalty=0.5,
-        seed=7,
-        parallel_tool_calls=False,
-        logit_bias={"123": 1.0},
-        prompt_cache_key="cache-key",
-        service_tier="priority",
+    provider = DeepseekProvider(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handle_request)),
+        max_retries=0,
     )
+    try:
+        await provider.acompletion(
+            model="deepseek-v4-pro",
+            messages=[
+                {"role": "user", "content": "Use the lookup tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "extra_content": {"deepseek": {"reasoning_content": "I should use lookup."}},
+                },
+            ],
+            tools=[{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+            reasoning_effort="medium",
+            user=user_id,
+            n=2,
+            frequency_penalty=0.5,
+            presence_penalty=0.5,
+            seed=7,
+            parallel_tool_calls=False,
+            logit_bias={"123": 1.0},
+            service_tier="priority",
+        )
+    finally:
+        await provider.client.close()
 
-    result = DeepseekProvider._convert_completion_params(params)
-
-    assert result["extra_body"]["user_id"] == user_id
+    assert len(requests) == 1
+    request = requests[0]
+    body = json.loads(request.content)
+    assert request.url.path == "/chat/completions"
+    assert body["model"] == "deepseek-v4-pro"
+    assert body["reasoning_effort"] == "high"
+    assert body["thinking"] == {"type": "enabled"}
+    assert body["user_id"] == user_id
+    assert body["messages"][1]["reasoning_content"] == "I should use lookup."
+    assert "extra_content" not in body["messages"][1]
     for field in (
         "user",
         "n",
@@ -359,10 +401,9 @@ def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:
         "seed",
         "parallel_tool_calls",
         "logit_bias",
-        "prompt_cache_key",
         "service_tier",
     ):
-        assert field not in result
+        assert field not in body
 
 
 @pytest.mark.parametrize("user_id", ["", "account.42", "a" * 513])

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -317,14 +317,19 @@ def test_deepseek_rejects_unsupported_minimal_reasoning_effort() -> None:
 
 
 def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
-    """A caller-supplied extra_body/thinking value should not be clobbered by the default."""
+    """Caller-supplied DeepSeek fields take precedence over normalized controls."""
     params = CompletionParams(
         model_id="deepseek-v4-flash",
         messages=[{"role": "user", "content": "hi"}],
-        reasoning_effort=None,
+        reasoning_effort="max",
+        user="normalized-user",
     )
-    result = DeepseekProvider._convert_completion_params(params, extra_body={"thinking": {"type": "enabled"}})
-    assert result["extra_body"]["thinking"] == {"type": "enabled"}
+    result = DeepseekProvider._convert_completion_params(
+        params,
+        extra_body={"thinking": {"type": "disabled"}, "user_id": "caller-user"},
+    )
+    assert result["reasoning_effort"] == "max"
+    assert result["extra_body"] == {"thinking": {"type": "disabled"}, "user_id": "caller-user"}
 
 
 def test_deepseek_maps_user_id_and_omits_unsupported_fields() -> None:

--- a/tests/unit/providers/test_deepseek_provider.py
+++ b/tests/unit/providers/test_deepseek_provider.py
@@ -334,6 +334,26 @@ def test_deepseek_thinking_respects_explicit_extra_body_override() -> None:
     assert result["extra_body"] == {"thinking": {"type": "disabled"}, "user_id": "caller-user"}
 
 
+def test_deepseek_does_not_mutate_extra_body_when_merging_controls() -> None:
+    extra_body = {"custom": "value", "user_id": "caller-user"}
+    params = CompletionParams(
+        model_id="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="low",
+        user="normalized-user",
+    )
+
+    result = DeepseekProvider._convert_completion_params(params, extra_body=extra_body)
+
+    assert extra_body == {"custom": "value", "user_id": "caller-user"}
+    assert result["extra_body"] == {
+        "custom": "value",
+        "thinking": {"type": "enabled"},
+        "user_id": "caller-user",
+    }
+    assert result["extra_body"] is not extra_body
+
+
 @pytest.mark.asyncio
 async def test_deepseek_emits_current_chat_wire_contract() -> None:
     requests: list[httpx.Request] = []


### PR DESCRIPTION
## Description

Align the Python DeepSeek provider with the current V4 Chat contract:

- preserve DeepSeek's enabled/high thinking defaults when no effort is requested;
- map `none`, low, medium, high, xhigh, and max to the documented Chat controls, while rejecting OpenAI-only minimal;
- send the normalized `user` value as DeepSeek's `user_id`;
- omit normalized fields absent from the current Chat schema, including the two penalty fields that DeepSeek marks deprecated and ineffective;
- replay every previous assistant reasoning value when the current request contains tools.

This PR does not add a transport, wrapper, dependency, public type, deprecated parameter, Vision support, or Responses support.

## Current sources

- [DeepSeek Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion)
- [DeepSeek Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/)
- [DeepSeek Rate Limit & Isolation](https://api-docs.deepseek.com/quick_start/rate_limit/)
- [DeepSeek Change Log](https://api-docs.deepseek.com/updates/)
- [OpenAI Python SDK v3.8.0 at immutable commit `88391abf`](https://github.com/openai/openai-python/tree/88391abf981df3ea395ca1b5bf55ec6a4011ea93)

DeepSeek does not publish an official Python SDK. Its official Python examples use the OpenAI SDK as a compatible transport, so DeepSeek's current online documentation defines provider behavior and the OpenAI SDK defines only the transport contract.

The detailed `user_id` setting rule requires `[a-zA-Z0-9_-]+` with a maximum length of 512. The same rate-limit page also says an empty id is treated as a special user. This PR follows the specific setting rule; live behavior for that documentation conflict remains unverified.

The project already requires `openai>=2.18.0`. The same focused suite passes on 2.18.0 and the latest 3.8.0, so this PR does not raise the dependency floor.

## Architecture and ablation

The provider owns DeepSeek-specific parameter conversion and reasoning replay. Shared OpenAI code continues to own HTTP, SSE, retry, timeout, cancellation, response parsing, and error conversion. This boundary was compared with [Fantasy's provider organization at immutable commit `73eb01de`](https://github.com/charmbracelet/fantasy/tree/73eb01dec54ee7923b9c77d3e03cc9fd78b28cf9/providers), but no Fantasy implementation, fixture, control flow, or assertion sequence was copied.

The ablation removed retired model-name branching, an unreachable `prompt_cache_key` filter, unnecessary `extra_body` copying, and a local TCP test server. The final wire test uses the real OpenAI SDK with `httpx.MockTransport` and the provider's default base URL, proving the documented `/chat/completions` route and final JSON body without socket lifecycle code.

The final diff is three files, `+261/-63`. Production changes are `+75/-30`; the directly required regression file is `+186/-33`. Five signed commits keep production contracts, direct regressions, caller overrides, validation, and final ablation reviewable; the largest is `+95/-41`.

## Verification

```text
DeepSeek focused, repository OpenAI SDK 3.3.1   34 passed
DeepSeek focused, minimum OpenAI SDK 2.18.0      34 passed
DeepSeek focused, latest OpenAI SDK 3.8.0        34 passed
Full unit suite                                2443 passed, 69 skipped
All-files pre-commit                           passed, including Ruff and strict mypy
```

No DeepSeek, OpenAI SDK, or Fantasy source or fixture was copied. The expected wire values were written independently from the current DeepSeek documentation.

Current exact head: `2c7b5343136f90417a643ed146f6cbed98a31bc0`.

## Remaining gaps

- No `DEEPSEEK_API_KEY` is available in the orb. Live V4 non-streaming, streaming, tool replay, timeout, cancellation, and error-envelope checks remain unverified.
- Vision and Responses are separate provider surfaces and remain outside this Chat PR.
- CodeRabbit's exact-head full review is pending.

The PR remains Draft while these gaps or their documented external blocks remain.

## PR Type

- 🐛 Bug Fix

## Relevant issues

No linked issue.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [x] New and existing affected tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-5.6 Sol X-HIGH
- AI Developer Tool used: Amp
- Any other info you'd like to share: Current DeepSeek docs and OpenAI Python 2.18.0 and 3.8.0 executable transport contracts were checked independently. Live service verification remains unavailable.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DeepSeek reasoning controls, including support for mapped reasoning-effort settings.
  * Preserved assistant reasoning across tool-enabled interactions.
  * Added support for passing user identifiers to DeepSeek requests.

* **Bug Fixes**
  * Improved validation and handling of unsupported or invalid DeepSeek request parameters.
  * Ensured explicit reasoning settings and tool configurations are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->