### PR TITLE
fix(ollama): normalize terminal done reasons

### DIFF
--- a/src/any_llm/providers/ollama/utils.py
+++ b/src/any_llm/providers/ollama/utils.py
@@ -29,6 +29,22 @@ from any_llm.types.completion import (
 from any_llm.types.model import Model
 
 
+def _map_ollama_done_reason(
+    done_reason: str | None,
+) -> Literal["stop", "length", "tool_calls", "content_filter", "function_call"]:
+    """Normalize a terminal reason, using stop when Ollama has no OpenAI equivalent.
+
+    Ollama's load/unload responses complete a model lifecycle operation without
+    generating text. Missing and unknown reasons use the same stop fallback as
+    other providers; they do not imply truncation, filtering, or a tool call.
+    """
+    match done_reason:
+        case "stop" | "length" | "tool_calls" | "content_filter" | "function_call":
+            return done_reason
+        case _:
+            return "stop"
+
+
 def _convert_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert OpenAI tool calls to the shape Ollama expects.
 
@@ -130,9 +146,10 @@ def _create_openai_chunk_from_ollama_chunk(ollama_chunk: OllamaChatResponse) -> 
     choice = ChunkChoice(
         index=0,
         delta=delta,
-        finish_reason=cast(
-            "Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call'] | None",
-            ollama_chunk.done_reason,
+        finish_reason=(
+            _map_ollama_done_reason(ollama_chunk.done_reason)
+            if ollama_chunk.done or ollama_chunk.done_reason is not None
+            else None
         ),
     )
 
@@ -217,7 +234,7 @@ def _create_chat_completion_from_ollama_response(response: OllamaChatResponse) -
         reasoning=Reasoning(content=response_message.thinking) if response_message.thinking else None,
     )
 
-    finish_reason: Any = "tool_calls" if openai_tool_calls else response.done_reason
+    finish_reason = "tool_calls" if openai_tool_calls else _map_ollama_done_reason(response.done_reason)
 
     choice = Choice(index=0, finish_reason=finish_reason, message=message)
 

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -1,8 +1,10 @@
+import json
 import logging
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 from ollama import ChatResponse as OllamaChatResponse
 from ollama import Message as OllamaMessage
@@ -12,7 +14,7 @@ from any_llm.providers.ollama.utils import (
     _create_chat_completion_from_ollama_response,
     _create_openai_chunk_from_ollama_chunk,
 )
-from any_llm.types.completion import CompletionParams
+from any_llm.types.completion import ChatCompletion, CompletionParams
 
 
 @pytest.mark.asyncio
@@ -458,6 +460,7 @@ async def test_streaming_assigns_distinct_tool_call_indices() -> None:
         chunk.message = message
         chunk.created_at = None
         chunk.model = "llama3.1"
+        chunk.done = False
         chunk.done_reason = None
         chunk.prompt_eval_count = None
         chunk.eval_count = None
@@ -780,3 +783,92 @@ async def test_tool_call_arguments_are_converted_to_a_mapping(arguments: Any, ex
     )
 
     assert sent[1]["tool_calls"] == [{"function": {"name": "get_weather", "arguments": expected}}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    ("reason_fields", "expected"),
+    [
+        ({}, "stop"),
+        ({"done_reason": None}, "stop"),
+        ({"done_reason": "load"}, "stop"),
+        ({"done_reason": "unload"}, "stop"),
+        ({"done_reason": "stop"}, "stop"),
+        ({"done_reason": "length"}, "length"),
+        ({"done_reason": "future_reason"}, "stop"),
+        ({"done_reason": "tool_calls"}, "tool_calls"),
+        ({"done_reason": "content_filter"}, "content_filter"),
+        ({"done_reason": "function_call"}, "function_call"),
+    ],
+)
+async def test_completion_normalizes_sdk_done_reason(
+    stream: bool, reason_fields: dict[str, str | None], expected: str
+) -> None:
+    """Exercise JSON and NDJSON decoding through the real Ollama SDK and provider."""
+    terminal = {
+        "model": "llama3.2",
+        "created_at": "2024-09-12T21:17:29.110811Z",
+        "message": {"role": "assistant", "content": ""},
+        "done": True,
+        **reason_fields,
+    }
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/chat"
+        assert json.loads(request.content)["stream"] is stream
+        if stream:
+            partial = {**terminal, "done": False, "message": {"role": "assistant", "content": "Hello"}}
+            partial.pop("done_reason", None)
+            return httpx.Response(
+                200,
+                content="\n".join(json.dumps(item) for item in [partial, terminal]) + "\n",
+                headers={"content-type": "application/x-ndjson"},
+            )
+        return httpx.Response(200, json=terminal)
+
+    provider = OllamaProvider(api_base="http://ollama.test", transport=httpx.MockTransport(handle))
+    try:
+        result = await provider.acompletion(
+            model="llama3.2", messages=[{"role": "user", "content": "Hello"}], stream=stream
+        )
+        if stream:
+            assert isinstance(result, AsyncIterator)
+            chunks = [chunk async for chunk in result]
+            assert len(chunks) == 2
+            assert chunks[0].choices[0].delta.content == "Hello"
+            assert chunks[0].choices[0].finish_reason is None
+            assert chunks[1].choices[0].delta.content == ""
+            assert chunks[1].choices[0].finish_reason == expected
+        else:
+            assert isinstance(result, ChatCompletion)
+            assert result.choices[0].message.content == ""
+            assert result.choices[0].finish_reason == expected
+    finally:
+        await provider.client._client.aclose()
+
+
+@pytest.mark.parametrize("done_reason", [None, "load", "unload", "stop", "length"])
+def test_completion_normalization_preserves_tool_call_precedence(done_reason: str | None) -> None:
+    response = OllamaChatResponse(
+        model="llama3.2",
+        created_at="2024-09-12T21:17:29.110811Z",
+        done=True,
+        done_reason=done_reason,
+        message=OllamaMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                OllamaMessage.ToolCall(
+                    function=OllamaMessage.ToolCall.Function(name="get_weather", arguments={"city": "Paris"})
+                )
+            ],
+        ),
+    )
+    completion = _create_chat_completion_from_ollama_response(response)
+    assert completion.choices[0].finish_reason == "tool_calls"
+    calls = completion.choices[0].message.tool_calls
+    assert calls is not None
+    assert calls[0].type == "function"
+    assert calls[0].function.name == "get_weather"
+    assert json.loads(calls[0].function.arguments) == {"city": "Paris"}


### PR DESCRIPTION
## Description

Normalize Ollama completion finish reasons before constructing any-llm's response types. An SDK response with a missing or null `done_reason` currently raises `ValidationError` in nonstreaming conversion; `load` and `unload` raise in both converters. These lifecycle responses are documented as completed, empty chat responses.

Use `stop` for missing terminal reasons, lifecycle reasons, and unknown reasons, following the existing provider fallback convention. Preserve all previously accepted OpenAI finish reasons and nonstreaming tool-call precedence. In streams, a chunk with no reason remains unfinished unless `done` is true, in which case it receives the terminal fallback.

Tests exercise the real Ollama SDK's JSON and NDJSON decoding through a mocked HTTP transport, plus typed SDK tool-call responses. On the base commit, 10 new cases fail and 15 pass; with the fix, all 79 Ollama unit tests pass. The full unit suite passes with 2,456 passed and 69 existing skips. Repository-wide pre-commit checks pass, including mypy.

Live validation now passes on Ollama 0.33.3 with llama3.2:1b: all four existing async/parallel/streaming integration tests passed with no skips. Real stop and length results survive both conversions; native SDK load/unload responses fail on the original converters and normalize to stop with this fix. Those lifecycle requests use the native SDK because any-llm does not accept an empty messages list. Missing/unknown reasons remain controlled-transport coverage, not observed live responses. No timestamp handling changes are included.

## PR Type

- 🐛 Bug Fix

## Relevant issues

None found for this normalization defect in the live open issue and PR checks.

## Checklist

- [ ] I understand the code I am submitting. (Human author review pending.)
- [x] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally (2,456 unit tests; all four selected live Ollama integration tests pass)
- [x] Documentation was updated where necessary (normalization semantics documented in the helper docstring)
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-llm/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: GPT-6
- AI Developer Tool used: Codex
- Any other info you'd like to share: Codex researched the current source and documentation, implemented the fix and regression tests, ran validation, and drafted this body. Human author review is pending. Controlled SDK transport tests are supplemented by real local inference and native SDK lifecycle probes; no user/private data was used.

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalised completion and streaming finish reasons from Ollama for consistent results.
  * Unknown or missing terminal reasons now default to `stop`.
  * Tool-call completions now report the appropriate `tool_calls` finish reason.
* **Tests**
  * Added coverage for streaming, non-streaming, and tool-call finish-reason handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->