### PR TITLE
tests: refresh retired model pins for nebius, portkey, moonshot

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def provider_reasoning_model_map() -> dict[LLMProvider, str]:
         LLMProvider.NEBIUS: "openai/gpt-oss-120b",
         LLMProvider.SAMBANOVA: "gpt-oss-120b",
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
-        LLMProvider.PORTKEY: "@nebius-any-llm/Qwen/Qwen3-32B",
+        LLMProvider.PORTKEY: "@nebius-any-llm/Qwen/Qwen3.5-397B-A17B",
         LLMProvider.MINIMAX: "MiniMax-M2",
         LLMProvider.ZAI: "glm-4.5-flash",
         LLMProvider.DEEPINFRA: "deepseek-ai/DeepSeek-R1",
@@ -106,7 +106,7 @@ def provider_model_map() -> dict[LLMProvider, str]:
         LLMProvider.GMI: "zai-org/GLM-5-FP8",
         LLMProvider.GITHUB: "openai/gpt-4.1-nano",
         LLMProvider.VERTEXAI: "gemini-3-flash-preview",
-        LLMProvider.MOONSHOT: "kimi-k2.6",
+        LLMProvider.MOONSHOT: "kimi-k3",
         LLMProvider.SAMBANOVA: "gpt-oss-120b",
         LLMProvider.TOGETHER: "openai/gpt-oss-20b",
         LLMProvider.XAI: "grok-3-mini-latest",
@@ -150,7 +150,7 @@ def provider_image_model_map(provider_model_map: dict[LLMProvider, str]) -> dict
         LLMProvider.OPENAI: "gpt-5-mini",  # Slightly more powerful so that it doesn't get caught in a loop of logic
         LLMProvider.WATSONX: "meta-llama/llama-guard-3-11b-vision",
         LLMProvider.SAMBANOVA: "gemma-4-31B-it",
-        LLMProvider.NEBIUS: "Qwen/Qwen2.5-VL-72B-Instruct",
+        LLMProvider.NEBIUS: "google/gemma-3-27b-it",
         LLMProvider.OPENROUTER: "google/gemini-2.5-flash-lite",
         LLMProvider.COHERE: "command-a-vision-07-2025",  # command-a-03-2025 rejects image content
         LLMProvider.OLLAMA: "llava-phi3",  # Fast vision model compatible with OpenAI format


### PR DESCRIPTION
## Description

Five integration tests have been red on `main` for at least three runs (33753751298, 33754482709, 33860577088), all from provider-side model changes rather than a regression:

- `test_completion_with_image[nebius]` — 404, `Qwen/Qwen2.5-VL-72B-Instruct` retired at Nebius.
- `test_completion_reasoning[portkey]` and `..._streaming[portkey]` — 404 with `'provider': 'nebius'`, `Qwen/Qwen3-32B` retired at the same upstream the virtual key routes to.
- `test_response_format[moonshot]` and `test_response_format_dataclass[moonshot]` — no HTTP error; `kimi-k2.6` ignores the `json_schema` response_format and answers in prose (`'The capital of France is **Paris**.'`), so `parse_json_content` raises `json_invalid`.

Repins the three models:

- Image: `google/gemma-3-27b-it`. Nebius serves it and Gemma 3 takes image input. `Qwen3.5-397B-A17B` is multimodal upstream but Nebius tags its catalog entry text-to-text, so it is not a drop-in for the vision test.
- Portkey reasoning: `@nebius-any-llm/Qwen/Qwen3.5-397B-A17B`. The `Qwen3-235B/30B-...-Instruct-2507` alternatives are non-thinking variants and would trade the 404 for a failed `reasoning.content` assertion.
- Moonshot: `kimi-k3`. Its API documents `response_format: {"type": "json_schema"}` structured output, and `test_together_response_format_on_strict_model` already pins `moonshotai/Kimi-K3` for exactly that. The moonshot reasoning pin stays on `kimi-k2.6`, which passes today.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None filed.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [ ] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

Notes on the two unchecked boxes: this is a test-fixture pin change, so there is nothing to unit test beyond the existing suite (`uv run pytest tests/unit` green, 2434 passed / 69 skipped; `uv run pre-commit run` clean). I could not run the integration tests locally — no NEBIUS, PORTKEY, or MOONSHOT keys in my env. **Needs the `run-integration-tests` label.** One pin is unverified against a live call: whether Nebius surfaces Qwen3.5's thinking as `reasoning_content`. Registry providers have no `<think>`-tag fallback, so if it does not, the portkey reasoning tests will fail on the assertion instead of a 404.

## AI Usage Information

- AI Model used: Opus 5
- AI Developer Tool used: Claude Code

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated provider-specific test configurations to use current reasoning, text, and image model variants.
  * Refreshed model selections for PORTKEY, MOONSHOT, and NEBIUS test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->