### PR TITLE
feat(providers): add llmman as a local model provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 
 all = [
-  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,gmi,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud,telnyx,edenai,kenari,meta]"
+  "any-llm-sdk[mistral,anthropic,huggingface,gemini,vertexai,vertexaianthropic,cohere,cerebras,fireworks,gmi,groq,bedrock,azure,azureanthropic,azureopenai,cascadia,watsonx,together,sambanova,ollama,moonshot,neosantara,nebius,xai,databricks,deepseek,inception,openai,otari,openrouter,portkey,qiniu,requesty,lmstudio,llama,voyage,perplexity,platform,llamafile,llamacpp,llmman,sagemaker,github,zai,minimax,mzai,vllm,dashscope,deepinfra,atlascloud,telnyx,edenai,kenari,meta]"
 ]
 
 platform = [
@@ -125,6 +125,7 @@ kenari = []
 llama = []
 llamacpp = []
 llamafile = []
+llmman = []
 meta = []
 moonshot = []
 nebius = []

--- a/src/any_llm/constants.py
+++ b/src/any_llm/constants.py
@@ -54,6 +54,7 @@ class LLMProvider(StrEnum):
     LMSTUDIO = "lmstudio"
     LLAMAFILE = "llamafile"
     LLAMACPP = "llamacpp"
+    LLMMAN = "llmman"
     META = "meta"
     MISTRAL = "mistral"
     MOONSHOT = "moonshot"

--- a/src/any_llm/providers/llmman/__init__.py
+++ b/src/any_llm/providers/llmman/__init__.py
@@ -1,0 +1,3 @@
+from .llmman import LlmmanProvider
+
+__all__ = ["LlmmanProvider"]

--- a/src/any_llm/providers/llmman/llmman.py
+++ b/src/any_llm/providers/llmman/llmman.py
@@ -1,0 +1,29 @@
+from typing_extensions import override
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+
+class LlmmanProvider(BaseOpenAIProvider):
+    """Provider for llmman, a local model runner (https://github.com/llmmanorg/llmman).
+
+    llmman serves the Ollama API alongside OpenAI- and Anthropic-compatible ones on
+    port 17434, backed by upstream llama.cpp (llama-server), vllm or mlx-lm. This
+    provider targets the OpenAI-compatible ``/v1`` routes, so no extra SDK is needed.
+    """
+
+    API_BASE = "http://localhost:17434/v1"
+    ENV_API_KEY_NAME = "None"
+    ENV_API_BASE_NAME = "LLMMAN_API_BASE"
+    PROVIDER_NAME = "llmman"
+    PROVIDER_DOCUMENTATION_URL = "https://github.com/llmmanorg/llmman"
+
+    SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_COMPLETION_STREAMING = True
+    SUPPORTS_COMPLETION_IMAGE = True
+    SUPPORTS_COMPLETION_PDF = False
+    SUPPORTS_MODERATION = False
+
+    @override
+    def _verify_and_set_api_key(self, api_key: str | None = None) -> str | None:
+        # llmman runs locally and does not require an API key.
+        return "no-key-required"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,6 +8,7 @@ LOCAL_PROVIDERS = [
     LLMProvider.LMSTUDIO,
     LLMProvider.LLAMAFILE,
     LLMProvider.CASCADIA,
+    LLMProvider.LLMMAN,
 ]
 
 # Providers that should never run in CI (only for local development)
@@ -16,6 +17,7 @@ CI_EXCLUDED_PROVIDERS = [
     LLMProvider.VERTEXAIANTHROPIC,
     LLMProvider.VLLM,
     LLMProvider.CASCADIA,
+    LLMProvider.LLMMAN,
 ]
 
 # Strip whitespace and drop empties so values like "anthropic, otari" or an unset env var

--- a/tests/unit/providers/test_llmman.py
+++ b/tests/unit/providers/test_llmman.py
@@ -1,0 +1,46 @@
+import pytest
+
+from any_llm.any_llm import AnyLLM
+from any_llm.constants import LLMProvider
+from any_llm.providers.llmman.llmman import LlmmanProvider
+
+
+def test_provider_metadata() -> None:
+    provider = LlmmanProvider()
+    assert provider.PROVIDER_NAME == "llmman"
+    assert provider.API_BASE == "http://localhost:17434/v1"
+    assert provider.ENV_API_BASE_NAME == "LLMMAN_API_BASE"
+    assert provider.PROVIDER_DOCUMENTATION_URL == "https://github.com/llmmanorg/llmman"
+
+
+def test_provider_without_api_key() -> None:
+    provider = LlmmanProvider()
+    assert provider._verify_and_set_api_key(None) == "no-key-required"
+
+
+def test_api_base_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LLMMAN_API_BASE", raising=False)
+    provider = LlmmanProvider()
+    assert str(provider.client.base_url).rstrip("/") == "http://localhost:17434/v1"
+
+
+def test_api_base_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLMMAN_API_BASE", "http://gpu-box:17434/v1")
+    provider = LlmmanProvider()
+    assert str(provider.client.base_url).rstrip("/") == "http://gpu-box:17434/v1"
+
+
+def test_capability_flags() -> None:
+    assert LlmmanProvider.SUPPORTS_COMPLETION
+    assert LlmmanProvider.SUPPORTS_COMPLETION_STREAMING
+    assert LlmmanProvider.SUPPORTS_COMPLETION_REASONING
+    assert LlmmanProvider.SUPPORTS_COMPLETION_IMAGE
+    assert LlmmanProvider.SUPPORTS_LIST_MODELS
+    assert LlmmanProvider.SUPPORTS_EMBEDDING
+    assert not LlmmanProvider.SUPPORTS_COMPLETION_PDF
+    assert not LlmmanProvider.SUPPORTS_MODERATION
+
+
+def test_resolves_by_name_and_enum() -> None:
+    assert AnyLLM.get_provider_class("llmman") is LlmmanProvider
+    assert AnyLLM.get_provider_class(LLMProvider.LLMMAN) is LlmmanProvider

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -150,6 +150,7 @@ def test_providers_raise_MissingApiKeyError(provider: LLMProvider) -> None:
         LLMProvider.BEDROCK,
         LLMProvider.LLAMACPP,
         LLMProvider.LLAMAFILE,
+        LLMProvider.LLMMAN,
         LLMProvider.LMSTUDIO,
         LLMProvider.OLLAMA,
         LLMProvider.SAGEMAKER,


### PR DESCRIPTION
## Description

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves OpenAI-compatible (plus Ollama and Anthropic) routes on port 17434.

- `src/any_llm/providers/llmman/` subclasses `BaseOpenAIProvider` like `llamacpp`; keyless (`_verify_and_set_api_key` returns `no-key-required`), which the config-only registry cannot express.
- Uses the `/v1` routes so no extra SDK is needed (`llmman = []` extra). Base URL from `LLMMAN_API_BASE`, following the `*_API_BASE` convention.
- Capability flags: reasoning, streaming, image and embeddings on; PDF and moderation off (matching `llamacpp`).
- Touchpoints: `LLMProvider.LLMMAN`, pyproject extra + `all` group, keyless skip in `tests/unit/test_provider.py`, `LOCAL_PROVIDERS` / `CI_EXCLUDED_PROVIDERS` so CI does not expect a server. Lands as 🤝 Community.

## PR Type

- 🆕 New Feature

## Relevant issues

None.

**Testing:** `ruff check`, `ruff format --check`, `mypy` on the changed files and `pytest tests/unit/providers/test_llmman.py` (6 passed); chat, streaming, reasoning, image input and `list_models` exercised live against `llmman serve`.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude (Anthropic)
- AI Developer Tool used: OpenCode
- Any other info you'd like to share: Docs table is generated from provider metadata, so no authored docs change was needed.

- [ ] I am an AI Agent filling out this form (check box if true)

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the local LLMMan model runner through its OpenAI-compatible API.
  - LLMMan can be selected as a provider without requiring an API key.
  - Supports streaming, image input and completion reasoning.
  - Included LLMMan in the bundled optional provider set, with environment-based API configuration available.

- **Tests**
  - Added coverage for provider selection, configuration, authentication handling and supported capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->